### PR TITLE
fix(weread): clear shelf index with cache

### DIFF
--- a/src/activities/apps/weread/WeReadStore.cpp
+++ b/src/activities/apps/weread/WeReadStore.cpp
@@ -258,8 +258,7 @@ bool clearCache() {
         ok = false;
         continue;
       }
-      if (strcmp(name, "session.bin") == 0 || strcmp(name, "disclaimer.accepted") == 0 ||
-          strcmp(name, "shelf.bin") == 0) {
+      if (strcmp(name, "session.bin") == 0 || strcmp(name, "disclaimer.accepted") == 0) {
         continue;
       }
       isDirectory = entry.isDirectory();

--- a/test/weread/WeReadStoreTest.cpp
+++ b/test/weread/WeReadStoreTest.cpp
@@ -694,7 +694,7 @@ TEST_F(WeReadStoreTest, ClearsSessionAndShelfButPreservesDownloadedContent) {
   EXPECT_TRUE(WeReadStore::clearShelf());
 }
 
-TEST_F(WeReadStoreTest, ClearsWeReadCacheButPreservesAccountShelfAndDownloadedBooks) {
+TEST_F(WeReadStoreTest, ClearsWeReadCacheButPreservesAccountAndDownloadedBooks) {
   ASSERT_TRUE(WeReadStore::ensureRoot());
   ASSERT_TRUE(WeReadStore::acceptDisclaimer());
   WeReadStore::Session session;
@@ -721,7 +721,7 @@ TEST_F(WeReadStoreTest, ClearsWeReadCacheButPreservesAccountShelfAndDownloadedBo
   ASSERT_TRUE(WeReadStore::clearCache());
   EXPECT_TRUE(Storage.exists(WeReadStore::kSessionPath));
   EXPECT_TRUE(WeReadStore::hasAcceptedDisclaimer());
-  EXPECT_TRUE(Storage.exists(WeReadStore::kShelfPath));
+  EXPECT_FALSE(Storage.exists(WeReadStore::kShelfPath));
   EXPECT_FALSE(Storage.exists("/.crosspoint/weread/shelf.bin.part"));
   EXPECT_FALSE(Storage.exists("/.crosspoint/weread/book-1"));
   EXPECT_FALSE(Storage.exists("/.crosspoint/weread/browse-cache"));


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Ensure clearing the WeRead cache also removes the local shelf index, so the next manual refresh rebuilds it from the server.
* **What changes are included?** Stop preserving `shelf.bin` in `WeReadStore::clearCache()` and update the regression test. Login state, disclaimer acceptance, and downloaded EPUB files remain untouched.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* After clearing the cache, the shelf remains empty until the user manually refreshes it.
* Verification: `build/test/weread/WeReadStoreTest` — 28/28 tests passed.
* Memory / flash impact: none; the change removes one filename comparison from the existing whitelist.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
