### PR TITLE
perf: skip built-in font scan and limit prompts

### DIFF
--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -155,10 +155,12 @@ uint32_t EpdFont::applyLigatures(uint32_t cp, const char*& text) const {
   return cp;
 }
 
-const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
-  const int count = data->intervalCount;
-  if (count == 0 && !data->glyphMissHandler) return nullptr;
+const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const { return getGlyph(cp, nullptr); }
 
+const EpdGlyph* EpdFont::getGlyph(const uint32_t cp, bool* const usedReplacement) const {
+  if (usedReplacement) *usedReplacement = false;
+
+  const int count = data->intervalCount;
   if (count > 0) {
     const EpdUnicodeInterval* intervals = data->intervals;
     const auto* end = intervals + count;
@@ -184,6 +186,7 @@ const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
   }
 
   if (cp != REPLACEMENT_GLYPH) {
+    if (usedReplacement) *usedReplacement = true;
     return getGlyph(REPLACEMENT_GLYPH);
   }
   return nullptr;

--- a/lib/EpdFont/EpdFont.h
+++ b/lib/EpdFont/EpdFont.h
@@ -11,6 +11,7 @@ class EpdFont {
   void getTextDimensions(const char* string, int* w, int* h) const;
 
   const EpdGlyph* getGlyph(uint32_t cp) const;
+  const EpdGlyph* getGlyph(uint32_t cp, bool* usedReplacement) const;
 
   /// Returns true if this font covers `cp`: either via its in-RAM interval
   /// table or, for SD card fonts, via the coverageHandler that consults the

--- a/lib/EpdFont/EpdFontFamily.cpp
+++ b/lib/EpdFont/EpdFontFamily.cpp
@@ -28,6 +28,10 @@ const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style) co
   return getFont(style)->getGlyph(cp);
 }
 
+const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style, bool* const usedReplacement) const {
+  return getFont(style)->getGlyph(cp, usedReplacement);
+}
+
 bool EpdFontFamily::hasCodepoint(const uint32_t cp, const Style style) const {
   return getFont(style)->hasCodepoint(cp);
 }

