### PR TITLE
feat: add standby shortcut toggle

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -290,6 +290,8 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   uint8_t longPressMenuFunction = LP_MENU_DISABLED;
   // UI Theme
   uint8_t uiTheme = LYRA;
+  // Show and enable the Standby shortcut on the home screen.
+  uint8_t standbyShortcutEnabled = 1;
   // Sunlight fading compensation
   uint8_t fadingFix = 0;
   // Power button return from footnotes (1 = enabled, 0 = disabled)

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -220,6 +220,8 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
         SettingInfo::Enum(StrId::STR_QUICK_RESUME_TIMEOUT, &CrossPointSettings::quickResumeSleepScreen,
                           {StrId::STR_STATE_OFF, StrId::STR_STATE_ON}, "quickResumeSleepScreen",
                           StrId::STR_CAT_DISPLAY),
+        SettingInfo::Toggle(StrId::STR_STANDBY_TITLE, &CrossPointSettings::standbyShortcutEnabled,
+                            "standbyShortcutEnabled", StrId::STR_CAT_DISPLAY),
         SettingInfo::Enum(StrId::STR_HIDE_BATTERY, &CrossPointSettings::hideBatteryPercentage,
                           {StrId::STR_NEVER, StrId::STR_IN_READER, StrId::STR_ALWAYS}, "hideBatteryPercentage",
                           StrId::STR_CAT_DISPLAY),

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -412,6 +412,10 @@ void HomeActivity::loop() {
     activateSelection();
   }
 
+  if (!SETTINGS.standbyShortcutEnabled) {
+    sawBackPressInActivity = false;
+    return;
+  }
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
     sawBackPressInActivity = true;
   }
@@ -473,7 +477,8 @@ void HomeActivity::render(RenderLock&&) {
   const bool isCarousel =
       static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
   if (!isCarousel) {
-    const auto labels = mappedInput.mapLabels(tr(STR_STANDBY_TITLE), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+    const auto labels = mappedInput.mapLabels(SETTINGS.standbyShortcutEnabled ? tr(STR_STANDBY_TITLE) : "",
+                                              tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   }
 


### PR DESCRIPTION
## Summary

- add a default-enabled “Standby display” toggle to Display settings
- hide and disable the Home Back-button standby shortcut when the toggle is off
- keep the Standby entry in the Apps menu unchanged

## Impact

The new `standbyShortcutEnabled` setting is persisted through the existing settings JSON and Web settings API. Existing installations keep the current behavior because the setting defaults to enabled. No translation keys, dependencies, or dynamic allocations are added.

## Validation

- `pio run`
- `pio run -e gh_release_cn`
- `pio check`
- `clang-format --dry-run --Werror src/CrossPointSettings.h src/SettingsList.h src/activities/home/HomeActivity.cpp`
- `git diff --check`

Hardware validation is still recommended for theme variants, remapped Back input, and persistence across reboot.
