### PR TITLE
ci: build nightly and releases on H2O

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,17 +9,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  models: read
+  contents: read
 
 jobs:
   build-nightly:
-    runs-on: ubuntu-latest
+    runs-on: h2o
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -47,6 +45,34 @@ jobs:
           mkdir -p dist
           cp .pio/build/gh_release_rc/firmware.bin     dist/firmware.bin
           cp .pio/build/gh_release_cn_rc/firmware.bin  dist/firmware-cn.bin
+
+      - name: Upload nightly build
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-build
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-nightly:
+    needs: build-nightly
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      models: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download nightly build
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-build
+          path: dist
+
+      - name: Extract short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Generate OTA summary
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,15 @@ on:
       - '*'
 
 permissions:
-  contents: write
-  models: read
+  contents: read
 
 jobs:
   build-release:
-    runs-on: ubuntu-latest
+    runs-on: h2o
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -30,13 +28,6 @@ jobs:
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
-      - name: Cache PlatformIO packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.platformio
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-${{ runner.os }}-
-
       - name: Build CrossMux (international + Chinese)
         run: pio run -e gh_release -e gh_release_cn
 
@@ -47,6 +38,39 @@ jobs:
           cp .pio/build/gh_release/bootloader.bin   dist/bootloader.bin
           cp .pio/build/gh_release/partitions.bin   dist/partitions.bin
           cp .pio/build/gh_release_cn/firmware.bin  dist/firmware-cn.bin
+
+      - name: Upload release build
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build
+          path: |
+            dist/*
+            .pio/build/gh_release/bootloader.bin
+            .pio/build/gh_release/firmware.bin
+            .pio/build/gh_release/firmware.elf
+            .pio/build/gh_release/firmware.map
+            .pio/build/gh_release/partitions.bin
+            .pio/build/gh_release_cn/firmware.bin
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+
+  publish-release:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      models: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download release build
+        uses: actions/download-artifact@v4
+        with:
+          name: release-build
+          path: .
 
       - name: Generate OTA summary
         continue-on-error: true


### PR DESCRIPTION
## Summary

- run Nightly and tagged Release compilation on the H2O self-hosted runner
- keep GitHub/Gitee publishing on GitHub-hosted runners
- pass firmware outputs between jobs with one-day workflow artifacts
- scope write and Models permissions to publishing jobs only

## Security

- H2O receives only the read-only workflow token
- `GITEE_TOKEN` and `contents: write` remain in GitHub-hosted jobs
- release candidate and font publishing workflows are unchanged

## Validation

- `actionlint` passes for both modified workflows
- YAML parsing and `git diff --check` pass
- release handoff includes every path consumed by the existing final artifact upload
- H2O is online, idle, service-enabled, and still runs without sudo or Docker group membership
- PR CI passed: H2O build completed in 6m19s and all GitHub-hosted checks succeeded

## Post-merge verification

- manually dispatch Nightly from `main` and verify H2O build plus GitHub-hosted publish
- validate the tagged Release path with the next real release tag; no synthetic release is created by this PR