--- a/lib/EpdFont/EpdFontFamily.h
+++ b/lib/EpdFont/EpdFontFamily.h
@@ -27,6 +27,7 @@ class EpdFontFamily {
   void getTextDimensions(const char* string, int* w, int* h, Style style = REGULAR) const;
   const EpdFontData* getData(Style style = REGULAR) const;
   const EpdGlyph* getGlyph(uint32_t cp, Style style = REGULAR) const;
+  const EpdGlyph* getGlyph(uint32_t cp, Style style, bool* usedReplacement) const;
   /// Returns true if the resolved style's font can render `cp` directly
   /// (interval coverage only — see EpdFont::hasCodepoint).
   bool hasCodepoint(uint32_t cp, Style style = REGULAR) const;

--- a/lib/GfxRenderer/FontCacheManager.cpp
+++ b/lib/GfxRenderer/FontCacheManager.cpp
@@ -3,9 +3,6 @@
 #include <FontDecompressor.h>
 #include <Logging.h>
 #include <SdCardFont.h>
-#ifdef ENABLE_CHINESE_VERSION
-#include <Utf8.h>
-#endif
 
 #include <cstring>
 
@@ -79,42 +76,42 @@ bool FontCacheManager::canIdlePrewarm(const int fontId) const {
   return sdCardFonts_.find(fontId) != sdCardFonts_.end();
 }
 
+bool FontCacheManager::needsPrewarmScan(const int fontId) const {
+  if (sdCardFonts_.count(fontId) != 0) return true;
+
+  const auto familyIt = fontMap_.find(fontId);
+  if (familyIt == fontMap_.end()) return false;
+  for (uint8_t i = 0; i < 4; i++) {
+    const auto style = static_cast<EpdFontFamily::Style>(i);
+    const EpdFontData* data = familyIt->second.getData(style);
+    if (data && data->groups) return true;
+  }
+  return false;
+}
+
 bool FontCacheManager::isScanning() const { return scanMode_ == ScanMode::Scanning; }
 
-void FontCacheManager::recordText(const char* text, int fontId, EpdFontFamily::Style style) {
+void FontCacheManager::recordText(const char* text, const int fontId, EpdFontFamily::Style style) {
   scanText_ += text;
   if (scanFontId_ < 0) scanFontId_ = fontId;
   const uint8_t baseStyle = static_cast<uint8_t>(style) & 0x03;
   const unsigned char* p = reinterpret_cast<const unsigned char*>(text);
   uint32_t cpCount = 0;
-#ifdef ENABLE_CHINESE_VERSION
-  const EpdFontFamily* builtinFamily = nullptr;
-  const EpdGlyph* replacementGlyph = nullptr;
-  if (missingChineseCodepoint_ == 0 && sdCardFonts_.count(fontId) == 0) {
-    const auto familyIt = fontMap_.find(fontId);
-    if (familyIt != fontMap_.end()) {
-      builtinFamily = &familyIt->second;
-      replacementGlyph = builtinFamily->getGlyph(REPLACEMENT_GLYPH, static_cast<EpdFontFamily::Style>(baseStyle));
-    }
-  }
-  while (*p) {
-    const uint32_t cp = utf8NextCodepoint(&p);
-    cpCount++;
-    if (builtinFamily && missingChineseCodepoint_ == 0 && isDownloadableChineseCodepoint(cp)) {
-      const auto* glyph = builtinFamily->getGlyph(cp, static_cast<EpdFontFamily::Style>(baseStyle));
-      if (!glyph || glyph == replacementGlyph) missingChineseCodepoint_ = cp;
-    }
-  }
-#else
   while (*p) {
     if ((*p & 0xC0) != 0x80) cpCount++;
     p++;
   }
-#endif
   scanStyleCounts_[baseStyle] += cpCount;
 }
 
 #ifdef ENABLE_CHINESE_VERSION
+void FontCacheManager::reportMissingChineseCodepoint(const int fontId, const uint32_t codepoint) {
+  if (missingChineseCodepoint_ != 0 || sdCardFonts_.count(fontId) != 0 || !isDownloadableChineseCodepoint(codepoint)) {
+    return;
+  }
+  missingChineseCodepoint_ = codepoint;
+}
+
 uint32_t FontCacheManager::consumeMissingChineseCodepoint() {
   const uint32_t codepoint = missingChineseCodepoint_;
   missingChineseCodepoint_ = 0;

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -20,11 +20,13 @@ class FontCacheManager {
   void logStats(const char* label = "render");
   void resetStats();
   bool canIdlePrewarm(int fontId) const;
+  bool needsPrewarmScan(int fontId) const;
 
   // Scan-mode API: called by GfxRenderer::drawText() during scan pass
   bool isScanning() const;
   void recordText(const char* text, int fontId, EpdFontFamily::Style style);
 #ifdef ENABLE_CHINESE_VERSION
+  void reportMissingChineseCodepoint(int fontId, uint32_t codepoint);
   uint32_t consumeMissingChineseCodepoint();
 #endif
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -619,6 +619,9 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
       continue;
     }
 
+#ifdef ENABLE_CHINESE_VERSION
+    const uint32_t sourceCp = cp;
+#endif
     cp = font.applyLigatures(cp, textCursor, style);
 
     // Differential rounding: snap (previous advance + current kern) as one unit so
@@ -629,7 +632,15 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
       lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
     }
 
+#ifdef ENABLE_CHINESE_VERSION
+    bool usedReplacement = false;
+    const EpdGlyph* glyph = font.getGlyph(cp, style, &usedReplacement);
+    if (usedReplacement && fontCacheManager_) {
+      fontCacheManager_->reportMissingChineseCodepoint(resolvedFontId, sourceCp);
+    }
+#else
     const EpdGlyph* glyph = font.getGlyph(cp, style);
+#endif
 
     lastBaseLeft = glyph ? glyph->left : 0;
     lastBaseWidth = glyph ? glyph->width : 0;
@@ -2078,6 +2089,9 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
       continue;
     }
 
+#ifdef ENABLE_CHINESE_VERSION
+    const uint32_t sourceCp = cp;
+#endif
     cp = font.applyLigatures(cp, text, style);
 
     // Differential rounding: snap (previous advance + current kern) as one unit,
@@ -2087,7 +2101,15 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
       lastBaseY -= fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
     }
 
