### PR TITLE
feat: refine Lyra Carousel cover presentation

### DIFF
--- a/docs/engineering/cache-management.md
+++ b/docs/engineering/cache-management.md
@@ -10,8 +10,15 @@
 **Location**: `.crosspoint/` directory on SD card root
 
 **Structure**:
-- EPUB: `.crosspoint/epub_<hash>/{book.bin, progress.bin, cover.bmp, sections/*.bin}`
+- EPUB: `.crosspoint/epub_<hash>/{book.bin, progress.bin, cover.bmp, thumb_<height>.bmp, sections/*.bin}`
+- XTC: `.crosspoint/xtc_<hash>/{cover.bmp, thumb_<height>.bmp}`
 - TXT: `.crosspoint/txt_<hash>/{index.bin, progress.bin}`
+
+`recent.json` stores the theme-neutral `thumb_[HEIGHT].bmp` path template for
+EPUB and XTC entries. Home themes replace `[HEIGHT]` with their requested
+thumbnail height. Lyra Carousel redirects only its in-memory `RecentBook` copy
+to `cover.bmp`, generating that full cover when missing; switching themes must
+not replace the persisted template.
 
 TXT `index.bin` version 6 stores a partial or complete lazy page index and the
 detected source encoding. It is invalidated by file-size, viewport, font,

--- a/docs/engineering/ui-and-input.md
+++ b/docs/engineering/ui-and-input.md
@@ -130,6 +130,15 @@ action**.
   count, page start, and page capacity so the active theme controls the bar
   dimensions and placement.
 
+### Lyra Carousel home
+
+Lyra Carousel displays one centered recent-book cover in a `380x540` frame.
+The complete image is scaled proportionally to fit and centered with white
+letterboxing when its aspect ratio differs; it is never cropped or stretched.
+The frame is drawn only while the cover row has focus. Its Apps menu icon uses
+a theme-local `28x28` four-cell drawing inside the standard `32x32` icon slot;
+shared icon assets and other themes remain unchanged.
+
 > User-facing text must use the `tr()` macro — see
 > [hardware-constraints.md](hardware-constraints.md) → Resource Protocol rule 5,
 > and the i18n workflow in [generated-files.md](generated-files.md).

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -112,6 +112,8 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
   recentsLoading = true;
   bool showingLoading = false;
   Rect popupRect;
+  const bool useFullCover =
+      static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
 
   int progress = 0;
   for (RecentBook& book : recentBooks) {
@@ -119,18 +121,35 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     const bool isEpub = FsHelpers::hasEpubExtension(book.path);
     const bool isXtc = FsHelpers::hasXtcExtension(book.path);
 
-    // Recover entries whose thumbnail template was cleared by an earlier
-    // transient generation failure.
-    if (book.coverBmpPath.empty()) {
-      if (isEpub) {
-        book.coverBmpPath = Epub(book.path, "/.crosspoint").getThumbBmpPath();
-      } else if (isXtc) {
-        book.coverBmpPath = Xtc(book.path, "/.crosspoint").getThumbBmpPath();
-      } else {
-        continue;
+    // Keep the persisted path theme-neutral; Carousel redirects only this activity's copy.
+    if (isEpub) {
+      const Epub epub(book.path, "/.crosspoint");
+      if (useFullCover) {
+        const std::string thumbPath = epub.getThumbBmpPath();
+        if (book.coverBmpPath != thumbPath) {
+          RECENT_BOOKS.updateBook(book.path, book.title, book.author, thumbPath);
+        }
+        book.coverBmpPath = epub.getCoverBmpPath();
+      } else if (book.coverBmpPath.empty()) {
+        book.coverBmpPath = epub.getThumbBmpPath();
+        RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.coverBmpPath);
       }
-      RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.coverBmpPath);
+    } else if (isXtc) {
+      const Xtc xtc(book.path, "/.crosspoint");
+      if (useFullCover) {
+        const std::string thumbPath = xtc.getThumbBmpPath();
+        if (book.coverBmpPath != thumbPath) {
+          RECENT_BOOKS.updateBook(book.path, book.title, book.author, thumbPath);
+        }
+        book.coverBmpPath = xtc.getCoverBmpPath();
+      } else if (book.coverBmpPath.empty()) {
+        book.coverBmpPath = xtc.getThumbBmpPath();
+        RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.coverBmpPath);
+      }
+    } else {
+      continue;
     }
