### PR TITLE
perf: accelerate WeRead shelf selection

### DIFF
--- a/docs/engineering/ui-and-input.md
+++ b/docs/engineering/ui-and-input.md
@@ -130,6 +130,30 @@ action**.
   count, page start, and page capacity so the active theme controls the bar
   dimensions and placement.
 
+## Retained Framebuffer Updates
+
+The firmware has one framebuffer, and its contents remain available after
+`displayBuffer()`. A hot UI path may redraw only the changed items, but only
+when it can identify the exact frame already in that buffer:
+
+- Snapshot cross-task UI state once at the start of `render()`; never read a
+  mutable selection again inside an item loop.
+- Track the framebuffer's selection/page in render-task-owned state. Invalidate
+  that state before shelf/list content changes, an asset finishes loading, or
+  the layout changes.
+- Clear and redraw the full screen when the retained frame is invalid or the
+  target is on another page. Otherwise restore the old item and draw the new
+  item; do not allocate a second buffer.
+- After drawing, record what the framebuffer now contains, then re-read the
+  cross-task state. If it changed, request an immediate render and return before
+  `displayBuffer()` so the stale frame never reaches the panel. Keep the recorded
+  framebuffer state even for that skipped panel update, because the next render
+  builds from it.
+
+Incremental drawing does not imply a different panel waveform or windowed
+refresh. Those are display-driver decisions and require separate hardware
+measurement.
+
 ### Lyra Carousel home
 
 Lyra Carousel displays one centered recent-book cover in a `380x540` frame.

--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -84,6 +84,7 @@ constexpr int kPortraitShelfRows = 3;
 constexpr int kLandscapeShelfColumns = 5;
 constexpr int kLandscapeShelfRows = 2;
 constexpr unsigned long kShelfPageHoldMs = 700;
+constexpr int kNoShelfSelection = -1;
 
 enum class ShelfVerticalDirection : uint8_t { Up, Down };
 
@@ -121,6 +122,19 @@ static_assert(shelfVerticalIndex(1, 20, 3, 9, ShelfVerticalDirection::Up) == 1);
 static_assert(shelfVerticalIndex(10, 11, 3, 9, ShelfVerticalDirection::Down) == 10);
 static_assert(shelfVerticalIndex(10, 13, 3, 9, ShelfVerticalDirection::Down) == 12);
 static_assert(shelfVerticalIndex(7, 14, 5, 10, ShelfVerticalDirection::Down) == 12);