+#ifdef ENABLE_CHINESE_VERSION
+    bool usedReplacement = false;
+    const EpdGlyph* glyph = font.getGlyph(cp, style, &usedReplacement);
+    if (usedReplacement && fontCacheManager_) {
+      fontCacheManager_->reportMissingChineseCodepoint(resolvedFontId, sourceCp);
+    }
+#else
     const EpdGlyph* glyph = font.getGlyph(cp, style);
+#endif
 
     lastBaseLeft = glyph ? glyph->left : 0;
     lastBaseWidth = glyph ? glyph->width : 0;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -368,7 +368,7 @@ bool EpubReaderActivity::maybeOfferCompleteChineseFont() {
   }
 
   const uint32_t codepoint = pendingMissingChineseCodepoint_.exchange(0, std::memory_order_relaxed);
-  if (codepoint == 0 || chineseFontPromptShown_.exchange(true, std::memory_order_relaxed)) return false;
+  if (codepoint == 0 || FontDownloadActivity::wasChineseFontPromptShownThisBoot()) return false;
 
   LOG_INF("FONT", "Missing built-in Chinese glyph U+%04X; offering SD fonts", static_cast<unsigned>(codepoint));
 
@@ -377,7 +377,6 @@ bool EpubReaderActivity::maybeOfferCompleteChineseFont() {
       makeUniqueNoThrow<FontDownloadActivity>(renderer, mappedInput, FontDownloadActivity::Purpose::PromptThenManage);
   if (!downloader) {
     LOG_ERR("FONT", "OOM allocating FontDownloadActivity (%zu bytes)", sizeof(FontDownloadActivity));
-    chineseFontPromptShown_.store(false, std::memory_order_relaxed);
     return false;
   }
 
@@ -1622,7 +1621,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);
 #ifdef ENABLE_CHINESE_VERSION
   const uint32_t missingCodepoint = fcm->consumeMissingChineseCodepoint();
-  if (missingCodepoint != 0 && !chineseFontPromptShown_.load(std::memory_order_relaxed)) {
+  if (missingCodepoint != 0 && !FontDownloadActivity::wasChineseFontPromptShownThisBoot()) {
     uint32_t expected = 0;
     pendingMissingChineseCodepoint_.compare_exchange_strong(expected, missingCodepoint, std::memory_order_relaxed);
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1575,18 +1575,29 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     renderer.clearScreen();
   }
 
-  // Font prewarm: scan pass accumulates text, then prewarm, then real render
+  // Compressed and SD fonts need a scan pass to build their page glyph cache.
+  // Raw built-in fonts render directly and skip both the scan and its temporary string.
   auto* fcm = renderer.getFontCacheManager();
-  auto scope = fcm->createPrewarmScope();
-  page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);  // scan pass
-  scope.endScanAndPrewarm();
 #ifdef ENABLE_CHINESE_VERSION
-  const uint32_t missingCodepoint = fcm->consumeMissingChineseCodepoint();
-  if (missingCodepoint != 0 && !chineseFontPromptShown_.load(std::memory_order_relaxed)) {
-    uint32_t expected = 0;
-    pendingMissingChineseCodepoint_.compare_exchange_strong(expected, missingCodepoint, std::memory_order_relaxed);
-  }
+  fcm->consumeMissingChineseCodepoint();  // discard status/UI glyphs left by the previous render
 #endif
+  struct RawFontCacheGuard {
+    FontCacheManager* manager = nullptr;
+    ~RawFontCacheGuard() {
+      if (manager) manager->clearCache();
+    }
+  } rawFontCacheGuard;
+  std::optional<FontCacheManager::PrewarmScope> prewarmScope;
+  if (fcm->needsPrewarmScan(fontId)) {
+    prewarmScope.emplace(*fcm);
+    page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);  // scan pass
+    prewarmScope->endScanAndPrewarm();
+  } else {
+    // Preserve PrewarmScope's cache lifecycle without allocating its scan string.
+    fcm->clearCache();
+    fcm->resetStats();
+    rawFontCacheGuard.manager = fcm;
+  }
   const auto tPrewarm = millis();
 
   const bool manualRefreshPending = forcedRefreshPending;
@@ -1609,6 +1620,13 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   };
 
   page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);
