### PR TITLE
feat(weread): improve shelf long-press navigation

### DIFF
--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -1015,15 +1015,27 @@ void WeReadActivity::handleMenuInput() {
 void WeReadActivity::handleShelfInput() {
   const int count = static_cast<int>(std::min<uint32_t>(shelfCount_, INT32_MAX));
   const int itemsPerPage = shelfItemsPerPage();
-  buttonNavigator_.onNext([this, count, itemsPerPage] {
+  buttonNavigator_.onNextRelease([this, count, itemsPerPage] {
     const int previousPage = shelfSelected_ / itemsPerPage;
     shelfSelected_ = ButtonNavigator::nextIndex(shelfSelected_, count);
     if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
     requestUpdate();
   });
-  buttonNavigator_.onPrevious([this, count, itemsPerPage] {
+  buttonNavigator_.onPreviousRelease([this, count, itemsPerPage] {
     const int previousPage = shelfSelected_ / itemsPerPage;
     shelfSelected_ = ButtonNavigator::previousIndex(shelfSelected_, count);
+    if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
+    requestUpdate();
+  });
+  buttonNavigator_.onNextContinuous([this, count, itemsPerPage] {
+    const int previousPage = shelfSelected_ / itemsPerPage;
+    shelfSelected_ = ButtonNavigator::nextPageIndex(shelfSelected_, count, itemsPerPage);
+    if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
+    requestUpdate();
+  });
+  buttonNavigator_.onPreviousContinuous([this, count, itemsPerPage] {
+    const int previousPage = shelfSelected_ / itemsPerPage;
+    shelfSelected_ = ButtonNavigator::previousPageIndex(shelfSelected_, count, itemsPerPage);
     if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
     requestUpdate();
   });


### PR DESCRIPTION
## Summary

- replace the previous furthest-progress/2% heuristic with a per-account last-write-wins baseline
- persist a fixed 156-byte `WPS1` sync record containing remote canonical progress and matching local page coordinates
- treat `/web/book/read` success as provisional and require a cache-bypassed read-back before reporting a local upload
- atomically persist EPUB progress before accepting an applied remote baseline

## Root cause

Progress sync previously preferred whichever position was further ahead and treated a successful POST as final. Moving backward locally was therefore overwritten by an older but further remote position, while a server-accepted POST could be reported as uploaded without confirming that WeRead had made it authoritative.

## User impact

After the first cloud-priority baseline, an explicit local page change is uploaded regardless of direction. An unchanged local position accepts a newer write from another WeRead source. Upload success is shown only after canonical position, update time, and source are confirmed; otherwise the UI offers a retry.

## Validation

- [x] WeRead host tests: 50/50 passed
- [x] `pio run -e gh_release_cn`
- [x] RAM: 53,060 bytes; Flash: 89.3%
- [x] `pio check` — no defects found
- [x] `git diff --check`

## Hardware validation

- [ ] Establish a baseline, move backward on X4, sync, and confirm WeRead keeps the X4 position
- [ ] Change progress in the WeRead app while X4 is unchanged and confirm X4 applies it
- [ ] Move forward on X4 and confirm upload success appears only after cloud read-back
- [ ] Cover a change below 2% and a cross-chapter change
- [ ] Repeat five cycles while monitoring free heap, largest block, and stack high-water marks
