### PR TITLE
fix: center game boards on wider screens

### DIFF
--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -151,8 +151,12 @@ void ChineseChessGameActivity::loop() {
 
 // ---------- Geometry ----------
 
+int ChineseChessGameActivity::boardOriginX() const {
+  return (renderer.getScreenWidth() - BOARD_PITCH * (ChineseChessBoard::FILES - 1)) / 2;
+}
+
 void ChineseChessGameActivity::cellXY(uint8_t r, uint8_t c, int* x, int* y) const {
-  *x = BOARD_ORIGIN_X + static_cast<int>(c) * BOARD_PITCH;
+  *x = boardOriginX() + static_cast<int>(c) * BOARD_PITCH;
   *y = BOARD_ORIGIN_Y + static_cast<int>(r) * BOARD_PITCH;
 }
 
@@ -465,7 +469,7 @@ void ChineseChessGameActivity::drawTitleBar() {
 // ---------- Board ----------
 
 void ChineseChessGameActivity::drawBoard() {
-  const int ox = BOARD_ORIGIN_X;
+  const int ox = boardOriginX();
   const int oy = BOARD_ORIGIN_Y;
   const int width = BOARD_PITCH * (ChineseChessBoard::FILES - 1);
   const int height = BOARD_PITCH * (ChineseChessBoard::RANKS - 1);
@@ -495,7 +499,7 @@ void ChineseChessGameActivity::drawBoard() {
 }
 
 void ChineseChessGameActivity::drawPalaceLines() {
-  const int ox = BOARD_ORIGIN_X;
+  const int ox = boardOriginX();
   const int oy = BOARD_ORIGIN_Y;
   // Black palace: rows 0..2, cols 3..5.
   {
@@ -520,7 +524,7 @@ void ChineseChessGameActivity::drawPalaceLines() {
 void ChineseChessGameActivity::drawRiver() {
   // The river sits between rows 4 and 5. Add two short horizontal lines and
   // a centered text label (using ASCII to avoid extra CJK glyph dependency).
-  const int ox = BOARD_ORIGIN_X;
+  const int ox = boardOriginX();
   const int oy = BOARD_ORIGIN_Y;
   const int yMid = oy + 4 * BOARD_PITCH + BOARD_PITCH / 2;
   const int width = BOARD_PITCH * (ChineseChessBoard::FILES - 1);

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
@@ -22,12 +22,11 @@ class ChineseChessGameActivity final : public Activity {
  private:
   enum class State : uint8_t { Playing, GameMenu, GameOver };
 
-  // Layout (Portrait 480×800).
+  // Portrait layout.
   static constexpr int CONTENT_X = 24;
   static constexpr int TITLE_BAR_H = 36;
   static constexpr int BOARD_AREA_Y = 60;
   static constexpr int BOARD_PITCH = 48;
-  static constexpr int BOARD_ORIGIN_X = (480 - BOARD_PITCH * (ChineseChessBoard::FILES - 1)) / 2;  // 40
   static constexpr int BOARD_ORIGIN_Y = BOARD_AREA_Y + 30;
   static constexpr int PIECE_RADIUS = 22;
   static constexpr int INFO_PANEL_Y = 602;
@@ -65,6 +64,7 @@ class ChineseChessGameActivity final : public Activity {
   ChineseChessBoard::Side resignWinner = ChineseChessBoard::Side::Red;
 
   // Geometry helpers
+  int boardOriginX() const;
   void cellXY(uint8_t r, uint8_t c, int* x, int* y) const;
 
   // Drawing

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -140,7 +140,9 @@ void GomokuGameActivity::loop() {
 // ---------- Geometry ----------
 
 int GomokuGameActivity::boardPitch() const { return (board.boardSize == 15) ? 30 : 50; }
-int GomokuGameActivity::boardOriginX() const { return (board.boardSize == 15) ? 30 : 40; }
+int GomokuGameActivity::boardOriginX() const {
+  return (renderer.getScreenWidth() - (board.boardSize - 1) * boardPitch()) / 2;
+}
 int GomokuGameActivity::boardOriginY() const { return BOARD_AREA_Y + boardPitch() / 2; }
 int GomokuGameActivity::stoneRadius() const { return (board.boardSize == 15) ? 12 : 20; }
 

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -386,7 +386,7 @@ void MinesweeperGameActivity::drawTitleBar() {
 
 void MinesweeperGameActivity::drawBoard() {
   const int size = cellSize();
-  const int x0 = BOARD_X;
+  const int x0 = (renderer.getScreenWidth() - BOARD_W) / 2;
   const int y0 = BOARD_Y;
 
   // Cells. The cursor frame is drawn separately below so cell content

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.h
@@ -40,12 +40,11 @@ class MinesweeperGameActivity final : public Activity {
   uint8_t menuSel = 0;
   static constexpr uint8_t MENU_ITEM_COUNT = 7;
 
-  // Layout (logical 480×800 portrait). Board occupies the same vertical slot
-  // as Sudoku's grid for visual consistency; cell pixel size varies by board
-  // dimensions so the total 432 px width is preserved.
+  // Portrait layout. Board occupies the same vertical slot as Sudoku's grid
+  // for visual consistency; cell pixel size varies by board dimensions so the
+  // total 432 px width is preserved.
   static constexpr int CONTENT_X = 24;
   static constexpr int TITLE_BAR_H = 36;
-  static constexpr int BOARD_X = 24;
   static constexpr int BOARD_Y = 60;   // matches Sudoku GRID_Y
   static constexpr int BOARD_W = 432;  // matches Sudoku GRID_SIZE_PX
   // End-game screen anchors. The Playing screen only uses the board area and

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -406,8 +406,9 @@ void SudokuGameActivity::renderGenerating() {
 
 void SudokuGameActivity::renderPlaying() {
   drawTitleBar();
-  drawGrid(GRID_X, GRID_Y);
-  drawPalette(PALETTE_X, PALETTE_Y);
+  const int screenWidth = renderer.getScreenWidth();
+  drawGrid((screenWidth - GRID_SIZE_PX) / 2, GRID_Y);
+  drawPalette((screenWidth - PALETTE_W) / 2, PALETTE_Y);
   drawFooter();
 }
 

--- a/src/activities/apps/sudoku/SudokuGameActivity.h
+++ b/src/activities/apps/sudoku/SudokuGameActivity.h
@@ -77,18 +77,16 @@ class SudokuGameActivity final : public Activity {
   uint8_t menuSel = 0;
   static constexpr uint8_t MENU_ITEM_COUNT = 7;
 
-  // Layout (logical 480×800 portrait). Single source of truth for the screen.
+  // Portrait layout. Single source of truth for fixed element sizes and vertical anchors.
   static constexpr int CONTENT_X = 24;
   static constexpr int TITLE_BAR_H = 36;
   static constexpr int CELL_PX = 48;
   static constexpr int GRID_SIZE_PX = CELL_PX * 9;  // 432
-  static constexpr int GRID_X = CONTENT_X;
   static constexpr int GRID_Y = TITLE_BAR_H + CONTENT_X;  // 60: gap below title bar matches left margin
   static constexpr int PALETTE_CELL_W = 80;
   static constexpr int PALETTE_CELL_H = PALETTE_CELL_W;  // square palette cells
   static constexpr int PALETTE_GAP = 8;
   static constexpr int PALETTE_W = PALETTE_CELL_W * 5 + PALETTE_GAP * 4;  // 432
   static constexpr int PALETTE_H = PALETTE_CELL_H * 2 + PALETTE_GAP;      // 168
-  static constexpr int PALETTE_X = CONTENT_X;
   static constexpr int PALETTE_Y = GRID_Y + GRID_SIZE_PX + CONTENT_X;  // 516: gap below grid matches left margin
 };

--- a/src/activities/apps/sudoku/SudokuGameActivity.h
+++ b/src/activities/apps/sudoku/SudokuGameActivity.h
@@ -81,12 +81,12 @@ class SudokuGameActivity final : public Activity {
   static constexpr int CONTENT_X = 24;
   static constexpr int TITLE_BAR_H = 36;
   static constexpr int CELL_PX = 48;
-  static constexpr int GRID_SIZE_PX = CELL_PX * 9;  // 432
+  static constexpr int GRID_SIZE_PX = CELL_PX * 9;        // 432
   static constexpr int GRID_Y = TITLE_BAR_H + CONTENT_X;  // 60: gap below title bar matches left margin
   static constexpr int PALETTE_CELL_W = 80;
   static constexpr int PALETTE_CELL_H = PALETTE_CELL_W;  // square palette cells
   static constexpr int PALETTE_GAP = 8;
   static constexpr int PALETTE_W = PALETTE_CELL_W * 5 + PALETTE_GAP * 4;  // 432
   static constexpr int PALETTE_H = PALETTE_CELL_H * 2 + PALETTE_GAP;      // 168
-  static constexpr int PALETTE_Y = GRID_Y + GRID_SIZE_PX + CONTENT_X;  // 516: gap below grid matches left margin
+  static constexpr int PALETTE_Y = GRID_Y + GRID_SIZE_PX + CONTENT_X;     // 516: gap below grid matches left margin
 };


### PR DESCRIPTION
## Summary

- Center Sudoku, Minesweeper, Gomoku, and Chinese Chess boards using the renderer's actual screen width.
- Keep existing board dimensions, vertical positions, and X4 appearance unchanged.
- Move related elements through their existing shared coordinate paths, including Sudoku's number palette and game pieces, cursors, and board decorations.

## Root cause

The affected layouts used horizontal coordinates derived from the X4 portrait width of 480 px. X3 portrait mode is 528 px wide, leaving these boards offset to the left.

## Impact

X3 now gets equal horizontal margins without device-specific branches, resizing, new allocations, or new dependencies. X4 retains the existing origins.

## Validation

- `pio run`
- `pio run -e gh_release_cn`
- `git diff --check`

X3 visual acceptance still requires real hardware because the simulator cannot emulate X3.
