### PR TITLE
fix: avoid repeated nightly OTA updates

### DIFF
--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -11,9 +11,35 @@
 #include <esp_wifi.h>
 // clang-format on
 
+#include <algorithm>
 #include <string>
+#include <string_view>
 
 namespace {
+constexpr std::string_view nightlyTagPrefix = "nightly-";
+constexpr size_t nightlyShaLength = 7;
+
+constexpr bool isSameNightlyBuild(const std::string_view currentVersion, const std::string_view latestTag) {
+  if (!latestTag.starts_with(nightlyTagPrefix) || latestTag.size() != nightlyTagPrefix.size() + nightlyShaLength) {
+    return false;
+  }
+
+  const std::string_view latestSha = latestTag.substr(nightlyTagPrefix.size());
+  const bool validSha = std::all_of(latestSha.begin(), latestSha.end(), [](const char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  });
+  if (!validSha) return false;
+
+  const size_t separator = currentVersion.rfind('+');
+  return separator != std::string_view::npos && currentVersion.substr(separator + 1) == latestSha;
+}
+
+static_assert(isSameNightlyBuild("1.5.2-rc+5064d90", "nightly-5064d90"));
+static_assert(isSameNightlyBuild("1.5.2-cn-rc+5064d90", "nightly-5064d90"));
+static_assert(!isSameNightlyBuild("1.5.2-rc+5064d90", "nightly-1234567"));
+static_assert(!isSameNightlyBuild("1.5.2", "nightly-5064d90"));
+static_assert(!isSameNightlyBuild("1.5.2-rc+5064d90", "nightly"));
+
 // OTA manifest endpoint. The global build uses crossmux.com; the Chinese build
 // (ENABLE_CHINESE_VERSION) uses crossmux.yunhug.com, the yunhug-hosted domain
 // with a more reliable mainland-China path. Either way the web proxy picks the
@@ -88,7 +114,12 @@ bool OtaUpdater::isUpdateNewer() const {
   if (!updateAvailable || latestVersion.empty()) {
     return false;
   }
-  if (channel == Channel::Nightly) return true;
+  switch (channel) {
+    case Channel::Stable:
+      break;
+    case Channel::Nightly:
+      return !isSameNightlyBuild(CROSSPOINT_VERSION, latestVersion);
+  }
   if (latestVersion == CROSSPOINT_VERSION) return false;
 
   int currentMajor, currentMinor, currentPatch;

--- a/test/release_json_parser/ReleaseJsonParserTest.cpp
+++ b/test/release_json_parser/ReleaseJsonParserTest.cpp
@@ -146,6 +146,19 @@ TEST(ReleaseJsonParser, RealisticMinified) {
   EXPECT_EQ(p.getFirmwareSize(), 1572864u);
 }
 
+TEST(ReleaseJsonParser, NightlyBuildTag) {
+  const char* json =
+      R"({"tag_name":"nightly-5064d90","assets":[{"name":"firmware.bin","size":5839088,"browser_download_url":"https://example.com/firmware.bin"}]})";
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  EXPECT_TRUE(p.foundTag());
+  EXPECT_TRUE(p.foundFirmware());
+  EXPECT_STREQ(p.getTagName(), "nightly-5064d90");
+  EXPECT_STREQ(p.getFirmwareUrl(), "https://example.com/firmware.bin");
+  EXPECT_EQ(p.getFirmwareSize(), 5839088u);
+}
+
 TEST(ReleaseJsonParser, PrettyAndMinifiedAgree) {
   ReleaseJsonParser pretty;
   pretty.feed(kRealisticPretty, strlen(kRealisticPretty));


### PR DESCRIPTION
## Summary
- compare the Nightly manifest SHA with the embedded firmware build SHA
- preserve Stable and legacy Nightly manifest behavior
- cover the new Nightly tag format in parser tests

## Testing
- pio run -e default -e sticky
- pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
- cmake -S test -B build/test -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build/test
- ctest --test-dir build/test --output-on-failure -j (226/226)
- ./bin/clang-format-fix
- pio run -e gh_release_rc -e gh_release_cn_rc