+#ifdef ENABLE_CHINESE_VERSION
+  const uint32_t missingCodepoint = fcm->consumeMissingChineseCodepoint();
+  if (missingCodepoint != 0 && !chineseFontPromptShown_.load(std::memory_order_relaxed)) {
+    uint32_t expected = 0;
+    pendingMissingChineseCodepoint_.compare_exchange_strong(expected, missingCodepoint, std::memory_order_relaxed);
+  }
+#endif
   renderStatusBar();
   const auto tBwRender = millis();
 

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -96,7 +96,6 @@ class EpubReaderActivity final : public Activity {
 
 #ifdef ENABLE_CHINESE_VERSION
   std::atomic<uint32_t> pendingMissingChineseCodepoint_{0};
-  std::atomic<bool> chineseFontPromptShown_{false};
   bool maybeOfferCompleteChineseFont();
 #endif
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -1,5 +1,9 @@
 #include "FontDownloadActivity.h"
 
+#ifdef ENABLE_CHINESE_VERSION
+#include <atomic>
+#endif
+
 #include <ArduinoJson.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
@@ -22,11 +26,21 @@ namespace {
 
 constexpr uint32_t kProgressRefreshIntervalMs = 2000;
 
+#ifdef ENABLE_CHINESE_VERSION
+std::atomic<bool> chineseFontPromptShownThisBoot{false};
+#endif
+
 }  // namespace
 
 FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                            const Purpose purpose)
     : Activity("FontDownload", renderer, mappedInput), purpose_(purpose), fontInstaller_(sdFontSystem.registry()) {}
+
+#ifdef ENABLE_CHINESE_VERSION
+bool FontDownloadActivity::wasChineseFontPromptShownThisBoot() {
+  return chineseFontPromptShownThisBoot.load(std::memory_order_relaxed);
+}
+#endif
 
 // --- Lifecycle ---
 
@@ -47,6 +61,9 @@ void FontDownloadActivity::onEnter() {
         finish();
         return;
       }
