### PR TITLE
ci: add local pre-PR checks

### DIFF
--- a/bin/ci-check
+++ b/bin/ci-check
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if git submodule status --recursive | grep -q '^-'; then
+  echo "Error: Git submodules are not initialized."
+  echo "Run: git submodule update --init --recursive"
+  exit 1
+fi
+
+echo "Checking formatting..."
+./bin/clang-format-fix --check
+
+echo "Running cppcheck..."
+pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
+
+echo "Building default and sticky firmware..."
+pio run -e default -e sticky
+
+echo "Running host unit tests..."
+cmake -S test -B build/test -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build/test
+ctest --test-dir build/test --output-on-failure -j
+
+echo "Local CI checks passed."
+echo "Remember to use a semantic PR title, for example: fix: handle malformed epub"

--- a/bin/clang-format-fix
+++ b/bin/clang-format-fix
@@ -13,11 +13,25 @@ fi
 
 set -euo pipefail
 
-GIT_LS_FILES_FLAGS=""
-# -g scopes formatting to tracked files currently modified in git status.
-if [[ "${1:-}" == "-g" ]]; then
-  GIT_LS_FILES_FLAGS="--modified"
-fi
+GIT_LS_FILES_FLAG=""
+CLANG_FORMAT_FLAGS=(-style=file -i)
+
+for arg in "$@"; do
+  case "${arg}" in
+    -g)
+      # Scope formatting to tracked files currently modified in git status.
+      GIT_LS_FILES_FLAG="--modified"
+      ;;
+    --check)
+      # Match CI without changing the working tree.
+      CLANG_FORMAT_FLAGS=(-style=file --dry-run --Werror)
+      ;;
+    *)
+      printf "Usage: %s [-g] [--check]\n" "$0" >&2
+      exit 2
+      ;;
+  esac
+done
 
 CLANG_FORMAT_VERSION_RAW="$(${CLANG_FORMAT_BIN} --version)"
 CLANG_FORMAT_MAJOR="$(printf '%s\n' "${CLANG_FORMAT_VERSION_RAW}" | grep -oE '[0-9]+' | head -n1)"
@@ -42,12 +56,12 @@ fi
 # Keep the no-match case non-fatal: grep returns 1 when no files match,
 # which is expected when there are no modified C/C++ files.
 set +o pipefail
-git ls-files  --exclude-standard ${GIT_LS_FILES_FLAGS} \
+git ls-files --exclude-standard ${GIT_LS_FILES_FLAG:+"${GIT_LS_FILES_FLAG}"} \
     | grep -E '\.(c|cpp|h|hpp)$' \
     | grep -v -E '^lib/EpdFont/builtinFonts/' \
     | grep -v -E '^lib/Epub/Epub/hyphenation/generated/' \
     | grep -v -E '^lib/uzlib/' \
     | grep -v -E '^lib/miniz/third_party/' \
-    | xargs -r "${CLANG_FORMAT_BIN}" -style=file -i
+    | xargs -r "${CLANG_FORMAT_BIN}" "${CLANG_FORMAT_FLAGS[@]}"
 # Restore strict pipeline failure handling for the rest of the script.
 set -o pipefail

--- a/docs/contributing/development-workflow.md
+++ b/docs/contributing/development-workflow.md
@@ -19,18 +19,22 @@ This page defines the expected local workflow before opening a pull request.
 ## 3) Run local checks
 
 ```sh
-./bin/clang-format-fix
-pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
-pio run
+./bin/ci-check
 ```
 
-CI enforces formatting, static analysis, and build checks.
-Use clang-format 21+ locally to match CI.
-If `clang-format` is missing or too old locally, see [Getting Started](./getting-started.md).
+This runs the same formatting, static analysis, `default`/`sticky` firmware
+builds, and host unit tests as CI. It stops at the first failure and does not
+modify source files.
+
+Before the first run, initialize submodules with
+`git submodule update --init --recursive`. The script does not install its
+required tools: PlatformIO, clang-format 21+, CMake, and Ninja. See
+[Getting Started](./getting-started.md) for the core setup.
 
 ## 4) Open the PR
 
 - Use a semantic title (example: `fix: avoid crash when opening malformed epub`)
+- The GitHub PR title check depends on PR metadata and is not run by `./bin/ci-check`
 - Fill out `.github/PULL_REQUEST_TEMPLATE.md`
 - Describe the problem, approach, and any tradeoffs
 - Include reproduction and verification steps for bug fixes


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let contributors reproduce required GitHub CI checks locally before opening a PR.
* **What changes are included?**
  - Add `./bin/ci-check` for formatting, cppcheck, `default`/`sticky` firmware builds, and host unit tests.
  - Add a non-mutating `--check` mode to `bin/clang-format-fix`.
  - Document the pre-PR workflow, prerequisites, and semantic PR title requirement.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is contributor-only maintainability tooling; stock firmware/fork feature comparison is not applicable.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Developer-only tooling; no firmware runtime, RAM, or flash impact.
* Validation: `./bin/ci-check`
  - clang-format check passed
  - cppcheck passed with no defects
  - `default` and `sticky` builds passed
  - 215/215 host unit tests passed

---

### AI Usage

Did you use AI tools to help write this code? **YES**
