### PR TITLE
fix: prompt for Wi-Fi in pixel switch

### DIFF
--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <esp_wifi.h>
 
 #include <algorithm>
@@ -12,6 +13,7 @@
 #include "../../../WifiCredentialStore.h"
 #include "../../../components/UITheme.h"
 #include "../../../fontIds.h"
+#include "../../network/WifiSelectionActivity.h"
 #include "../airpage/AirPageDeviceId.h"
 
 namespace {
@@ -62,6 +64,8 @@ void PixelSwitchActivity::onEnter() {
   broughtWifiUp_ = false;
   snapshotReady_ = false;
   ignoreConfirmRelease_ = mappedInput.isPressed(MappedInputManager::Button::Confirm);
+  waitForWifiInputRelease_ = false;
+  returnToAppsAfterWifi_ = false;
   showCooldown_ = false;
   subscribedAtMs_ = 0;
   cooldownStartedMs_ = 0;
@@ -70,14 +74,15 @@ void PixelSwitchActivity::onEnter() {
 
   mqtt_.setServer(MQTT_HOST, MQTT_PORT);
   mqtt_.setCallback(&PixelSwitchActivity::mqttCallback);
-  // Whole-canvas Retain needs one bounded activity-lifetime buffer; 1600 bytes
-  // cannot live on the task stack and PubSubClient reports allocation failure.
-  mqttBufferReady_ = mqtt_.setBufferSize(MQTT_BUFFER_SIZE);
-  if (!mqttBufferReady_) {
-    LOG_ERR("PXSW", "OOM: MQTT buffer (%u bytes)", static_cast<unsigned>(MQTT_BUFFER_SIZE));
+  lastConnectAttemptMs_ = millis() - MQTT_RECONNECT_MS;
+
+  if (WiFi.status() != WL_CONNECTED) {
+    launchWifiSelection();
+    requestUpdate();
+    return;
   }
 
-  lastConnectAttemptMs_ = millis() - MQTT_RECONNECT_MS;
+  prepareMqttBuffer();
   requestUpdate();
 }
 
@@ -118,6 +123,47 @@ void PixelSwitchActivity::handleMqttMessage(const char* topic, const uint8_t* pa
 }
 
 bool PixelSwitchActivity::canPublish() { return snapshotReady_ && mqtt_.connected(); }
+
+bool PixelSwitchActivity::prepareMqttBuffer() {
+  if (mqttBufferReady_) return true;
+
+  // Whole-canvas Retain needs one bounded activity-lifetime buffer; 1600 bytes
+  // cannot live on the task stack and PubSubClient reports allocation failure.
+  mqttBufferReady_ = mqtt_.setBufferSize(MQTT_BUFFER_SIZE);
+  if (!mqttBufferReady_) {
+    LOG_ERR("PXSW", "OOM: MQTT buffer (%u bytes)", static_cast<unsigned>(MQTT_BUFFER_SIZE));
+  }
+  return mqttBufferReady_;
+}
+
+void PixelSwitchActivity::launchWifiSelection() {
+  // ActivityManager owns the picker across frames; stack lifetime is insufficient.
+  auto wifi = makeUniqueNoThrow<WifiSelectionActivity>(renderer, mappedInput, true);
+  if (!wifi) {
+    LOG_ERR("PXSW", "OOM: WifiSelectionActivity (%u bytes)", static_cast<unsigned>(sizeof(WifiSelectionActivity)));
+    activityManager.goToApps();
+    return;
+  }
+
+  broughtWifiUp_ = true;
+  startActivityForResult(std::move(wifi), [this](const ActivityResult& result) {
+    waitForWifiInputRelease_ = true;
+    returnToAppsAfterWifi_ = result.isCancelled || WiFi.status() != WL_CONNECTED;
+    if (!returnToAppsAfterWifi_) prepareMqttBuffer();
+    requestUpdate();
+  });
+}
+
+bool PixelSwitchActivity::consumeWifiInputReleaseBarrier() {
+  if (!waitForWifiInputRelease_) return false;
+
+  const bool anyPressed = mappedInput.isPressed(MappedInputManager::Button::Back) ||
+                          mappedInput.isPressed(MappedInputManager::Button::Confirm) ||
+                          mappedInput.isPressed(MappedInputManager::Button::NavPrevious) ||
+                          mappedInput.isPressed(MappedInputManager::Button::NavNext);
+  if (!anyPressed) waitForWifiInputRelease_ = false;
+  return true;
+}
 
 bool PixelSwitchActivity::connectBroker() {
   char clientId[40];
@@ -211,6 +257,12 @@ void PixelSwitchActivity::pumpNetwork() {
 }
 
 void PixelSwitchActivity::loop() {
+  if (consumeWifiInputReleaseBarrier()) return;
+  if (returnToAppsAfterWifi_) {
+    activityManager.goToApps();
+    return;
+  }
+
   pumpNetwork();
   const uint32_t now = millis();
   if (showCooldown_ && pixel_switch::hasElapsed(cooldownStartedMs_, now, COOLDOWN_POPUP_MS)) {

--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.h
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.h
@@ -32,6 +32,9 @@ class PixelSwitchActivity final : public Activity {
 
   void handleMqttMessage(const char* topic, const uint8_t* payload, size_t length);
   bool canPublish();
+  bool prepareMqttBuffer();
+  void launchWifiSelection();
+  bool consumeWifiInputReleaseBarrier();
   void pumpNetwork();
   bool connectBroker();
   bool startSavedWifiAssociation();
@@ -60,6 +63,8 @@ class PixelSwitchActivity final : public Activity {
   bool broughtWifiUp_ = false;
   bool snapshotReady_ = false;
   bool ignoreConfirmRelease_ = false;
+  bool waitForWifiInputRelease_ = false;
+  bool returnToAppsAfterWifi_ = false;
   bool showCooldown_ = false;
   uint32_t lastConnectAttemptMs_ = 0;
   uint32_t subscribedAtMs_ = 0;


### PR DESCRIPTION
## Summary

- Open the existing Wi-Fi picker when Pixel Switch starts offline.
- Continue to MQTT only after Wi-Fi connects; defer the 1600-byte MQTT buffer until the picker is destroyed.
- Consume the picker-triggering button release and return to Apps on cancellation or failure.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [ ] This touches an existing hidden interactive app; it does not add or expose a new app.
- [ ] This is a narrow bug fix for existing fork behavior; no stock-firmware comparison was performed.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Additional Context

- Reuses WifiSelectionActivity and its saved-network/scan flow.
- Keeps the existing background reconnect behavior after an in-game disconnect.
- Heap impact is bounded: WifiSelectionActivity and the MQTT buffer are not held at the same time.

## Verification

- ./bin/ci-check
- pio run -e simulator -e simulator_x3
- Hardware validation remains pending.

### AI Usage

Did you use AI tools to help write this code? **YES**