### PR TITLE
chore: sync upstream develop into main (ba1b849f)

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1248,6 +1248,8 @@ void CrossPointWebServer::handleGetSettings() const {
       seenFirst = true;
     }
     server->sendContent(output);
+    yield();                          // Yield to allow WiFi and other tasks to process during a slow send
+    resetTaskWatchdogIfSubscribed();  // Reset watchdog: each sendContent() is a blocking network write
   }
 
   server->sendContent("]");
@@ -1360,6 +1362,8 @@ void CrossPointWebServer::handleGetOpdsServers() const {
 
     if (i > 0) server->sendContent(",");
     server->sendContent(output);
+    yield();                          // Yield to allow WiFi and other tasks to process during a slow send
+    resetTaskWatchdogIfSubscribed();  // Reset watchdog: each sendContent() is a blocking network write
   }
 
   server->sendContent("]");
@@ -1476,6 +1480,8 @@ void CrossPointWebServer::handleGetWifiNetworks() const {
 
     if (i > 0) server->sendContent(",");
     server->sendContent(output);
+    yield();                          // Yield to allow WiFi and other tasks to process during a slow send
+    resetTaskWatchdogIfSubscribed();  // Reset watchdog: each sendContent() is a blocking network write
   }
 
   server->sendContent("]");

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -596,8 +596,6 @@
     btn.textContent = 'Save Settings';
   }
 
-  loadSettings();
-
   // --- Wi-Fi Network Management ---
   // Renders an editable list of saved Wi-Fi networks using /api/wifi endpoints.
   // Password fields are never pre-filled; when left blank during edit, existing
@@ -825,8 +823,14 @@
     }
   }
 
-  loadWifiNetworks();
-  loadOpdsServers();
+  // Sequential, not concurrent: the device's web server handles one client
+  // connection at a time, and three simultaneous fetches on page load can
+  // stall long enough inside a single response to trip the firmware watchdog.
+  (async () => {
+    await loadSettings();
+    await loadWifiNetworks();
+    await loadOpdsServers();
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Sync `upstream/develop` at `ba1b849f3d5bf8a990e32bee31c9f3dd95cd0267` into `main`.
- Yield and reset the task watchdog after each chunked Settings, OPDS, and Wi-Fi response write.
- Load Settings, Wi-Fi, and OPDS data sequentially in both English and Chinese web pages.

## Conflict resolution

- Upstream still edits `src/network/html/SettingsPage.html`; CrossMux split that source into `en/` and `zh-CN/` variants.
- Ported the upstream loading-order change to both localized sources while preserving CrossMux branding and Chinese behavior.
- No upstream hunks were skipped.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `pio run`
- `pio run -e gh_release_cn`