### PR TITLE
fix: wrap oversized URLs safely

### DIFF
--- a/docs/engineering/cache-management.md
+++ b/docs/engineering/cache-management.md
@@ -57,7 +57,7 @@ rm -rf /path/to/sd/.crosspoint/epub_<hash>/sections/
 
 **Current Versions** (as of [../file-formats.md](../file-formats.md)):
 - `book.bin`: **Version 11** (metadata structure) — includes NFC-composed titles and ignores ambiguous EPUB guide text references while remaining above every version shipped by either lineage.
-- `section.bin`: **per-flavor** — Latin builds **Version 44**, Chinese builds (`ENABLE_CHINESE_VERSION`) **Version 45**. Versions 44/45 invalidate pagination after closed HTML tags began splitting adjacent text blocks. The two flavors emit different word streams (per-character CJK tokenization), so each carries an independent counter; numbers stay distinct and above every previously shipped value so a firmware flavor swap never reuses the other's cache.
+- `section.bin`: **per-flavor** — Latin builds **Version 46**, Chinese builds (`ENABLE_CHINESE_VERSION`) **Version 47**. Versions 46/47 invalidate pagination after oversized tokens began using UTF-8-safe emergency wrapping without synthetic hyphens. The two flavors emit different word streams (per-character CJK tokenization), so each carries an independent counter; numbers stay distinct and above every previously shipped value so a firmware flavor swap never reuses the other's cache.
 
 **Version Increment Rules**:
 1. **ALWAYS increment version** BEFORE changing binary structure

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -95,10 +95,10 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Versions 44 / 45
+### Versions 46 / 47
 
 > Chinese builds (`ENABLE_CHINESE_VERSION`) carry an independent version counter,
-> currently **45**; Latin builds use **44**. The byte layout is identical between
+> currently **47**; Latin builds use **46**. The byte layout is identical between
 > flavors; only
 > the word-stream contents differ (per-character CJK tokenization), so caches are
 > not reusable across flavors.
