### PR TITLE
fix: update AirPage sleep screen flow

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -31,6 +31,7 @@ constexpr char kAirPageBase[] =
 #else
     "airpage.crossmux.com";
 #endif
+constexpr uint32_t kWallpaperNoticeDurationMs = 1000u;
 
 uint64_t currentArchiveDateKey() {
   const uint32_t timestamp = TimeUtils::getCurrentValidTimestamp();
@@ -341,16 +342,6 @@ void AirPageActivity::loop() {
     requestUpdate();
     return;
   }
-  if (phase_ == Phase::WallpaperRequested) {
-    phase_ = Phase::WallpaperWriting;
-    wallpaperResult_ =
-        airpage::AirPageWallpaper::install(selectedImage_) ? WallpaperResult::Saved : WallpaperResult::Failed;
-    phase_ = Phase::Idle;
-    imageNeedsDisplay_ = true;
-    requestUpdate();
-    return;
-  }
-
   applyConnectionEvent(connection_.pump(phase_ == Phase::Idle && screen_ != Screen::Settings));
 }
 
@@ -442,9 +433,16 @@ void AirPageActivity::handleWallpaperResult(const ActivityResult& result) {
     return;
   }
 
+  phase_ = Phase::WallpaperWriting;
+  wallpaperResult_ =
+      airpage::AirPageWallpaper::install(selectedImage_) ? WallpaperResult::Saved : WallpaperResult::Failed;
+  phase_ = Phase::WallpaperNotice;
+  requestUpdateAndWait();
+  delay(kWallpaperNoticeDurationMs);
+
   wallpaperResult_ = WallpaperResult::None;
-  phase_ = Phase::WallpaperRequested;
-  requestUpdate();
+  phase_ = Phase::Idle;
+  requestUpdateAndWait();
 }
 
 void AirPageActivity::handleRefresh() {
@@ -565,6 +563,16 @@ Rect AirPageActivity::contentViewport() const {
 
 void AirPageActivity::render(RenderLock&&) {
   const Rect fullScreen{0, 0, renderer.getScreenWidth(), renderer.getScreenHeight()};
+
+  if (phase_ == Phase::WallpaperNotice) {
+    renderer.setRenderMode(GfxRenderer::BW);
+    renderer.clearScreen();
+    const char* message =
+        wallpaperResult_ == WallpaperResult::Saved ? tr(STR_AIRPAGE_WALLPAPER_SAVED) : tr(STR_AIRPAGE_WALLPAPER_FAILED);
+    GUI.drawPopup(renderer, message);
+    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+    return;
+  }
 
   if (screen_ == Screen::Image && phase_ == Phase::Idle) {
     const bool screenSizeChanged =

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -23,7 +23,7 @@ class AirPageActivity final : public Activity {
 
  private:
   enum class Screen : uint8_t { Qr, Settings, History, Image };
-  enum class Phase : uint8_t { Idle, FetchRequested, Fetching, WallpaperRequested, WallpaperWriting };
+  enum class Phase : uint8_t { Idle, FetchRequested, Fetching, WallpaperWriting, WallpaperNotice };
   enum class Notice : uint8_t {
     None,
     NoImage,


### PR DESCRIPTION
## Summary

- Install the displayed AirPage image directly as the sleep screen without queuing another fetch.
- Keep real MQTT pushes active on the image screen.
- Show the existing sleep-screen update result for one second before restoring the current image.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this existing AirPage workflow correctly; this PR fixes that behavior without expanding its scope.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Additional Context

- Validation: formatting, cppcheck, default and Sticky firmware builds, and all 225 host tests pass.
- No new heap allocation, public API, download path, or translation string.

---

### AI Usage

Did you use AI tools to help write this code? **YES**