### PR TITLE
feat: refine Lyra Carousel home layout

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -346,7 +346,7 @@ void HomeActivity::loop() {
   int menuRow = -1;
   MappedInputManager::RowTouch menuTouch;
   if (isCarousel) {
-    const int menuBottom = renderer.getScreenHeight() - metrics.buttonHintsHeight;
+    const int menuBottom = renderer.getScreenHeight();
     const int columnWidth = renderer.getScreenWidth() / renderedMenuCount;
     menuTouch = mappedInput.colTouch(menuRow, 0, columnWidth, renderedMenuCount, menuBottom - metrics.menuRowHeight,
                                      menuBottom, columnWidth);
@@ -433,10 +433,11 @@ void HomeActivity::render(RenderLock&&) {
 
   const bool isCarousel =
       static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
-  const auto labels =
-      isCarousel ? mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT))
-                 : mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  if (!isCarousel) {
+    const auto labels =
+        mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  }
 
   renderer.displayBuffer();
 

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -434,8 +434,7 @@ void HomeActivity::render(RenderLock&&) {
   const bool isCarousel =
       static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
   if (!isCarousel) {
-    const auto labels =
-        mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+    const auto labels = mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   }
 

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -19,7 +19,7 @@ constexpr int kCenterCoverHeight = 540;
 constexpr int kSideCoverWidth = 200;
 constexpr int kSideCoverHeight = 390;
 constexpr int kSideOverlap = 60;
-constexpr int kCoverTopPadding = 10;
+constexpr int kCoverTopPadding = 22;
 constexpr int kCornerRadius = 6;
 constexpr int kCenterOutlineWidth = 4;
 constexpr int kActiveOutlineWidth = 3;
@@ -145,7 +145,7 @@ void LyraCarouselTheme::drawHomeMenu(GfxRenderer& renderer, Rect rect, int butto
 
   const int tileHeight = kMenuIconPadding * 2 + kMenuIconSize;
   const int tileWidth = renderer.getScreenWidth() / buttonCount;
-  const int rowY = renderer.getScreenHeight() - UITheme::getInstance().getMetrics().buttonHintsHeight - tileHeight;
+  const int rowY = renderer.getScreenHeight() - tileHeight;
 
   for (int i = 0; i < buttonCount; ++i) {
     const int tileX = i * tileWidth;


### PR DESCRIPTION
## Summary

- hide the bottom front-button hints on the Lyra Carousel home screen
- move the home option row and its touch target to the bottom edge
- shift the cover carousel, indicators, and book metadata down by 12 px

## Why

The Carousel home screen no longer needs a separate button-hint row. Reusing that space gives the option row a cleaner bottom-aligned layout and improves the vertical balance of the cover group.

## Validation

- `pio run`
- `git diff --check`

Hardware visual and touch-position verification is still recommended.