+#ifdef ENABLE_CHINESE_VERSION
+      chineseFontPromptShownThisBoot.store(true, std::memory_order_relaxed);
+#endif
       startActivityForResult(std::move(confirmation), [this](const ActivityResult& result) {
         if (result.isCancelled) {
           finish();

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -38,6 +38,10 @@ class FontDownloadActivity : public Activity {
   explicit FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                 Purpose purpose = Purpose::Manage);
 
+#ifdef ENABLE_CHINESE_VERSION
+  static bool wasChineseFontPromptShownThisBoot();
+#endif
+
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -379,7 +379,7 @@ void TextSettingsActivity::applySize(int listIndex) {
 
 #ifdef ENABLE_CHINESE_VERSION
 void TextSettingsActivity::maybeOfferCompleteChineseFont() {
-  if (chineseFontPromptShown_ || SETTINGS.sdFontFamilyName[0] != '\0' ||
+  if (FontDownloadActivity::wasChineseFontPromptShownThisBoot() || SETTINGS.sdFontFamilyName[0] != '\0' ||
       SETTINGS.fontPointSize < 16) {  // Legacy LARGE threshold.
     return;
   }
@@ -396,7 +396,6 @@ void TextSettingsActivity::maybeOfferCompleteChineseFont() {
     return;
   }
 
-  chineseFontPromptShown_ = true;
   startActivityForResult(std::move(downloader), [this](const ActivityResult&) { requestUpdate(); });
 }
 #endif

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -95,9 +95,6 @@ class TextSettingsActivity final : public Activity {
       {};  // per-Tab nav position (0 = tab bar, 1..N = row); set in onEnter
   int currentFamilyIndex_ = 0;
   int currentSizeIndex_ = 0;
-#ifdef ENABLE_CHINESE_VERSION
-  bool chineseFontPromptShown_ = false;
-#endif
 
   ThemeMetrics metrics_ = {};
   int afterHeader = 0;

--- a/test/differential_rounding/DifferentialRoundingTest.cpp
+++ b/test/differential_rounding/DifferentialRoundingTest.cpp
@@ -76,10 +76,48 @@ const EpdFontData kTestFontData = {
   .glyphMissHandler  = nullptr,
   .glyphMissCtx      = nullptr,
 };
+
+const EpdGlyph kReplacementGlyphs[] = {
+  { 8, 12, 128, 0, 12, 0, 0 },
+};
+
+const EpdUnicodeInterval kReplacementIntervals[] = {
+  { 0xFFFD, 0xFFFD, 0 },
+};
+
+const EpdFontData kReplacementFontData = {
+  .bitmap            = nullptr,
+  .glyph             = kReplacementGlyphs,
+  .intervals         = kReplacementIntervals,
+  .intervalCount     = 1,
+  .advanceY          = 16,
+  .ascender          = 12,
+  .descender         = 0,
+  .is2Bit            = false,
+  .groups            = nullptr,
+  .groupCount        = 0,
+  .glyphToGroup      = nullptr,
+  .kernLeftClasses   = nullptr,
+  .kernRightClasses  = nullptr,
+  .kernMatrix        = nullptr,
+  .kernLeftEntryCount  = 0,
+  .kernRightEntryCount = 0,
+  .kernLeftClassCount  = 0,
+  .kernRightClassCount = 0,
+  .ligaturePairs     = nullptr,
+  .ligaturePairCount = 0,
+  .glyphMissHandler  = nullptr,
+  .glyphMissCtx      = nullptr,
+};
 // clang-format on
 
 EpdFont& testFont() {
   static EpdFont font(&kTestFontData);
+  return font;
+}
+
+EpdFont& replacementFont() {
+  static EpdFont font(&kReplacementFontData);
   return font;
 }
 
@@ -245,6 +283,24 @@ TEST(EpdFont, GlyphLookup) {
   // No U+FFFD in font, so unknown codepoints return nullptr
   EXPECT_EQ(testFont().getGlyph('Z'), nullptr);
   EXPECT_EQ(testFont().getGlyph('b'), nullptr);
+}
+
+TEST(EpdFont, CoveredGlyphDoesNotReportReplacement) {
+  bool usedReplacement = true;
+  EXPECT_NE(testFont().getGlyph('T', &usedReplacement), nullptr);
+  EXPECT_FALSE(usedReplacement);
+}
+
+TEST(EpdFont, MissingGlyphReportsReplacement) {
+  bool usedReplacement = false;
+  EXPECT_EQ(replacementFont().getGlyph(0x749F, &usedReplacement), &kReplacementGlyphs[0]);
+  EXPECT_TRUE(usedReplacement);
+}
+
+TEST(EpdFont, MissingGlyphWithoutReplacementStillReportsMissing) {
+  bool usedReplacement = false;
+  EXPECT_EQ(testFont().getGlyph(0x749F, &usedReplacement), nullptr);
+  EXPECT_TRUE(usedReplacement);
 }
 
 // Known-value regression tests.  Expected widths are computed by hand using


### PR DESCRIPTION
## Summary

- skip the EPUB prewarm scan for raw built-in fonts, removing the duplicate page traversal and the per-page 2 KB scan-text reservation
- report built-in Chinese replacement glyph use from the actual text draw path without a second glyph-range lookup
- keep formal prewarming and the cross-page mini cache unchanged for SD fonts and compressed built-in fonts
- share one automatic Chinese font prompt per firmware boot between EPUB missing-glyph detection and the Text Settings large-size guide
- consume that quota only after the confirmation dialog is allocated; manual font management remains available

This does not change cache formats, settings, the HAL, or persistent state, and it adds no heap allocation or resident cache.

## Validation

- [x] `ctest --test-dir build/test --output-on-failure` (168/168)
- [x] `clang-format --dry-run --Werror` on all modified C++ files
- [x] `git diff --check`
- [x] `pio run -e default`
- [x] `pio run -e gh_release_cn`

## X4 device validation

- [ ] built-in 14 pt: common Chinese renders without a prompt; a page containing `璟` prompts once
- [ ] cancel the missing-glyph prompt, then turn pages, switch books, and re-enter the reader without another prompt
- [ ] trigger and cancel from Text Settings first, then verify the reader stays quiet; repeat in reverse order
- [ ] manual font download remains available after the automatic prompt quota is consumed
- [ ] SD Chinese font does not trigger the full-font download prompt
- [ ] confirmation-dialog allocation failure does not consume the boot quota
- [ ] deep-sleep wake, software restart, and power cycle each restore one automatic prompt
- [ ] regular/bold/ruby, anti-aliasing on/off, and all four orientations
- [ ] compare `prewarm` and `total` across 30 page turns
- [ ] verify free heap and largest allocatable block remain stable across 200 page turns

Future built-in styles with different font coverage should revalidate replacement-glyph detection; the current Chinese built-in styles share the same font data.
