### PR TITLE
fix: avoid web settings heap exhaustion

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -176,7 +176,8 @@ uint8_t CrossPointSettings::sleepTimeoutEnumToMinutes(const uint8_t legacyValue)
 void CrossPointSettings::toJson(JsonDocument& doc) const {
   const CrossPointSettings& s = *this;
 
-  for (const auto& info : getSettingsList()) {
+  for (const auto& info : getBaseSettingsList()) {
+    if (!isSettingAvailableOnBoard(info)) continue;
     if (!info.key) continue;
     // Dynamic entries (KOReader etc.) are stored in their own files — skip.
     if (!info.valuePtr && !info.stringOffset) continue;
@@ -238,7 +239,8 @@ bool CrossPointSettings::fromJson(JsonVariantConst doc) {
     needsResave = true;
   }
 
-  for (const auto& info : getSettingsList()) {
+  for (const auto& info : getBaseSettingsList()) {
+    if (!isSettingAvailableOnBoard(info)) continue;
     if (!info.key) continue;
     // Dynamic entries (KOReader etc.) are stored in their own files — skip.
     if (!info.valuePtr && !info.stringOffset) continue;

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -30,50 +30,32 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
   enumValues = {StrId::STR_NOTO_SERIF, StrId::STR_NOTO_SANS};
 #endif
   const int builtinOptionCount = static_cast<int>(enumValues.size());
-  // Runtime string labels for SD card fonts
-  std::vector<std::string> enumStringValues;
-
-  if (registry) {
-    const auto& families = registry->getFamilies();
-    enumStringValues.reserve(families.size());
-    std::transform(families.begin(), families.end(), std::back_inserter(enumStringValues),
-                   [](const SdCardFontFamilyInfo& f) { return f.name; });
-  }
-
-  // Capture the SD font count for the lambdas
-  const int sdFontCount = static_cast<int>(enumStringValues.size());
-
-  // The render code checks enumStringValues first, so any list containing SD
-  // fonts needs string labels for all visible options.
-  std::vector<std::string> allStringValues;
-  if (sdFontCount > 0) {
-    for (const StrId value : enumValues) allStringValues.push_back(I18N.get(value));
-    allStringValues.insert(allStringValues.end(), enumStringValues.begin(), enumStringValues.end());
-  }
 
   SettingInfo s;
   s.nameId = StrId::STR_FONT_FAMILY;
   s.type = SettingType::ENUM;
-  s.enumValues = std::move(enumValues);
-  s.enumStringValues = std::move(allStringValues);
   s.key = "fontFamily";
   s.category = StrId::STR_CAT_READER;
   s.inTextSettings = true;  // matches the static font-family entry it replaces
 
-  // Capture registry families by copy for the lambdas
-  std::vector<std::string> sdFamilyNames;
-  if (registry) {
+  if (registry && registry->getFamilyCount() > 0) {
     const auto& families = registry->getFamilies();
-    sdFamilyNames.reserve(families.size());
-    std::transform(families.begin(), families.end(), std::back_inserter(sdFamilyNames),
+    s.enumStringValues.reserve(builtinOptionCount + families.size());
+    for (const StrId value : enumValues) s.enumStringValues.push_back(I18N.get(value));
+    std::transform(families.begin(), families.end(), std::back_inserter(s.enumStringValues),
                    [](const SdCardFontFamilyInfo& f) { return f.name; });
+  } else {
+    s.enumValues = std::move(enumValues);
   }
 
-  s.valueGetter = [sdFamilyNames, builtinOptionCount]() -> uint8_t {
+  // The global SdCardFontSystem owns the registry for the lifetime of every
+  // settings consumer, so referencing it avoids duplicating every family name.
+  s.valueGetter = [registry, builtinOptionCount]() -> uint8_t {
     // If an SD card font is selected, find its index
-    if (SETTINGS.sdFontFamilyName[0] != '\0') {
-      for (int i = 0; i < static_cast<int>(sdFamilyNames.size()); i++) {
-        if (sdFamilyNames[i] == SETTINGS.sdFontFamilyName) {
+    if (registry && SETTINGS.sdFontFamilyName[0] != '\0') {
+      const auto& families = registry->getFamilies();
+      for (int i = 0; i < static_cast<int>(families.size()); i++) {
+        if (families[i].name == SETTINGS.sdFontFamilyName) {
           return static_cast<uint8_t>(builtinOptionCount + i);
         }
       }
@@ -86,7 +68,7 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
 #endif
   };
 
-  s.valueSetter = [sdFamilyNames, builtinOptionCount](uint8_t v) {
+  s.valueSetter = [registry, builtinOptionCount](uint8_t v) {
     if (v < builtinOptionCount) {
 #ifdef ENABLE_CHINESE_VERSION
       SETTINGS.fontFamily = CrossPointSettings::NOTOSANS;
@@ -95,10 +77,11 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
 #endif
       SETTINGS.sdFontFamilyName[0] = '\0';
       SETTINGS.sdFontFlashPreload = 0;
-    } else {
+    } else if (registry) {
       int sdIdx = v - builtinOptionCount;
-      if (sdIdx < static_cast<int>(sdFamilyNames.size())) {
-        strncpy(SETTINGS.sdFontFamilyName, sdFamilyNames[sdIdx].c_str(), sizeof(SETTINGS.sdFontFamilyName) - 1);
+      const auto& families = registry->getFamilies();
+      if (sdIdx < static_cast<int>(families.size())) {
+        strncpy(SETTINGS.sdFontFamilyName, families[sdIdx].name.c_str(), sizeof(SETTINGS.sdFontFamilyName) - 1);
         SETTINGS.sdFontFamilyName[sizeof(SETTINGS.sdFontFamilyName) - 1] = '\0';
         SETTINGS.sdFontFlashPreload = 0;
       }
@@ -191,18 +174,10 @@ inline SettingInfo buildDictionarySetting(const std::vector<DictionaryEntry>& di
   return s;
 }
 
-// Shared settings list used by both the device settings UI and the web settings API.
+// Shared base settings list used by the device UI, persistence, and web API.
 // Each entry has a key (for JSON API) and category (for grouping).
 // ACTION-type entries and entries without a key are device-only.
-//
-// The static list is constructed exactly once (master's optimization, #1086 +
-// #1636) so the per-entry SettingInfo cost is paid once; every call then copies
-// it. When an SdCardFontRegistry is supplied AND has SD card fonts installed,
-// the font-family entry is replaced in that copy with a registry-aware version.
-// The font-size entry is always rebuilt, since its options are point sizes read
-// from the active family rather than a fixed enum.
-inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* registry = nullptr,
-                                                const std::vector<DictionaryEntry>* dictionaries = nullptr) {
+inline const std::vector<SettingInfo>& getBaseSettingsList() {
   static const std::vector<SettingInfo> baseList = [] {
     // Enum settings are persisted as numeric values. Assign these labels by enum
     // value so a reordered menu or enum cannot silently swap their behavior.
@@ -442,20 +417,42 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
     return v;
   }();
 
+  return baseList;
+}
+
+inline bool isSettingAvailableOnBoard(const SettingInfo& setting) {
+  if (!BoardConfig::hasTouch()) return setting.nameId != StrId::STR_TOUCH_READER_CONTROLS;
+  return setting.nameId != StrId::STR_FRONT_BTN_FOLLOW_ORIENTATION && setting.nameId != StrId::STR_SUNLIGHT_FADING_FIX;
+}
+
+// Visits the shared list without copying it. Dynamic font entries are built
+// only while their callback runs, keeping the web request's peak heap bounded.
+template <typename Callback>
+inline void forEachSettingsListEntry(const SdCardFontRegistry* registry, Callback&& callback) {
+  for (const auto& setting : getBaseSettingsList()) {
+    if (!isSettingAvailableOnBoard(setting)) continue;
+
+    if (setting.nameId == StrId::STR_FONT_FAMILY) {
+      const SettingInfo dynamicSetting = buildFontFamilySetting(registry);
+      callback(dynamicSetting);
+    } else if (setting.nameId == StrId::STR_FONT_SIZE) {
+      const SettingInfo dynamicSetting = buildFontSizeSetting(registry);
+      callback(dynamicSetting);
+    } else {
+      callback(setting);
+    }
+  }
+}
+
+// Device settings need an owned list because they retain category entries and
+// may insert a dynamically discovered dictionary entry.
+inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* registry = nullptr,
+                                                const std::vector<DictionaryEntry>* dictionaries = nullptr) {
+  const auto& baseList = getBaseSettingsList();
+
   std::vector<SettingInfo> v = baseList;
-  if (!BoardConfig::hasTouch()) {
-    v.erase(std::remove_if(v.begin(), v.end(),
-                           [](const SettingInfo& s) { return s.nameId == StrId::STR_TOUCH_READER_CONTROLS; }),
-            v.end());
-  }
-  if (BoardConfig::hasTouch()) {
-    v.erase(std::remove_if(v.begin(), v.end(),
-                           [](const SettingInfo& s) {
-                             return s.nameId == StrId::STR_FRONT_BTN_FOLLOW_ORIENTATION ||
-                                    s.nameId == StrId::STR_SUNLIGHT_FADING_FIX;
-                           }),
-            v.end());
-  }
+  v.erase(std::remove_if(v.begin(), v.end(), [](const SettingInfo& s) { return !isSettingAvailableOnBoard(s); }),
+          v.end());
   {
     auto it = std::find_if(v.begin(), v.end(), [](const SettingInfo& s) { return s.nameId == StrId::STR_FONT_FAMILY; });
     if (it != v.end()) {

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1164,11 +1164,6 @@ void CrossPointWebServer::handleSettingsPage() const {
 }
 
 void CrossPointWebServer::handleGetSettings() const {
-  // Pass the SD font registry so the fontFamily setting's enumStringValues
-  // includes SD-resident families — otherwise the web API only exposes the
-  // three built-in fonts.
-  const auto& settings = getSettingsList(&sdFontSystem.registry());
-
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
   server->sendContent("[");
@@ -1178,8 +1173,8 @@ void CrossPointWebServer::handleGetSettings() const {
   bool seenFirst = false;
   JsonDocument doc;
 
-  for (const auto& s : settings) {
-    if (!s.key) continue;  // Skip ACTION-only entries
+  forEachSettingsListEntry(&sdFontSystem.registry(), [this, &doc, &output, &seenFirst](const SettingInfo& s) {
+    if (!s.key) return;  // Skip ACTION-only entries
 
     doc.clear();
     doc["key"] = s.key;
@@ -1233,13 +1228,13 @@ void CrossPointWebServer::handleGetSettings() const {
         break;
       }
       default:
-        continue;
+        return;
     }
 
     const size_t written = serializeJson(doc, output, outputSize);
     if (written >= outputSize) {
       LOG_DBG("WEB", "Skipping oversized setting JSON for: %s", s.key);
-      continue;
+      return;
     }
 
     if (seenFirst) {
@@ -1248,7 +1243,7 @@ void CrossPointWebServer::handleGetSettings() const {
       seenFirst = true;
     }
     server->sendContent(output);
-  }
+  });
 
   server->sendContent("]");
   server->sendContent("");
@@ -1269,12 +1264,11 @@ void CrossPointWebServer::handlePostSettings() {
     return;
   }
 
-  const auto& settings = getSettingsList(&sdFontSystem.registry());
   int applied = 0;
 
-  for (const auto& s : settings) {
-    if (!s.key) continue;
-    if (!doc[s.key].is<JsonVariant>()) continue;
+  forEachSettingsListEntry(&sdFontSystem.registry(), [&doc, &applied](const SettingInfo& s) {
+    if (!s.key) return;
+    if (!doc[s.key].is<JsonVariant>()) return;
 
     switch (s.type) {
       case SettingType::TOGGLE: {
@@ -1324,7 +1318,7 @@ void CrossPointWebServer::handlePostSettings() {
       default:
         break;
     }
-  }
+  });
 
   SETTINGS.saveToFile();
 


### PR DESCRIPTION
## Summary

- Prevent ESP32-C3 restarts when opening the Web settings page with custom fonts installed.
- Replace full `SettingInfo` table copies in Web GET/POST and settings persistence with synchronous no-copy traversal.
- Keep one exactly reserved font display-name vector and capture the long-lived font registry pointer in accessors.
- Preserve the current Chinese firmware built-in font filtering, dynamic built-in option count, no-SD-font behavior, HTTP fields/order/validation, and persistence format.

## Root cause

`/api/settings` deep-copied the complete settings table. With custom fonts, the family names were then duplicated across vectors and lambdas. On the ESP32-C3's constrained contiguous heap, allocation failure under `-fno-exceptions` aborts the process and restarts the device.

## Scope

- Changes only `src/SettingsList.h`, `src/CrossPointSettings.cpp`, and `src/network/CrossPointWebServer.cpp`.
- No frontend or generated-file changes.
- No new dependencies or long-lived heap allocations.
- This is a focused stability fix for an existing CrossPoint feature.

## Validation

- [x] `git diff --check`
- [x] clang-format check
- [x] `./bin/ci-check` (including 254/254 host tests and default/sticky firmware builds)
- [x] `pio run -e simulator`
- [x] `pio run -e gh_release_cn`
- [ ] On-device AP mode: open settings at least 10 times with custom fonts
- [ ] On-device STA mode: open settings at least 10 times with custom fonts
- [ ] Verify normal-setting and custom-font persistence across refresh/reboot
- [ ] Verify no-custom-font and font upload/delete regressions
- [ ] Confirm serial `Free / Min Free / MaxAlloc` logs show no reset/leak and retain the existing >50 KB heap acceptance threshold

The hardware checks remain intentionally pending, so this PR is Draft.

## AI usage

AI assistance was used to trace the allocation path, implement the focused refactor, resolve the overlap with current Chinese-font behavior, and run validation. The resulting diff was manually scoped and reviewed.