+    if (book.coverBmpPath.empty()) continue;
 
     const std::string coverPath = UITheme::getCoverThumbPath(book.coverBmpPath, coverHeight);
     if (Storage.exists(coverPath.c_str())) {
@@ -143,7 +162,7 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
         }
         if (cachedCover.fileSize() == 0) {
           // EPUB uses an empty thumbnail as a persistent "no supported cover" marker.
-          if (isEpub) continue;
+          if (isEpub && !useFullCover) continue;
           invalidCache = true;
         } else {
           Bitmap bitmap(cachedCover);
@@ -172,9 +191,12 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
         popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
       }
       GUI.fillPopupProgress(renderer, popupRect, 10 + currentProgress * (90 / recentBooks.size()));
-      // Keep the template on failure so transient OOM/SD errors can retry.
-      // Epub writes an empty marker when the book has no supported cover.
-      epub.generateThumbBmp(coverHeight);
+      if (useFullCover) {
+        epub.generateCoverBmp();
+      } else {
+        // Epub writes an empty thumbnail as a persistent "no supported cover" marker.
+        epub.generateThumbBmp(coverHeight);
+      }
     } else if (isXtc) {
       Xtc xtc(book.path, "/.crosspoint");
       if (!xtc.load()) {
@@ -187,8 +209,9 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
         popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
       }
       GUI.fillPopupProgress(renderer, popupRect, 10 + currentProgress * (90 / recentBooks.size()));
-      if (!xtc.generateThumbBmp(coverHeight)) {
-        LOG_ERR("HOME", "Failed to generate XTC thumbnail: %s", book.path.c_str());
+      const bool generated = useFullCover ? xtc.generateCoverBmp() : xtc.generateThumbBmp(coverHeight);
+      if (!generated) {
+        LOG_ERR("HOME", "Failed to generate XTC cover: %s", book.path.c_str());
       }
     }
   }

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -25,6 +25,20 @@ constexpr int kMenuIconSize = 32;
 constexpr int kMenuIconPadding = 14;
 constexpr int kMenuHighlightPadding = 7;
 
