### PR TITLE
ci: route trusted builds to H2O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ permissions:
 
 jobs:
   clang-format:
-    # Public PRs stay isolated on GitHub-hosted runners; only trusted main runs use H2O.
-    runs-on: ${{ github.ref == 'refs/heads/main' && 'h2o' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -23,7 +22,6 @@ jobs:
           python-version: '3.14'
 
       - name: Install clang-format-21
-        if: github.ref != 'refs/heads/main'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -37,7 +35,7 @@ jobs:
           git diff --exit-code || (echo "Please run 'bin/clang-format-fix' to fix formatting issues" && exit 1)
 
   cppcheck:
-    runs-on: ${{ github.ref == 'refs/heads/main' && 'h2o' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -67,7 +65,8 @@ jobs:
         run: pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
 
   build:
-    runs-on: ${{ github.ref == 'refs/heads/main' && 'h2o' || 'ubuntu-latest' }}
+    # Only trusted same-repository PRs and main builds may use the persistent H2O runner.
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && 'h2o' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -78,6 +77,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install simulator build tools
+        if: runner.environment == 'github-hosted'
         run: |
           sudo apt-get update
           sudo apt-get install -y libsdl2-dev libssl-dev
@@ -129,14 +129,13 @@ jobs:
           if-no-files-found: error
 
   unit-tests:
-    runs-on: ${{ github.ref == 'refs/heads/main' && 'h2o' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Install build tools
-        if: github.ref != 'refs/heads/main'
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build libcurl4-openssl-dev libssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio


### PR DESCRIPTION
## Summary

- run only the resource-heavy build job on H2O for main and same-repository pull requests
- keep fork pull requests and non-main manual runs on GitHub-hosted runners
- keep formatting, static analysis, unit tests, and the required status job GitHub-hosted
- install simulator packages only when the build uses a GitHub-hosted runner

## H2O preparation

- installed `libsdl2-dev`
- configured runner-owned ccache and temporary directories through the systemd service
- retained the unprivileged `github-runner` account without sudo or Docker membership

## Validation

- workflow YAML parses successfully and the diff passes `git diff --check`
- H2O service is enabled, active, online, idle, and labeled `h2o`
- PR run 30750340443 assigned only `build` to H2O; all other jobs used GitHub-hosted runners
- H2O completed all four build environments and uploaded `firmware.bin` in 6m17s
- formatting, static analysis, unit tests, and the required Test Status check all passed
