### PR TITLE
feat: improve WeRead shelf selection

### DIFF
--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -83,6 +83,44 @@ constexpr int kPortraitShelfColumns = 3;
 constexpr int kPortraitShelfRows = 3;
 constexpr int kLandscapeShelfColumns = 5;
 constexpr int kLandscapeShelfRows = 2;
+constexpr unsigned long kShelfPageHoldMs = 700;
+
+enum class ShelfVerticalDirection : uint8_t { Up, Down };
+
+constexpr int shelfVerticalIndex(const int currentIndex, const int totalItems, const int columns,
+                                 const int itemsPerPage, const ShelfVerticalDirection direction) {
+  if (currentIndex < 0 || currentIndex >= totalItems || columns <= 0 || itemsPerPage < columns) return 0;
+
+  const int pageStart = currentIndex / itemsPerPage * itemsPerPage;
+  const int pageEnd = std::min(pageStart + itemsPerPage, totalItems);
+  const int pageIndex = currentIndex - pageStart;
+  const int column = pageIndex % columns;
+
+  switch (direction) {
+    case ShelfVerticalDirection::Up:
+      if (pageIndex >= columns) return currentIndex - columns;
+      return pageStart > 0 ? pageStart - columns + column : currentIndex;
+    case ShelfVerticalDirection::Down: {
+      const int nextRowIndex = currentIndex + columns;
+      if (nextRowIndex < pageEnd) return nextRowIndex;
+      const int currentRowStart = pageStart + pageIndex / columns * columns;
+      const int lastRowStart = pageStart + (pageEnd - pageStart - 1) / columns * columns;
+      if (currentRowStart < lastRowStart) return pageEnd - 1;
+      if (pageEnd >= totalItems) return currentIndex;
+      return std::min(pageEnd + column, totalItems - 1);
+    }
+  }
+  return currentIndex;
+}
+
+static_assert(shelfVerticalIndex(1, 20, 3, 9, ShelfVerticalDirection::Down) == 4);
+static_assert(shelfVerticalIndex(7, 20, 3, 9, ShelfVerticalDirection::Down) == 10);
+static_assert(shelfVerticalIndex(8, 11, 3, 9, ShelfVerticalDirection::Down) == 10);
+static_assert(shelfVerticalIndex(10, 20, 3, 9, ShelfVerticalDirection::Up) == 7);
+static_assert(shelfVerticalIndex(1, 20, 3, 9, ShelfVerticalDirection::Up) == 1);
+static_assert(shelfVerticalIndex(10, 11, 3, 9, ShelfVerticalDirection::Down) == 10);
+static_assert(shelfVerticalIndex(10, 13, 3, 9, ShelfVerticalDirection::Down) == 12);
+static_assert(shelfVerticalIndex(7, 14, 5, 10, ShelfVerticalDirection::Down) == 12);
 
 struct ShelfGridLayout {
   int columns = 1;
@@ -1334,18 +1372,58 @@ void WeReadActivity::handleMenuInput() {
 
 void WeReadActivity::handleShelfInput() {
   const int count = static_cast<int>(std::min<uint32_t>(shelfCount_, INT32_MAX));
-  const int itemsPerPage = shelfItemsPerPage();
-  buttonNavigator_.onNext([this, count, itemsPerPage] {
-    const int previousPage = shelfSelected_ / itemsPerPage;
-    shelfSelected_ = ButtonNavigator::nextIndex(shelfSelected_, count);
-    if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
-    requestUpdate();
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const auto layout = shelfGridLayout(renderer, contentBounds(), metrics.contentSidePadding, metrics.verticalSpacing);
+  const int itemsPerPage = layout.itemsPerPage;
+  const int columns = layout.columns;
+
+  switch (shelfSideGesture_) {
+    case ShelfSideGesture::Idle:
+      if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
+        shelfSideGesture_ = ShelfSideGesture::UpPressed;
+      } else if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
+        shelfSideGesture_ = ShelfSideGesture::DownPressed;
+      } else {
+        break;
+      }
+      return;
+    case ShelfSideGesture::UpPressed:
+    case ShelfSideGesture::DownPressed: {
+      const bool movingUp = shelfSideGesture_ == ShelfSideGesture::UpPressed;
+      const auto button = movingUp ? MappedInputManager::Button::Up : MappedInputManager::Button::Down;
+      const auto direction = movingUp ? ShelfVerticalDirection::Up : ShelfVerticalDirection::Down;
+      if (mappedInput.wasReleased(button)) {
+        shelfSideGesture_ = ShelfSideGesture::Idle;
+        moveShelfSelection(shelfVerticalIndex(shelfSelected_, count, columns, itemsPerPage, direction), itemsPerPage);
+        return;
+      }
+      if (mappedInput.isPressed(button) && mappedInput.getHeldTime() >= kShelfPageHoldMs) {
+        shelfSideGesture_ = ShelfSideGesture::PageHandled;
+        if (count > itemsPerPage) {
+          const int target = movingUp ? ButtonNavigator::previousPageIndex(shelfSelected_, count, itemsPerPage)
+                                      : ButtonNavigator::nextPageIndex(shelfSelected_, count, itemsPerPage);
+          moveShelfSelection(target, itemsPerPage);
+        }
+      }
+      return;
+    }
+    case ShelfSideGesture::PageHandled:
+      if (!mappedInput.isPressed(MappedInputManager::Button::Up) &&
+          !mappedInput.isPressed(MappedInputManager::Button::Down)) {
+        shelfSideGesture_ = ShelfSideGesture::Idle;
+      }
+      return;
+  }
+
+  const bool swapFrontDirections = mappedInput.isNavDirectionSwapped();
+  const auto previousButton =
+      swapFrontDirections ? MappedInputManager::Button::Right : MappedInputManager::Button::Left;
+  const auto nextButton = swapFrontDirections ? MappedInputManager::Button::Left : MappedInputManager::Button::Right;
+  buttonNavigator_.onPressAndContinuous({previousButton}, [this, count, itemsPerPage] {
+    moveShelfSelection(ButtonNavigator::previousIndex(shelfSelected_, count), itemsPerPage);
   });
-  buttonNavigator_.onPrevious([this, count, itemsPerPage] {
-    const int previousPage = shelfSelected_ / itemsPerPage;
-    shelfSelected_ = ButtonNavigator::previousIndex(shelfSelected_, count);
-    if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
-    requestUpdate();
+  buttonNavigator_.onPressAndContinuous({nextButton}, [this, count, itemsPerPage] {
+    moveShelfSelection(ButtonNavigator::nextIndex(shelfSelected_, count), itemsPerPage);
   });
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     resetShelfCoverLoading();
@@ -1355,6 +1433,14 @@ void WeReadActivity::handleShelfInput() {
     state_.store(State::Menu);
     requestUpdate();
   }
+}
+
+void WeReadActivity::moveShelfSelection(const int index, const int itemsPerPage) {
+  if (index == shelfSelected_) return;
+  const int previousPage = shelfSelected_ / itemsPerPage;
+  shelfSelected_ = index;
+  if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
+  requestUpdate();
 }
 
 void WeReadActivity::handleErrorInput() {
@@ -2098,8 +2184,8 @@ void WeReadActivity::render(RenderLock&&) {
     case State::Shelf:
       back = tr(STR_BACK);
       confirm = tr(STR_OPEN);
-      previous = tr(STR_DIR_UP);
-      next = tr(STR_DIR_DOWN);
+      previous = tr(STR_DIR_LEFT);
+      next = tr(STR_DIR_RIGHT);
       break;
     case State::Detail:
     case State::DetailCoverLoading:

--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -1695,6 +1695,14 @@ void WeReadActivity::drawShelfGrid(const Rect& content) {
                        column * (layout.coverWidth + layout.columnGap);
     const int coverY = startY + row * (layout.itemHeight + layout.rowGap);
     const Rect cover{coverX, coverY, layout.coverWidth, layout.coverHeight};
+    const bool selected = index == shelfSelected_;
+    bool foregroundBlack = true;
+    if (selected) {
+      foregroundBlack =
+          GUI.drawSelectionBackground(renderer, Rect{cover.x - 2, cover.y - 2, cover.width + 4, layout.itemHeight + 4});
+      renderer.fillRect(cover.x, cover.y, cover.width, cover.height, false);
+    }
+
     const bool coverDrawn = drawCachedCover(renderer, WeReadStore::bookDirectory(book.bookId), cover);
     renderer.drawRect(cover.x, cover.y, cover.width, cover.height);
     if (!coverDrawn) {
@@ -1704,11 +1712,7 @@ void WeReadActivity::drawShelfGrid(const Rect& content) {
     const std::string title = renderer.truncatedText(SMALL_FONT_ID, book.title, layout.coverWidth);
     const int titleWidth = renderer.getTextAdvanceX(SMALL_FONT_ID, title.c_str(), EpdFontFamily::REGULAR);
     renderer.drawText(SMALL_FONT_ID, cover.x + std::max(0, (cover.width - titleWidth) / 2),
-                      cover.y + cover.height + layout.titleGap, title.c_str());
-    if (index == shelfSelected_) {
-      renderer.drawRect(cover.x - 2, cover.y - 2, cover.width + 4, layout.itemHeight + 4);
-      renderer.drawRect(cover.x - 1, cover.y - 1, cover.width + 2, layout.itemHeight + 2);
-    }
+                      cover.y + cover.height + layout.titleGap, title.c_str(), foregroundBlack);
   }
 
   GUI.drawSideScrollBar(renderer, content, count, pageStart, layout.itemsPerPage);

--- a/src/activities/apps/weread/WeReadActivity.h
+++ b/src/activities/apps/weread/WeReadActivity.h
@@ -46,6 +46,7 @@ class WeReadActivity final : public Activity {
   enum class Job : uint8_t { Sync, Detail, Download };
   enum class DetailAction : uint8_t { Introduction, Read, Browse, Cache, Images };
   enum class PostProcessNotice : uint8_t { None, Waiting, LongWait };
+  enum class ShelfSideGesture : uint8_t { Idle, UpPressed, DownPressed, PageHandled };
   static constexpr int kDetailActionCount = 5;
   static constexpr int kDetailListActionCount = kDetailActionCount - 1;
   static constexpr int kMaxIntroPages = 128;
@@ -70,6 +71,7 @@ class WeReadActivity final : public Activity {
   int shelfSelected_ = 0;
   int shelfCoverPageStart_ = -1;
   int shelfCoverCursor_ = 0;
+  ShelfSideGesture shelfSideGesture_ = ShelfSideGesture::Idle;
   int detailSelected_ = 0;
   int introPage_ = 0;
   int introPageCount_ = 1;
@@ -142,6 +144,7 @@ class WeReadActivity final : public Activity {
   void handleDisclaimerInput();
   void handleMenuInput();
   void handleShelfInput();
+  void moveShelfSelection(int index, int itemsPerPage);
   void handleErrorInput();
   void handleLogoutErrorInput();
   const char* errorMessage() const;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -972,6 +972,13 @@ void BaseTheme::drawTextField(const GfxRenderer& renderer, Rect rect, const int 
   }
 }
 
+bool BaseTheme::drawSelectionBackground(const GfxRenderer& renderer, const Rect rect) const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  renderer.fillRoundedRect(rect.x, rect.y, rect.width, rect.height, metrics.optionPopupSelectionRadius,
+                           metrics.optionPopupSelectionLight ? Color::LightGray : Color::Black);
+  return metrics.optionPopupSelectionLight;
+}
+
 void BaseTheme::drawOptionPopup(const GfxRenderer& renderer, const char* title, const std::vector<std::string>& options,
                                 int selectedIndex) const {
   const auto& metrics = UITheme::getInstance().getMetrics();
@@ -1036,34 +1043,23 @@ void BaseTheme::drawOptionPopup(const GfxRenderer& renderer, const char* title, 
 
   const int itemRectX = dialogX + innerPadding;
   const int itemRectW = dialogW - innerPadding * 2;
-  const int selectionRadius = metrics.optionPopupSelectionRadius;
 
   for (int i = 0; i < optionCount; i++) {
     const int itemY = y + i * (rowHeight + itemSpacing);
     const bool selected = (i == selectedIndex);
     const char* labelText = options[i].c_str();
 
-    if (metrics.optionPopupDrawAllRows || selected) {
-      Color rowColor;
-      if (selected) {
-        rowColor = metrics.optionPopupSelectionLight ? Color::LightGray : Color::Black;
-      } else {
-        rowColor = Color::White;
-      }
-      if (selectionRadius > 0) {
-        renderer.fillRoundedRect(itemRectX, itemY, itemRectW, rowHeight, selectionRadius, rowColor);
-      } else {
-        renderer.fillRect(itemRectX, itemY, itemRectW, rowHeight, rowColor == Color::Black);
-      }
+    bool foregroundBlack = true;
+    if (selected) {
+      foregroundBlack = drawSelectionBackground(renderer, Rect{itemRectX, itemY, itemRectW, rowHeight});
+    } else if (metrics.optionPopupDrawAllRows) {
+      renderer.fillRoundedRect(itemRectX, itemY, itemRectW, rowHeight, metrics.optionPopupSelectionRadius,
+                               Color::White);
     }
 
     const int textW = renderer.getTextWidth(optionFontId, labelText, optionStyle);
     const int textY = itemY + (rowHeight - optionLineHeight) / 2;
     const int textX = itemRectX + (itemRectW - textW) / 2;
-    // Unselected items: text is dark (invert=true means draw on white bg).
-    // Selected on dark bg: text must be white (invert=false).
-    // Selected on light bg: text stays dark (invert=true).
-    const bool invertText = selected ? metrics.optionPopupSelectionLight : true;
-    renderer.drawText(optionFontId, textX, textY, labelText, invertText, optionStyle);
+    renderer.drawText(optionFontId, textX, textY, labelText, foregroundBlack, optionStyle);
   }
 }

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -256,6 +256,8 @@ class BaseTheme {
                             const std::function<std::string(int index)>& buttonLabel,
                             const std::function<UIIcon(int index)>& rowIcon) const;
   virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
+  // Draws the active theme's selected-row background and returns whether foreground text should be black.
+  bool drawSelectionBackground(const GfxRenderer& renderer, Rect rect) const;
   virtual void drawOptionPopup(const GfxRenderer& renderer, const char* title, const std::vector<std::string>& options,
                                int selectedIndex) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Improve WeRead shelf selection visibility and make cover-grid navigation match the physical button layout.
* **What changes are included?**
  - Reuse the active theme's selection background for both option popups and the WeRead shelf, with automatic title contrast.
  - Use side Up/Down for vertical grid movement; holding either for 700 ms flips exactly one page, while front Left/Right retain item navigation and repeat behavior.
  - Consolidate the side-button gesture handling into a four-state release-barrier state machine and cover the grid-index edge cases with compile-time assertions.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This only refines the existing WeRead integration and shared theme renderer. It does not add an app, theme, connector,
setting, dependency, or generated artifact, and it does not touch the SDK, HAL, bootloader, OTA, or recovery code.

## Additional Context

* No new heap allocation is introduced.
* Chinese firmware memory: 118,751 bytes DRAM; PlatformIO reports 51,724 bytes RAM.
* Verification completed:
  - `./bin/ci-check` (format, cppcheck, default/sticky firmware, and all 250 host tests)
  - `pio run -e gh_release_cn`
  - `pio run -e simulator`
  - X4 simulator checks for portrait 3x3 and landscape 5x2 grids, short/long presses, cross-page same-column movement, partial final pages, release suppression, single-page shelves, Left/Right repeat behavior, and all five themes

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
