### PR TITLE
chore: schedule nightly for 07:00 Beijing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ name: Nightly
 # assets. The website's Insider/Nightly reads the newest prerelease.
 on:
   schedule:
-    - cron: '0 18 * * *' # daily 18:00 UTC
+    - cron: '0 23 * * *' # daily 07:00 Asia/Shanghai
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

- Run the rolling nightly workflow at `23:00 UTC`, corresponding to `07:00 Asia/Shanghai`.
- Update the inline schedule comment to document the intended Beijing time.

## Why

The nightly build should be published every morning at 07:00 Beijing time.

## Impact

The workflow schedule changes only; build and release behavior is unchanged.

## Validation

- `git diff --cached --check`
- Confirmed the PR contains one file with one cron/comment replacement.