+void drawAppsMenuIcon(const GfxRenderer& renderer, int x, int y, bool selected) {
+  constexpr int kInset = 2;
+  constexpr int kCellSize = 13;
+  constexpr int kCellGap = 2;
+  static_assert(kInset * 2 + kCellSize * 2 + kCellGap == kMenuIconSize);
+
+  for (int row = 0; row < 2; ++row) {
+    for (int column = 0; column < 2; ++column) {
+      renderer.drawRoundedRect(x + kInset + column * (kCellSize + kCellGap), y + kInset + row * (kCellSize + kCellGap),
+                               kCellSize, kCellSize, 2, 2, !selected);
+    }
+  }
+}
+
 void drawCover(const GfxRenderer& renderer, const RecentBook& book, int x, int y, int width, int height) {
   if (!book.coverBmpPath.empty()) {
     const std::string coverPath =
@@ -144,7 +158,13 @@ void LyraCarouselTheme::drawHomeMenu(GfxRenderer& renderer, Rect rect, int butto
     }
 
     if (rowIcon == nullptr) continue;
-    const uint8_t* icon = iconForName(rowIcon(i), kMenuIconSize);
+    const UIIcon iconName = rowIcon(i);
+    if (iconName == UIIcon::Apps) {
+      drawAppsMenuIcon(renderer, iconX, iconY, selected);
+      continue;
+    }
+
+    const uint8_t* icon = iconForName(iconName, kMenuIconSize);
     if (icon == nullptr) continue;
     if (selected) {
       renderer.drawIconInverted(icon, iconX, iconY, kMenuIconSize);

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -14,37 +14,34 @@
 #include "fontIds.h"
 
 namespace {
-constexpr int kCenterCoverWidth = 340;
+constexpr int kCenterCoverWidth = 380;
 constexpr int kCenterCoverHeight = 540;
-constexpr int kSideCoverWidth = 200;
-constexpr int kSideCoverHeight = 390;
-constexpr int kSideOverlap = 60;
 constexpr int kCoverTopPadding = 32;
 constexpr int kCornerRadius = 6;
-constexpr int kCenterOutlineWidth = 4;
 constexpr int kActiveOutlineWidth = 3;
-constexpr int kInactiveOutlineWidth = 1;
 constexpr int kDotSize = 8;
 constexpr int kDotGap = 6;
 constexpr int kMenuIconSize = 32;
 constexpr int kMenuIconPadding = 14;
 constexpr int kMenuHighlightPadding = 7;
 
-bool drawCover(const GfxRenderer& renderer, const RecentBook& book, int x, int y, int width, int height) {
+void drawCover(const GfxRenderer& renderer, const RecentBook& book, int x, int y, int width, int height) {
   if (!book.coverBmpPath.empty()) {
-    const std::string thumbPath =
+    const std::string coverPath =
         UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselMetrics::values.homeCoverHeight);
     HalFile file;
-    if (Storage.openFileForRead("HOME", thumbPath, file)) {
+    if (Storage.openFileForRead("HOME", coverPath, file)) {
       Bitmap bitmap(file);
       if (bitmap.parseHeaders() == BmpReaderError::Ok && bitmap.getWidth() > 0 && bitmap.getHeight() > 0) {
-        const float sourceRatio = static_cast<float>(bitmap.getWidth()) / static_cast<float>(bitmap.getHeight());
-        const float targetRatio = static_cast<float>(width) / static_cast<float>(height);
-        const float cropX = sourceRatio > targetRatio ? 1.0f - targetRatio / sourceRatio : 0.0f;
-        const float cropY = sourceRatio < targetRatio ? 1.0f - sourceRatio / targetRatio : 0.0f;
-        renderer.drawBitmap(bitmap, x, y, width, height, cropX, cropY);
-        renderer.maskRoundedRectOutsideCorners(x, y, width, height, kCornerRadius, Color::White);
-        return true;
+        const float scale = std::min(
+            {1.0f, static_cast<float>(width) / bitmap.getWidth(), static_cast<float>(height) / bitmap.getHeight()});
+        const int drawWidth = std::max(1, static_cast<int>(bitmap.getWidth() * scale));
+        const int drawHeight = std::max(1, static_cast<int>(bitmap.getHeight() * scale));
+        const int drawX = x + (width - drawWidth) / 2;
+        const int drawY = y + (height - drawHeight) / 2;
+        renderer.drawBitmap(bitmap, drawX, drawY, drawWidth, drawHeight);
+        renderer.maskRoundedRectOutsideCorners(drawX, drawY, drawWidth, drawHeight, kCornerRadius, Color::White);
+        return;
       }
     }
   }
@@ -53,7 +50,6 @@ bool drawCover(const GfxRenderer& renderer, const RecentBook& book, int x, int y
   renderer.fillRoundedRect(x, y + height / 3, width, 2 * height / 3, kCornerRadius, false, false, true, true,
                            Color::Black);
   renderer.drawIcon(CoverIcon, x + (width - kMenuIconSize) / 2, y + height / 6 - kMenuIconSize / 2, kMenuIconSize);
-  return false;
 }
 }  // namespace
 
@@ -82,24 +78,10 @@ void LyraCarouselTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect,
 
   const int centerX = (renderer.getScreenWidth() - kCenterCoverWidth) / 2;
   const int centerY = rect.y + kCoverTopPadding;
-  const int sideY = centerY + (kCenterCoverHeight - kSideCoverHeight) / 2;
-  const int leftX = centerX - kSideCoverWidth + kSideOverlap;
-  const int rightX = centerX + kCenterCoverWidth - kSideOverlap;
 
   if (!coverRendered) {
     renderer.fillRect(rect.x, rect.y, rect.width, rect.height, false);
 
-    const int previousIndex = (centerIndex + bookCount - 1) % bookCount;
-    const int nextIndex = (centerIndex + 1) % bookCount;
-    if (bookCount >= 3) {
-      drawCover(renderer, recentBooks[previousIndex], leftX, sideY, kSideCoverWidth, kSideCoverHeight);
-    }
-    if (bookCount >= 2) {
-      drawCover(renderer, recentBooks[nextIndex], rightX, sideY, kSideCoverWidth, kSideCoverHeight);
-    }
-
-    renderer.fillRect(centerX - kCenterOutlineWidth, centerY - kCenterOutlineWidth,
-                      kCenterCoverWidth + kCenterOutlineWidth * 2, kCenterCoverHeight + kCenterOutlineWidth * 2, false);
     drawCover(renderer, recentBooks[centerIndex], centerX, centerY, kCenterCoverWidth, kCenterCoverHeight);
 
     const int dotsY = centerY + kCenterCoverHeight + 8;
@@ -133,8 +115,10 @@ void LyraCarouselTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect,
     coverRendered = coverBufferStored;
   }
 
-  renderer.drawRoundedRect(centerX, centerY, kCenterCoverWidth, kCenterCoverHeight,
-                           coversFocused ? kActiveOutlineWidth : kInactiveOutlineWidth, kCornerRadius, true);
+  if (coversFocused) {
+    renderer.drawRoundedRect(centerX, centerY, kCenterCoverWidth, kCenterCoverHeight, kActiveOutlineWidth,
+                             kCornerRadius, true);
+  }
 }
 
 void LyraCarouselTheme::drawHomeMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,


### PR DESCRIPTION
## Summary

- show one centered 380x540 Lyra Carousel cover with aspect-fit scaling
- keep full-cover selection local instead of persisting theme-specific paths
- balance the Carousel Apps icon and document cover/cache behavior

## Validation

- pio run
- pio run -e simulator -e simulator_x3
- ./bin/clang-format-fix -g --check
- git diff --check