### PR TITLE
feat(standby): block auto-deep-sleep on clock face, keep CPU downclock

### DIFF
--- a/src/activities/apps/standby/StandbyActivity.cpp
+++ b/src/activities/apps/standby/StandbyActivity.cpp
@@ -430,12 +430,13 @@ void StandbyActivity::loop() {
 
   pumpTimeSync();
 
-  // After 5 s of idle, hide chrome and let the face fill the screen. On
-  // battery the framework takes care of power saving from there: CPU drops to
-  // LOW_POWER_FREQ after 3 s (HalPowerManager) and the whole device deep-
-  // sleeps after SETTINGS.getSleepTimeoutMs() (main.cpp). We deliberately do
-  // not run our own light-sleep loop — that just stalls main.cpp's auto power
-  // management and leaves the device unresponsive.
+  // After 5 s of idle, hide chrome and let the face fill the screen. From
+  // there the framework's idle-3 s auto-downclock kicks in (HalPowerManager →
+  // LOW_POWER_FREQ, 10 MHz). We keep preventAutoSleep() returning true so the
+  // device will NOT auto-deep-sleep — standby is a clock and must keep showing
+  // the time. The deep-sleep timer is short-circuited in main.cpp via
+  // preventAutoSleep(); downclocking is unaffected because main.cpp only
+  // resets lastActivityTime on real user input, not on preventAutoSleep().
   // Interactive faces (airpage) stay in Normal mode so they keep their chrome
   // (QR title/dots) and receive Up/Down/Confirm on the first press.
   const bool interactive = currentFace_ && currentFace_->isInteractive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -658,13 +658,16 @@ void loop() {
     }
   }
 
-  // Check for any user activity (button press or release) or active background work
+  // Check for any real user activity (button press, button release, or tilt).
   static unsigned long lastActivityTime = millis();
-  if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || halTiltSensor.hadActivity() ||
-      activityManager.preventAutoSleep()) {
+  if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || halTiltSensor.hadActivity()) {
     lastActivityTime = millis();         // Reset inactivity timer
     powerManager.setPowerSaving(false);  // Restore normal CPU frequency on user activity
   }
+  // preventAutoSleep() is intentionally NOT folded into the activity check above:
+  // it only short-circuits the deep-sleep timer below, not the inactivity clock
+  // that drives auto-downclock. Standby (a clock face) wants deep sleep blocked
+  // but still benefits from the framework dropping CPU to LOW_POWER_FREQ.
 
   static bool screenshotButtonsReleased = true;
   static bool screenshotComboActive = false;
@@ -691,7 +694,8 @@ void loop() {
   }
 
   const unsigned long sleepTimeoutMs = SETTINGS.getSleepTimeoutMs();
-  if (millis() - lastActivityTime >= sleepTimeoutMs) {
+  if (!activityManager.preventAutoSleep() &&
+      millis() - lastActivityTime >= sleepTimeoutMs) {
     LOG_DBG("SLP", "Auto-sleep triggered after %lu ms of inactivity", sleepTimeoutMs);
     enterDeepSleep(true);
     // This should never be hit as `enterDeepSleep` calls esp_deep_sleep_start


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let the standby clock face keep the time visible while still allowing the framework to drop the CPU to `LOW_POWER_FREQ` on idle. Before this change, the standby face's `preventAutoSleep()` also reset the inactivity clock that drives auto-downclock, so the CPU stayed at full speed indefinitely.
* **What changes are included?**
  * `src/main.cpp`: split `preventAutoSleep()` out of the user-activity branch. It now only short-circuits the deep-sleep timer; the inactivity clock that triggers auto-downclock keeps ticking on real user input only.
  * `src/activities/apps/standby/StandbyActivity.cpp`: update the comment block to describe the new "deep sleep blocked, downclock allowed" behavior.

## Additional Context

* Net behavior on the standby face: no auto-deep-sleep (correct — it's a clock), but CPU now downclocks to 10 MHz after 3 s of no input via `HalPowerManager`. Significant power saving for the always-on use case.
* Other activities are unaffected because they don't return `true` from `preventAutoSleep()`.
* Risk: any activity that *also* needs the CPU pinned at full speed during idle (none today) would need to explicitly reset `lastActivityTime` or signal real activity.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