@@ -111,7 +111,9 @@ if (parsedSize != fileSize) {
 > of truncated. Versions 42/43 persist each image's book-internal source href for
 > lazy extraction and serialize ruby annotations/group-continuation styles.
 > Versions 44/45 invalidate pagination after closed HTML tags began splitting
-> adjacent text blocks. The counters remain
+> adjacent text blocks. Versions 46/47 keep the byte layout unchanged but
+> invalidate pagination because oversized tokens now wrap at UTF-8 boundaries
+> without inserting synthetic hyphens. The counters remain
 > distinct and above every previously shipped value so a firmware-flavor swap
 > cannot read the other flavor's stale cache. `lib/Epub/Epub/Section.cpp` is the
 > source of truth.
@@ -146,7 +148,7 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define EXPECTED_VERSION 44
+#define EXPECTED_VERSION 46
 #define MAX_STRING_LENGTH 65535
 #define FOOTNOTE_NUMBER_LEN 32
 #define FOOTNOTE_HREF_LEN 96

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -957,32 +957,35 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   const std::string& word = words[wordIndex];
   const auto style = wordStyles[wordIndex];
 
-  // Collect candidate breakpoints (byte offsets and hyphen requirements).
-  auto breakInfos = Hyphenator::breakOffsets(word, allowFallbackBreaks);
-  if (breakInfos.empty()) {
-    return false;
-  }
-
   size_t chosenOffset = 0;
   int chosenWidth = -1;
   bool chosenNeedsHyphen = true;
 
-  // Iterate over each legal breakpoint and retain the widest prefix that still fits.
-  for (const auto& info : breakInfos) {
-    const size_t offset = info.byteOffset;
-    if (offset == 0 || offset >= word.size()) {
-      continue;
-    }
+  const auto chooseWidestFittingBreak = [&](const bool includeFallback) {
+    const auto breakInfos = Hyphenator::breakOffsets(word, includeFallback);
+    for (const auto& info : breakInfos) {
+      const size_t offset = info.byteOffset;
+      if (offset == 0 || offset >= word.size()) {
+        continue;
+      }
 
-    const bool needsHyphen = info.requiresInsertedHyphen;
-    const int prefixWidth = measureWordWidth(renderer, fontId, word.substr(0, offset), style, needsHyphen);
-    if (prefixWidth > availableWidth || prefixWidth <= chosenWidth) {
-      continue;  // Skip if too wide or not an improvement
-    }
+      const bool needsHyphen = info.requiresInsertedHyphen;
+      const int prefixWidth = measureWordWidth(renderer, fontId, word.substr(0, offset), style, needsHyphen);
+      if (prefixWidth > availableWidth || prefixWidth <= chosenWidth) {
+        continue;
+      }
 
-    chosenWidth = prefixWidth;
-    chosenOffset = offset;
-    chosenNeedsHyphen = needsHyphen;
+      chosenWidth = prefixWidth;
+      chosenOffset = offset;
+      chosenNeedsHyphen = needsHyphen;
+    }
+  };
+
+  // Prefer language and explicit breakpoints. Only allocate the full UTF-8 fallback list
+  // when an oversized token has no legal breakpoint that fits the available width.
+  chooseWidestFittingBreak(/*includeFallback=*/false);
+  if (chosenWidth < 0 && allowFallbackBreaks) {
+    chooseWidestFittingBreak(/*includeFallback=*/true);
   }
 
   if (chosenWidth < 0) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -32,10 +32,12 @@ namespace {
 // v42/v43: Images persist their book-internal source href for lazy extraction,
 // and TextBlocks serialize ruby annotations and group-continuation styles.
 // v44/v45: Closed HTML tags split adjacent text blocks, changing pagination.
+// v46/v47: Oversized tokens use UTF-8-safe emergency wrapping without inserting
+// synthetic hyphens, changing cached word positions and pagination.
 #ifdef ENABLE_CHINESE_VERSION
-constexpr uint8_t SECTION_FILE_VERSION = 45;
+constexpr uint8_t SECTION_FILE_VERSION = 47;
 #else
-constexpr uint8_t SECTION_FILE_VERSION = 44;
+constexpr uint8_t SECTION_FILE_VERSION = 46;
 #endif
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /

--- a/lib/Epub/Epub/hyphenation/Hyphenator.cpp
+++ b/lib/Epub/Epub/hyphenation/Hyphenator.cpp
@@ -85,7 +85,7 @@ std::vector<Hyphenator::BreakInfo> buildExplicitBreakInfos(const std::vector<Cod
 bool isSegmentSeparator(const uint32_t cp) { return isExplicitHyphen(cp) || isApostrophe(cp); }
 
 void appendSegmentPatternBreaks(const std::vector<CodepointInfo>& cps, const LanguageHyphenator& hyphenator,
-                                const bool includeFallback, std::vector<Hyphenator::BreakInfo>& outBreaks) {
+                                std::vector<Hyphenator::BreakInfo>& outBreaks) {
   size_t segStart = 0;
 
   for (size_t i = 0; i <= cps.size(); ++i) {
@@ -98,14 +98,6 @@ void appendSegmentPatternBreaks(const std::vector<CodepointInfo>& cps, const Lan
     if (i > segStart) {
       std::vector<CodepointInfo> segment(cps.begin() + segStart, cps.begin() + i);
       auto segIndexes = hyphenator.breakIndexes(segment);
-
-      if (includeFallback && segIndexes.empty()) {
-        const size_t minPrefix = hyphenator.minPrefix();
-        const size_t minSuffix = hyphenator.minSuffix();
-        for (size_t idx = minPrefix; idx + minSuffix <= segment.size(); ++idx) {
-          segIndexes.push_back(idx);
-        }
-      }
 
       for (const size_t idx : segIndexes) {
         assert(idx > 0 && idx < segment.size());
@@ -170,6 +162,18 @@ void sortAndDedupeBreakInfos(std::vector<Hyphenator::BreakInfo>& infos) {
               infos.end());
 }
 
+void appendFallbackBreakInfos(const std::vector<CodepointInfo>& cps, const size_t minPrefix, const size_t minSuffix,
+                              std::vector<Hyphenator::BreakInfo>& infos) {
+  if (cps.size() < minPrefix + minSuffix) return;
+
+  const size_t fallbackCount = cps.size() - minPrefix - minSuffix + 1;
+  // Cold oversized-token path: one bounded BreakInfo per UTF-8 codepoint; reserve once to avoid heap fragmentation.
+  infos.reserve(infos.size() + fallbackCount);
+  for (size_t idx = minPrefix; idx + minSuffix <= cps.size(); ++idx) {
+    infos.push_back({cps[idx].byteOffset, false});
+  }
+}
+
 }  // namespace
 
 std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& word, const bool includeFallback) {
@@ -209,12 +213,17 @@ std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& w
     //                                            @16 Satellitensys|tems  (+hyphen)
     //   Result: 6 sorted break points; the line-breaker picks the widest prefix that fits.
     if (hyphenator) {
-      appendSegmentPatternBreaks(cps, *hyphenator, /*includeFallback=*/false, explicitBreakInfos);
+      appendSegmentPatternBreaks(cps, *hyphenator, explicitBreakInfos);
     }
     // Also add apostrophe contraction breaks when present (e.g. "l'état-major"
     // has both an explicit hyphen and an apostrophe that can independently break).
     if (hasApostropheLikeSeparator) {
       appendApostropheContractionBreaks(cps, explicitBreakInfos);
+    }
+    if (includeFallback) {
+      const size_t minPrefix = hyphenator ? hyphenator->minPrefix() : LiangWordConfig::kDefaultMinPrefix;
+      const size_t minSuffix = hyphenator ? hyphenator->minSuffix() : LiangWordConfig::kDefaultMinSuffix;
+      appendFallbackBreakInfos(cps, minPrefix, minSuffix, explicitBreakInfos);
     }
     // Merge all break points into ascending byte-offset order.
     sortAndDedupeBreakInfos(explicitBreakInfos);
@@ -228,9 +237,14 @@ std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& w
   if (hasApostropheLikeSeparator) {
     std::vector<BreakInfo> segmentedBreaks;
     if (hyphenator) {
-      appendSegmentPatternBreaks(cps, *hyphenator, includeFallback, segmentedBreaks);
+      appendSegmentPatternBreaks(cps, *hyphenator, segmentedBreaks);
     }
     appendApostropheContractionBreaks(cps, segmentedBreaks);
+    if (includeFallback) {
+      const size_t minPrefix = hyphenator ? hyphenator->minPrefix() : LiangWordConfig::kDefaultMinPrefix;
+      const size_t minSuffix = hyphenator ? hyphenator->minSuffix() : LiangWordConfig::kDefaultMinSuffix;
+      appendFallbackBreakInfos(cps, minPrefix, minSuffix, segmentedBreaks);
+    }
     sortAndDedupeBreakInfos(segmentedBreaks);
     return segmentedBreaks;
   }
@@ -239,19 +253,6 @@ std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& w
   std::vector<size_t> indexes;
   if (hyphenator) {
     indexes = hyphenator->breakIndexes(cps);
-  }
-
-  // Only add fallback breaks if needed
-  if (includeFallback && indexes.empty()) {
-    const size_t minPrefix = hyphenator ? hyphenator->minPrefix() : LiangWordConfig::kDefaultMinPrefix;
-    const size_t minSuffix = hyphenator ? hyphenator->minSuffix() : LiangWordConfig::kDefaultMinSuffix;
-    for (size_t idx = minPrefix; idx + minSuffix <= cps.size(); ++idx) {
-      indexes.push_back(idx);
-    }
-  }
-
-  if (indexes.empty()) {
-    return {};
   }
 
   std::vector<Hyphenator::BreakInfo> breaks;
@@ -267,6 +268,13 @@ std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& w
       needsHyphen = false;
     }
     breaks.push_back({byteOffsetForIndex(cps, idx), needsHyphen});
+  }
+
+  if (includeFallback) {
+    const size_t minPrefix = hyphenator ? hyphenator->minPrefix() : LiangWordConfig::kDefaultMinPrefix;
+    const size_t minSuffix = hyphenator ? hyphenator->minSuffix() : LiangWordConfig::kDefaultMinSuffix;
+    appendFallbackBreakInfos(cps, minPrefix, minSuffix, breaks);
+    sortAndDedupeBreakInfos(breaks);
   }
 
   return breaks;

--- a/lib/Epub/Epub/hyphenation/Hyphenator.h
+++ b/lib/Epub/Epub/hyphenation/Hyphenator.h
@@ -10,9 +10,8 @@ class Hyphenator {
  public:
   struct BreakInfo {
     size_t byteOffset;            // Byte position inside the UTF-8 word where a break may occur.
-    bool requiresInsertedHyphen;  // true = a visible '-' must be rendered at the break (pattern/fallback breaks).
-                                  // false = break occurs at an existing visible separator boundary
-                                  //         (explicit '-' or eligible apostrophe contraction boundary).
+    bool requiresInsertedHyphen;  // true = a visible '-' must be rendered at a language-pattern break.
+                                  // false = break is already visible or is an emergency wrap that preserves text.
   };
 
   // Returns byte offsets where the word may be hyphenated.
@@ -30,9 +29,8 @@ class Hyphenator {
   //      avoiding short clitics (e.g. l', d') and contraction tails (e.g. 've, 're, 'll).
   //   3. Language-specific Liang patterns (e.g. German de_patterns).
   //      Example: "Quadratkilometer" -> Qua|drat|ki|lo|me|ter.
-  //   4. Fallback every-N-chars splitting (only when includeFallback is true AND no
-  //      pattern breaks were found). Used as a last resort to prevent a single oversized
-  //      word from overflowing the page width.
+  //   4. UTF-8-safe fallback boundaries when includeFallback is true. These do not insert
+  //      a visible hyphen, so URLs and identifiers remain unchanged when emergency-wrapped.
   static std::vector<BreakInfo> breakOffsets(const std::string& word, bool includeFallback);
 
   // Provide a publication-level language hint (e.g. "en", "en-US", "ru") used to select hyphenation rules.

--- a/test/hyphenation_eval/HyphenationEvaluationTest.cpp
+++ b/test/hyphenation_eval/HyphenationEvaluationTest.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "lib/Epub/Epub/hyphenation/HyphenationCommon.h"
+#include "lib/Epub/Epub/hyphenation/Hyphenator.h"
 #include "lib/Epub/Epub/hyphenation/LanguageHyphenator.h"
 #include "lib/Epub/Epub/hyphenation/LanguageRegistry.h"
 
@@ -232,3 +233,39 @@ TEST(HyphenationEval, Spanish) { runLanguageEval("spanish", "es", "spanish_hyphe
 TEST(HyphenationEval, Italian) { runLanguageEval("italian", "it", "italian_hyphenation_tests.txt", 98.99); }
 TEST(HyphenationEval, Polish) { runLanguageEval("polish", "pl", "polish_hyphenation_tests.txt", 98.92); }
 TEST(HyphenationEval, Swedish) { runLanguageEval("swedish", "sv", "swedish_hyphenation_tests.txt", 94.01); }
+
+TEST(HyphenationFallback, OversizedUrlWrapsWithoutChangingText) {
+  Hyphenator::setPreferredLanguage("en");
+  const std::string url = "https://example.com/very-long_path/章节?id=1234567890";
+
+  const auto legalBreaks = Hyphenator::breakOffsets(url, false);
+  ASSERT_FALSE(legalBreaks.empty());
+
+  const size_t firstLegalOffset =
+      std::min_element(legalBreaks.begin(), legalBreaks.end(), [](const auto& left, const auto& right) {
+        return left.byteOffset < right.byteOffset;
+      })->byteOffset;
+  ASSERT_GT(firstLegalOffset, 3u);
+
+  const auto emergencyBreaks = Hyphenator::breakOffsets(url, true);
+  const Hyphenator::BreakInfo* fallback = nullptr;
+  for (const auto& info : emergencyBreaks) {
+    if (info.byteOffset < firstLegalOffset && (!fallback || info.byteOffset > fallback->byteOffset)) {
+      fallback = &info;
+    }
+  }
+
+  ASSERT_NE(fallback, nullptr);
+  EXPECT_FALSE(fallback->requiresInsertedHyphen);
+  EXPECT_EQ(url.substr(0, fallback->byteOffset) + url.substr(fallback->byteOffset), url);
+  EXPECT_NE(static_cast<unsigned char>(url[fallback->byteOffset]) & 0xC0, 0x80);
+}
+
+TEST(HyphenationFallback, LinguisticBreaksRemainAvailableBeforeEmergencyFallback) {
+  Hyphenator::setPreferredLanguage("de");
+  const auto legalBreaks = Hyphenator::breakOffsets("Quadratkilometer", false);
+
+  ASSERT_FALSE(legalBreaks.empty());
+  EXPECT_TRUE(std::any_of(legalBreaks.begin(), legalBreaks.end(),
+                          [](const auto& info) { return info.requiresInsertedHyphen; }));
+}


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Prevent oversized URL-like EPUB tokens from reaching the renderer outside the display bounds and flooding the serial log with `[GFX] !! Outside range` errors.
* **What changes are included?** Prefer language, soft-hyphen, and explicit separator breaks first; when none fit, generate UTF-8-safe emergency break candidates without inserting a synthetic hyphen. Add URL and language-hyphenation regressions, bump Latin/Chinese section cache versions to 46/47, and update the cache format documentation.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The current firmware does not handle this EPUB rendering edge case correctly.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

The line-breaker previously requested fallback breaks together with normal hyphenation candidates. `Hyphenator::breakOffsets()` only generated fallback candidates when no language or explicit break existed, so an oversized URL with existing but unusable breakpoints could remain wider than the screen and reach `GfxRenderer` out of bounds.

The layout pass now tries legal breakpoints first and requests emergency candidates only when none fit. Emergency candidates are aligned to UTF-8 codepoint boundaries and preserve the original text without adding `-`. The fallback vector is allocated only on this cold oversized-token path, reserves once, scales with the current token's codepoint count, and is released on return. There is no persistent RAM, cache-field, dependency, or `GfxRenderer` change.

The section cache byte layout is unchanged, but pagination changes, so Latin/Chinese versions advance from 44/45 to 46/47 to force repagination.

### Validation

- [x] Hyphenation evaluation and fallback tests: 10/10 passed
- [x] `pio run`
- [x] `pio run -e gh_release_cn`
- [x] `git diff --check`
- [ ] Device verification with automatic hyphenation enabled and disabled in all four orientations; confirm complete URL wrapping and no corresponding `[GFX] !! Outside range` serial logs

Memory / flash impact: no persistent allocation or new dependency. The build reports are absolute values rather than before/after deltas, so this PR does not claim a measured RAM or flash reduction.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
