### PR TITLE
feat: support X3 AirPage JPEG delivery

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <GfxRenderer.h>
+#include <HalGPIO.h>
 #include <I18n.h>
 #include <Logging.h>
 #include <Memory.h>
@@ -101,14 +102,21 @@ void AirPageActivity::onEnter() {
   uploadUrl_ += kAirPageBase;
   uploadUrl_ += "/?id=";
   uploadUrl_ += deviceId;
-  uploadUrl_ += "&type=x4";
+  uploadUrl_ += gpio.deviceIsX3() ? "&type=xteink-x3" : "&type=xteink-x4";
 
   downloadUrl_.reserve(64 + deviceId.size());
   downloadUrl_ = "https://";
   downloadUrl_ += kAirPageBase;
   downloadUrl_ += "/api/device/";
   downloadUrl_ += deviceId;
-  downloadUrl_ += "/latest.bmp";
+  downloadUrl_ += "/latest";
+
+  legacyDownloadUrl_.reserve(64 + deviceId.size());
+  legacyDownloadUrl_ = "https://";
+  legacyDownloadUrl_ += kAirPageBase;
+  legacyDownloadUrl_ += "/api/device/";
+  legacyDownloadUrl_ += deviceId;
+  legacyDownloadUrl_ += "/latest.bmp";
 
   applyConnectionEvent(connection_.begin(airpage::loadRealtimeMode()));
   LOG_DBG("AIRP", "onEnter free=%u largest=%u id=%s cached=%d realtime=%d", static_cast<unsigned>(ESP.getFreeHeap()),
@@ -509,8 +517,11 @@ void AirPageActivity::doFetch() {
     return;
   }
 
-  const HttpDownloader::DownloadError error =
+  HttpDownloader::DownloadError error =
       HttpDownloader::downloadToFile(downloadUrl_, airpage::AirPageImageStore::kDownloadPartPath);
+  if (error != HttpDownloader::OK) {
+    error = HttpDownloader::downloadToFile(legacyDownloadUrl_, airpage::AirPageImageStore::kDownloadPartPath);
+  }
   if (error != HttpDownloader::OK) {
     LOG_ERR("AIRP", "Download failed: %d", static_cast<int>(error));
     notice_ = Notice::DownloadFailed;

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -91,4 +91,5 @@ class AirPageActivity final : public Activity {
   // once per activity lifetime and reused.
   std::string uploadUrl_;
   std::string downloadUrl_;
+  std::string legacyDownloadUrl_;
 };

--- a/src/activities/apps/airpage/AirPageConnection.cpp
+++ b/src/activities/apps/airpage/AirPageConnection.cpp
@@ -1,6 +1,7 @@
 #include "AirPageConnection.h"
 
 #include <Arduino.h>
+#include <HalGPIO.h>
 #include <Logging.h>
 #include <esp_wifi.h>
 
@@ -151,7 +152,7 @@ AirPageConnection::Event AirPageConnection::pause(const Event event) {
 
 bool AirPageConnection::connectBroker() {
   char clientId[24];
-  snprintf(clientId, sizeof(clientId), "x4-%s", deviceId().c_str());
+  snprintf(clientId, sizeof(clientId), "%s-%s", gpio.deviceIsX3() ? "x3" : "x4", deviceId().c_str());
   if (!mqtt_.connect(clientId)) {
     LOG_ERR("AIRP", "MQTT connect failed (state=%d)", mqtt_.state());
     return false;


### PR DESCRIPTION
## Summary
- emit canonical xteink-x3/xteink-x4 AirPage QR parameters
- request /latest first and fall back to /latest.bmp for older backends
- identify MQTT clients with the actual X3/X4 model prefix

## Testing
- pio run -e default