+
+constexpr bool canIncrementShelfFrame(const int frameSelection, const int frameItemsPerPage, const int selectedIndex,
+                                      const int itemsPerPage) {
+  return frameItemsPerPage == itemsPerPage && frameSelection >= 0 && selectedIndex >= 0 &&
+         frameSelection != selectedIndex && itemsPerPage > 0 &&
+         frameSelection / itemsPerPage == selectedIndex / itemsPerPage;
+}
+
+static_assert(!canIncrementShelfFrame(kNoShelfSelection, 9, 0, 9));
+static_assert(!canIncrementShelfFrame(3, 9, 3, 9));
+static_assert(canIncrementShelfFrame(3, 9, 4, 9));
+static_assert(!canIncrementShelfFrame(8, 9, 9, 9));
+static_assert(!canIncrementShelfFrame(3, 9, 4, 10));
 
 struct ShelfGridLayout {
   int columns = 1;
@@ -419,7 +433,8 @@ void WeReadActivity::onEnter() {
   disclaimerSelected_ = 0;
   disclaimerSaveFailed_ = false;
   menuSelected_ = 0;
-  shelfSelected_ = 0;
+  shelfSelected_.store(0);
+  shelfFrameInvalidated_.store(true);
   resetShelfCoverLoading();
   detailSelected_ = 0;
   introPage_ = 0;
@@ -464,6 +479,7 @@ void WeReadActivity::onExit() {
 }
 
 bool WeReadActivity::refreshShelf() {
+  shelfFrameInvalidated_.store(true);
   if (shelfFile_.isOpen()) shelfFile_.close();
   shelfCount_ = 0;
   if (!WeReadStore::openShelf(shelfFile_, shelfCount_)) {
@@ -471,9 +487,9 @@ bool WeReadActivity::refreshShelf() {
     return false;
   }
   if (shelfCount_ == 0) {
-    shelfSelected_ = 0;
-  } else if (shelfSelected_ >= static_cast<int>(shelfCount_)) {
-    shelfSelected_ = static_cast<int>(shelfCount_ - 1);
+    shelfSelected_.store(0);
+  } else if (shelfSelected_.load() >= static_cast<int>(shelfCount_)) {
+    shelfSelected_.store(static_cast<int>(shelfCount_ - 1));
   }
   resetShelfCoverLoading();
   return true;
@@ -684,7 +700,7 @@ void WeReadActivity::maybeShowLongWait(RenderLock& renderBarrier) {
 void WeReadActivity::advanceShelfCovers() {
   if (shelfCoverStopped_ || shelfCount_ == 0 || WiFi.status() != WL_CONNECTED) return;
   const int itemsPerPage = shelfItemsPerPage();
-  const int pageStart = shelfSelected_ / itemsPerPage * itemsPerPage;
+  const int pageStart = shelfSelected_.load() / itemsPerPage * itemsPerPage;
   if (pageStart != shelfCoverPageStart_) {
     operation_.reset();
     shelfCoverPageStart_ = pageStart;
@@ -698,6 +714,7 @@ void WeReadActivity::advanceShelfCovers() {
         return;
       case WeReadClient::Operation::Event::Complete:
         ++shelfCoverCursor_;
+        shelfFrameInvalidated_.store(true);
         requestUpdate();
         return;
       case WeReadClient::Operation::Event::QrReady:
@@ -933,7 +950,7 @@ void WeReadActivity::openSelectedDetail(const WeReadStore::ShelfRecord& book) {
 
 void WeReadActivity::activateSelected() {
   WeReadStore::ShelfRecord book;
-  if (readShelf(shelfSelected_, book)) openSelectedDetail(book);
+  if (readShelf(shelfSelected_.load(), book)) openSelectedDetail(book);
 }
 
 bool WeReadActivity::detailActionEnabled(const DetailAction action) const {
@@ -1329,7 +1346,8 @@ void WeReadActivity::performLogout() {
   const bool shelfCleared = WeReadStore::clearShelf();
   const bool browseCacheCleared = WeReadBrowse::clearAllCaches();
   shelfCount_ = 0;
-  shelfSelected_ = 0;
+  shelfSelected_.store(0);
+  shelfFrameInvalidated_.store(true);
   if (!sessionCleared || !shelfCleared || !browseCacheCleared) {
     LOG_ERR("WR", "Failed to clear local login state");
     state_.store(State::LogoutError);
@@ -1394,14 +1412,16 @@ void WeReadActivity::handleShelfInput() {
       const auto direction = movingUp ? ShelfVerticalDirection::Up : ShelfVerticalDirection::Down;
       if (mappedInput.wasReleased(button)) {
         shelfSideGesture_ = ShelfSideGesture::Idle;
-        moveShelfSelection(shelfVerticalIndex(shelfSelected_, count, columns, itemsPerPage, direction), itemsPerPage);
+        moveShelfSelection(shelfVerticalIndex(shelfSelected_.load(), count, columns, itemsPerPage, direction),
+                           itemsPerPage);
         return;
       }
       if (mappedInput.isPressed(button) && mappedInput.getHeldTime() >= kShelfPageHoldMs) {
         shelfSideGesture_ = ShelfSideGesture::PageHandled;
         if (count > itemsPerPage) {
-          const int target = movingUp ? ButtonNavigator::previousPageIndex(shelfSelected_, count, itemsPerPage)
-                                      : ButtonNavigator::nextPageIndex(shelfSelected_, count, itemsPerPage);
+          const int selected = shelfSelected_.load();
+          const int target = movingUp ? ButtonNavigator::previousPageIndex(selected, count, itemsPerPage)
+                                      : ButtonNavigator::nextPageIndex(selected, count, itemsPerPage);
           moveShelfSelection(target, itemsPerPage);
         }
       }
@@ -1420,10 +1440,10 @@ void WeReadActivity::handleShelfInput() {
       swapFrontDirections ? MappedInputManager::Button::Right : MappedInputManager::Button::Left;
   const auto nextButton = swapFrontDirections ? MappedInputManager::Button::Left : MappedInputManager::Button::Right;
   buttonNavigator_.onPressAndContinuous({previousButton}, [this, count, itemsPerPage] {
-    moveShelfSelection(ButtonNavigator::previousIndex(shelfSelected_, count), itemsPerPage);
+    moveShelfSelection(ButtonNavigator::previousIndex(shelfSelected_.load(), count), itemsPerPage);
   });
   buttonNavigator_.onPressAndContinuous({nextButton}, [this, count, itemsPerPage] {
-    moveShelfSelection(ButtonNavigator::nextIndex(shelfSelected_, count), itemsPerPage);
+    moveShelfSelection(ButtonNavigator::nextIndex(shelfSelected_.load(), count), itemsPerPage);
   });
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     resetShelfCoverLoading();
@@ -1436,10 +1456,9 @@ void WeReadActivity::handleShelfInput() {
 }
 
 void WeReadActivity::moveShelfSelection(const int index, const int itemsPerPage) {
-  if (index == shelfSelected_) return;
-  const int previousPage = shelfSelected_ / itemsPerPage;
-  shelfSelected_ = index;
-  if (shelfSelected_ / itemsPerPage != previousPage) resetShelfCoverLoading();
+  const int previousIndex = shelfSelected_.exchange(index);
+  if (index == previousIndex) return;
+  if (index / itemsPerPage != previousIndex / itemsPerPage) resetShelfCoverLoading();
   requestUpdate();
 }
 
@@ -1756,22 +1775,20 @@ void WeReadActivity::drawDisclaimer(const Rect& content) {
   }
 }
 
-void WeReadActivity::drawShelfGrid(const Rect& content) {
+void WeReadActivity::drawShelfGrid(const Rect& content, const int selectedIndex, const int frameSelection) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const auto layout = shelfGridLayout(renderer, content, metrics.contentSidePadding, metrics.verticalSpacing);
   const int count = static_cast<int>(std::min<uint32_t>(shelfCount_, INT32_MAX));
-  const int page = shelfSelected_ / layout.itemsPerPage;
+  const int page = selectedIndex / layout.itemsPerPage;
   const int pageStart = page * layout.itemsPerPage;
   const int pageEnd = std::min(pageStart + layout.itemsPerPage, count);
   const int pageCount = pageEnd - pageStart;
   const int visibleRows = (pageCount + layout.columns - 1) / layout.columns;
   const int visibleHeight = visibleRows * layout.itemHeight + std::max(0, visibleRows - 1) * layout.rowGap;
   const int startY = content.y + std::max(0, (content.height - visibleHeight) / 2);
+  const bool incrementalFrame = frameSelection >= pageStart && frameSelection < pageEnd;
 
-  for (int index = pageStart; index < pageEnd; ++index) {
-    WeReadStore::ShelfRecord book;
-    if (!readShelf(index, book)) continue;
-
+  const auto drawItem = [&](const int index, const bool selected) {
     const int item = index - pageStart;
     const int row = item / layout.columns;
     const int column = item % layout.columns;
@@ -1781,13 +1798,17 @@ void WeReadActivity::drawShelfGrid(const Rect& content) {
                        column * (layout.coverWidth + layout.columnGap);
     const int coverY = startY + row * (layout.itemHeight + layout.rowGap);
     const Rect cover{coverX, coverY, layout.coverWidth, layout.coverHeight};
-    const bool selected = index == shelfSelected_;
+    const Rect itemBounds{cover.x - 2, cover.y - 2, cover.width + 4, layout.itemHeight + 4};
     bool foregroundBlack = true;
     if (selected) {
-      foregroundBlack =
-          GUI.drawSelectionBackground(renderer, Rect{cover.x - 2, cover.y - 2, cover.width + 4, layout.itemHeight + 4});
+      foregroundBlack = GUI.drawSelectionBackground(renderer, itemBounds);
       renderer.fillRect(cover.x, cover.y, cover.width, cover.height, false);
+    } else if (incrementalFrame) {
+      renderer.fillRect(itemBounds.x, itemBounds.y, itemBounds.width, itemBounds.height, false);
     }
+
+    WeReadStore::ShelfRecord book;
+    if (!readShelf(index, book)) return;
 
     const bool coverDrawn = drawCachedCover(renderer, WeReadStore::bookDirectory(book.bookId), cover);
     renderer.drawRect(cover.x, cover.y, cover.width, cover.height);
@@ -1799,6 +1820,13 @@ void WeReadActivity::drawShelfGrid(const Rect& content) {
     const int titleWidth = renderer.getTextAdvanceX(SMALL_FONT_ID, title.c_str(), EpdFontFamily::REGULAR);
     renderer.drawText(SMALL_FONT_ID, cover.x + std::max(0, (cover.width - titleWidth) / 2),
                       cover.y + cover.height + layout.titleGap, title.c_str(), foregroundBlack);
+  };
+
+  if (incrementalFrame) {
+    drawItem(frameSelection, false);
+    drawItem(selectedIndex, true);
+  } else {
+    for (int index = pageStart; index < pageEnd; ++index) drawItem(index, index == selectedIndex);
   }
 
   GUI.drawSideScrollBar(renderer, content, count, pageStart, layout.itemsPerPage);
@@ -1982,9 +2010,17 @@ void WeReadActivity::render(RenderLock&&) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int width = renderer.getScreenWidth();
   const State state = state_.load();
+  const int shelfSelection = shelfSelected_.load();
   const Rect content = state == State::Disclaimer ? disclaimerContentBounds() : contentBounds();
+  const int shelfItems = state == State::Shelf && shelfCount_ > 0 ? shelfItemsPerPage() : 0;
+  const int shelfFrameSelection = shelfFrameSelection_;
+  const int shelfFrameItems = shelfFrameItemsPerPage_;
+  const bool shelfFrameInvalidated = state == State::Shelf && shelfFrameInvalidated_.exchange(false);
+  const bool incrementalShelfFrame =
+      state == State::Shelf && !shelfFrameInvalidated &&
+      canIncrementShelfFrame(shelfFrameSelection, shelfFrameItems, shelfSelection, shelfItems);
 
-  renderer.clearScreen();
+  if (!incrementalShelfFrame) renderer.clearScreen();
   const char* header = tr(STR_WEREAD_TITLE);
   switch (state) {
     case State::Disclaimer:
@@ -2030,7 +2066,7 @@ void WeReadActivity::render(RenderLock&&) {
       if (shelfCount_ == 0) {
         GUI.drawPopup(renderer, tr(STR_WEREAD_SHELF_EMPTY));
       } else {
-        drawShelfGrid(content);
+        drawShelfGrid(content, shelfSelection, incrementalShelfFrame ? shelfFrameSelection : kNoShelfSelection);
       }
       break;
     case State::Detail:
@@ -2226,6 +2262,29 @@ void WeReadActivity::render(RenderLock&&) {
   }
   const auto labels = mappedInput.mapLabels(back, confirm, previous, next);
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  if (state == State::Shelf) {
+    if (shelfFrameInvalidated_.load() || state_.load() != State::Shelf) {
+      shelfFrameSelection_ = kNoShelfSelection;
+      shelfFrameItemsPerPage_ = 0;
+      requestUpdate(true);
+      return;
+    }
+    if (shelfCount_ > 0) {
+      // The framebuffer contains this snapshot even when the stale panel update below is skipped.
+      shelfFrameSelection_ = shelfSelection;
+      shelfFrameItemsPerPage_ = shelfItems;
+      if (shelfSelected_.load() != shelfSelection) {
+        requestUpdate(true);
+        return;
+      }
+    } else {
+      shelfFrameSelection_ = kNoShelfSelection;
+      shelfFrameItemsPerPage_ = 0;
+    }
+  } else {
+    shelfFrameSelection_ = kNoShelfSelection;
+    shelfFrameItemsPerPage_ = 0;
+  }
   renderer.displayBuffer();
 }
 

--- a/src/activities/apps/weread/WeReadActivity.h
+++ b/src/activities/apps/weread/WeReadActivity.h
@@ -68,7 +68,10 @@ class WeReadActivity final : public Activity {
   uint32_t shelfCount_ = 0;
   int disclaimerSelected_ = 0;
   int menuSelected_ = 0;
-  int shelfSelected_ = 0;
+  std::atomic<int> shelfSelected_{0};
+  int shelfFrameSelection_ = -1;
+  int shelfFrameItemsPerPage_ = 0;
+  std::atomic<bool> shelfFrameInvalidated_{true};
   int shelfCoverPageStart_ = -1;
   int shelfCoverCursor_ = 0;
   ShelfSideGesture shelfSideGesture_ = ShelfSideGesture::Idle;
@@ -126,7 +129,7 @@ class WeReadActivity final : public Activity {
   void handleIntroductionInput();
   void buildIntroductionPages();
   bool drawDetailIntroduction(const Rect& bounds, bool selected);
-  void drawShelfGrid(const Rect& content);
+  void drawShelfGrid(const Rect& content, int selectedIndex, int frameSelection);
   void drawDisclaimer(const Rect& content);
   void drawBookDetail(const Rect& content, bool coverLoading = false);
   void drawIntroduction(const Rect& content);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Reduce WeRead shelf cursor latency and prevent stale frames from showing two selection backgrounds during rapid input.
* **What changes are included?**
  * Snapshot the cross-task shelf selection and track the exact selection, page capacity, and content validity represented by the retained framebuffer.
  * On same-page movement, restore only the old item and draw the new selected item. First entry, page/layout changes, shelf refreshes, and completed cover loads still use a full redraw.
  * Skip a stale panel update when input or shelf content changes during drawing, then immediately render the newest state.
  * Document the retained-framebuffer rules in the UI/input engineering guide.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* X4 serial measurements reduced same-page UI drawing from 992–1033 ms to 225–246 ms (about 77%) and total cursor response from about 1.57 s to 800–820 ms (about 49%, or 1.95x faster). Cross-page redraws remain about 1.58 s because they still redraw the complete shelf page.
* Rapid-input diagnostics confirmed that a stale full frame drawn for 1033 ms was discarded before `displayBuffer()` rather than displayed.
* The existing full-screen FAST refresh waveform is unchanged. This PR adds no framebuffer, cache, public API, setting, or dynamic allocation; it only adds fixed activity state.
* Final `gh_release_cn` usage: DRAM 118,887 bytes; PlatformIO RAM 51,860 bytes.
* Verified with `./bin/ci-check` (formatting, cppcheck, default and Sticky builds, 254 tests), `pio run -e gh_release_cn`, `pio run -e simulator`, `git diff --check`, and X4 hardware measurements.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
