### PR TITLE
feat: default CN firmware to UTC+8

### DIFF
--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -15,7 +15,7 @@ gates every CN-only resource:
 | `src/main.cpp` font globals | Each Latin `EpdFont`/`EpdFontFamily` global is aliased to the matching-size CJK header. Bold/italic variants all point at the Regular OTF (no style data in the subset). SD-card fonts still provide style variants when the user loads them. |
 | EPUB layout ([lib/Epub/Epub/ParsedText.cpp](../../lib/Epub/Epub/ParsedText.cpp)) | CJK punctuation rules are active: line-head prohibition (禁则) glues trailing punctuation back onto the previous line; full-width punctuation gets width-padded so it occupies a full CJK cell. Both are zero-cost in non-CN builds (gated by `#ifdef`). |
 | Activities (`src/activities/apps/chinese-chess/`) | Compiled in (also gated by `build_src_filter +<activities/apps/chinese-chess/>`). |
-| First-boot default language (`src/CrossPointSettings.h`) | `language` is initialized to `Language::ZH_CN` so a fresh device boots straight into Chinese UI; non-CN builds still default to `Language::EN`. |
+| First-boot locale defaults (`src/CrossPointSettings.h`) | A fresh CN build starts with `Language::ZH_CN` and UTC+8 (`clockUtcOffsetQ = 80`); non-CN builds default to `Language::EN` and UTC+0. Saved UTC offsets are preserved across reflashes. When switching CN → global, the existing SKU/renderability guard resets Chinese to English, including legacy settings without a `langSku` marker. |
 
 **Flash budget** (default `partitions.csv`, dual A/B app slot = 6.25 MB):
 

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -219,7 +219,11 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   // Clock UTC offset in quarter-hour steps, biased by 48 so it fits in uint8_t.
   // Value 48 = UTC+0, 0 = UTC-12:00, 104 = UTC+14:00.
   // Quarter-hour granularity supports oddball zones like Nepal (+5:45) and Chatham (+12:45).
+#ifdef ENABLE_CHINESE_VERSION
+  uint8_t clockUtcOffsetQ = 80;  // UTC+8
+#else
   uint8_t clockUtcOffsetQ = 48;
+#endif
   // Clock display format: 0 = 24-hour, 1 = 12-hour
   uint8_t clockFormat = 0;
   // Set once an NTP sync succeeds. Used to skip re-syncing on every WiFi connect.


### PR DESCRIPTION
## Summary

- default fresh Chinese firmware installs to Simplified Chinese and UTC+8
- keep global firmware defaults at English and UTC+0
- preserve saved UTC offsets across reflashes
- document the existing CN-to-global language fallback to English

## Why

The Chinese firmware already selected Simplified Chinese on first boot, but its clock offset still defaulted to UTC+0. Using the existing `ENABLE_CHINESE_VERSION` build flag keeps the locale defaults aligned without adding settings, migrations, dependencies, or allocations.

## Validation

- `pio run -e default`
- `pio run -e gh_release_cn`
- `CROSSPOINT_RC_HASH=local pio run -e gh_release_cn_rc`
- `git diff --check`
