### PR TITLE
feat: prioritize WeRead in apps menu

### DIFF
--- a/src/activities/apps/AppsMenuActivity.cpp
+++ b/src/activities/apps/AppsMenuActivity.cpp
@@ -36,10 +36,10 @@ struct AppEntry {
 };
 
 constexpr AppEntry kAppEntries[] = {
-    {AppId::ReadingStats, StrId::STR_READING_STATS, UIIcon::Library, &ActivityManager::goToReadingStatsMenu},
 #if defined(ENABLE_CHINESE_VERSION) && !defined(__EMSCRIPTEN__)
     {AppId::WeRead, StrId::STR_WEREAD_TITLE, UIIcon::WeRead, &ActivityManager::goToWeRead},
 #endif
+    {AppId::ReadingStats, StrId::STR_READING_STATS, UIIcon::Library, &ActivityManager::goToReadingStatsMenu},
     {AppId::Sudoku, StrId::STR_SUDOKU_TITLE, UIIcon::Sudoku, &ActivityManager::goToSudoku},
     {AppId::Gomoku, StrId::STR_GOMOKU_TITLE, UIIcon::Gomoku, &ActivityManager::goToGomoku},
 #ifdef ENABLE_CHINESE_VERSION


### PR DESCRIPTION
## Summary

- Place WeRead first in the shared app catalog for Simplified Chinese non-WASM builds.
- Keep `AppId::WeRead = 1`, preserving existing app visibility preferences.
- Leave non-Chinese and WASM app ordering unchanged.

## Impact

WeRead is now the initially selected item in the Apps menu and appears first in App Visibility settings for supported Chinese builds. This change adds no public API, data format, allocation, or translation changes.

## Validation

- `pio run -e gh_release_cn -e default`
- `git diff --check`

## Manual testing

- Not run on hardware.
