### PR TITLE
fix: prevent popup confirm release-through

### DIFF
--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -94,12 +94,27 @@ class OptionPopup {
       selectedIndex = (selectedIndex + 1) % count;
       requestUpdate();
       return true;
-    } else if (input.wasReleased(MappedInputManager::Button::Confirm)) {
+    }
+
+    const auto confirm = MappedInputManager::Button::Confirm;
+    const bool confirmReleased = input.wasReleased(confirm);
+    // A popup opened by Confirm inherits that held button; consume only its trailing release.
+    if (ignoreInitialConfirmRelease) {
+      if (confirmReleased) {
+        ignoreInitialConfirmRelease = false;
+        return true;
+      } else if (!input.isPressed(confirm)) {
+        ignoreInitialConfirmRelease = false;
+      }
+    }
+
+    if (confirmReleased) {
       active = false;
       if (onSelectCallback) onSelectCallback(selectedIndex);
       requestUpdate();
       return true;
-    } else if (input.wasPressed(MappedInputManager::Button::Back)) {
+    }
+    if (input.wasPressed(MappedInputManager::Button::Back)) {
       active = false;
       requestUpdate();
       return true;
@@ -141,6 +156,7 @@ class OptionPopup {
       selectedIndex = currentIndex;
     }
     onSelectCallback = std::move(onSelect);
+    ignoreInitialConfirmRelease = true;
     active = true;
   }
 
@@ -207,6 +223,7 @@ class OptionPopup {
   std::vector<std::string> ownedStrings;
   int selectedIndex = 0;
   std::function<void(int)> onSelectCallback;
+  bool ignoreInitialConfirmRelease = false;
   mutable Layout layout;
   mutable bool layoutValid = false;
 };


### PR DESCRIPTION
## Summary

- Prevent `OptionPopup` instances opened by a Confirm press from immediately consuming that gesture's release.
- Reset a small release barrier on every `show()`, consume only the inherited Confirm release, and preserve normal subsequent Confirm, navigation, Back, and touch behavior.

## Root cause and impact

Settings opens the clear-cache activity on the Confirm press edge. Its confirmation popup then received the same gesture's release edge and selected the default Cancel option, making the dialog appear to flash and close. Fixing the shared popup also protects the other popup callers from the same release-through behavior.

The change adds no heap allocation, public API, or cache-format change. Memory impact is one boolean per `OptionPopup` instance.

## Validation

- [x] `git diff --check`
- [x] `clang-format --dry-run --Werror src/components/OptionPopup.h`
- [x] Simulator build compiled the affected activities, including clear-cache, settings, reading statistics, status bar, and bookmark callers.
- [ ] `pio run` — blocked by the local PlatformIO framework package losing its manifest (`Arduino.h` / `Client.h`, then missing `package.json`).
- [ ] Full simulator link — blocked by unrelated missing `ImageDimsProbe` symbols.
- [ ] Device regression: clear-cache opening release, one-shot clearing, settings popups, reading statistics, status bar, bookmark deletion, touch, and parent-page release-through.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a targeted reading UI input bug fix; it does not duplicate a stock-firmware feature.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## AI Usage

AI tools were used to trace the input transition, implement the minimal shared fix, and prepare this PR.
