### PR TITLE
fix: restore location after silent restart

### DIFF
--- a/src/SilentRestart.h
+++ b/src/SilentRestart.h
@@ -1,8 +1,32 @@
 #pragma once
 
+#include <cstdint>
+
 // ESP.restart() with an RTC_NOINIT flag that survives the reboot, so setup()
 // skips the boot splash and routes straight to a destination. Used to clear
 // heap fragmentation accumulated during a wifi session.
 
-void silentRestart();          // home screen
-void silentRestartToReader();  // currently-open EPUB (APP_STATE.openEpubPath)
+enum class SilentRestartTarget : uint8_t {
+  Home,
+  HomeOpds,
+  HomeFileTransfer,
+  SettingsCheckUpdates,
+  SettingsManageFonts,
+  SettingsText,
+  SettingsDateTime,
+  SettingsKOReader,
+  Reader,
+  Count,
+};
+
+constexpr SilentRestartTarget decodeSilentRestartTarget(const uint32_t rawTarget) {
+  return rawTarget < static_cast<uint32_t>(SilentRestartTarget::Count) ? static_cast<SilentRestartTarget>(rawTarget)
+                                                                       : SilentRestartTarget::Home;
+}
+
+static_assert(decodeSilentRestartTarget(static_cast<uint32_t>(SilentRestartTarget::Reader)) ==
+              SilentRestartTarget::Reader);
+static_assert(decodeSilentRestartTarget(static_cast<uint32_t>(SilentRestartTarget::Count)) ==
+              SilentRestartTarget::Home);
+
+void silentRestart(SilentRestartTarget target);

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -209,6 +209,10 @@ void ActivityManager::goToFileTransfer() {
 
 void ActivityManager::goToSettings() { replaceActivity(std::make_unique<SettingsActivity>(renderer, mappedInput)); }
 
+void ActivityManager::goToSettings(const SettingAction initialAction) {
+  replaceActivity(std::make_unique<SettingsActivity>(renderer, mappedInput, initialAction));
+}
+
 void ActivityManager::goToUglyAvatar() { replaceActivity(std::make_unique<UglyAvatarActivity>(renderer, mappedInput)); }
 
 void ActivityManager::goToFileBrowser(std::string path) {

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -16,6 +16,7 @@
 
 class Activity;    // forward declaration
 class RenderLock;  // forward declaration
+enum class SettingAction;
 
 enum class HomeMenuItem { NONE, FILE_BROWSER, RECENTS, OPDS_BROWSER, FILE_TRANSFER, SETTINGS_MENU, APPS };
 
@@ -83,6 +84,7 @@ class ActivityManager {
   // goTo... functions are convenient wrapper for replaceActivity()
   void goToFileTransfer();
   void goToSettings();
+  void goToSettings(SettingAction initialAction);
   void goToUglyAvatar();
   void goToReadingStatsMenu();
   void goToFileBrowser(std::string path = {});

--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -1247,7 +1247,7 @@ void WeReadActivity::openBook(const char* path) {
 
   WiFi.disconnect(false);
   delay(30);
-  silentRestartToReader();
+  silentRestart(SilentRestartTarget::Reader);
 #endif
 }
 

--- a/src/activities/apps/weread/WeReadProgressSyncActivity.cpp
+++ b/src/activities/apps/weread/WeReadProgressSyncActivity.cpp
@@ -68,7 +68,7 @@ void WeReadProgressSyncActivity::onExit() {
   if (!wifiActivated_) return;
   WiFi.disconnect(false);
   delay(30);
-  silentRestartToReader();
+  silentRestart(SilentRestartTarget::Reader);
 }
 
 bool WeReadProgressSyncActivity::preventAutoSleep() { return state_ == State::Starting || state_ == State::Syncing; }

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -68,7 +68,7 @@ void OpdsBookBrowserActivity::onExit() {
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::HomeOpds);
   }
 }
 

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -57,7 +57,7 @@ void CalibreConnectActivity::onExit() {
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::HomeFileTransfer);
   }
 }
 

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -102,7 +102,7 @@ void CrossPointWebServerActivity::onExit() {
       WiFi.disconnect(false);
     }
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::HomeFileTransfer);
   }
 
   LOG_DBG("WEBACT", "Free heap at onExit end: %d bytes", ESP.getFreeHeap());

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -412,8 +412,8 @@ bool EpubReaderActivity::maybeOfferCompleteChineseFont() {
   LOG_INF("FONT", "Missing built-in Chinese glyph U+%04X; offering SD fonts", static_cast<unsigned>(codepoint));
 
   // ActivityManager owns the downloader across frames, so it must live on the heap.
-  auto downloader =
-      makeUniqueNoThrow<FontDownloadActivity>(renderer, mappedInput, FontDownloadActivity::Purpose::PromptThenManage);
+  auto downloader = makeUniqueNoThrow<FontDownloadActivity>(
+      renderer, mappedInput, FontDownloadActivity::Purpose::PromptThenManage, SilentRestartTarget::Reader);
   if (!downloader) {
     LOG_ERR("FONT", "OOM allocating FontDownloadActivity (%zu bytes)", sizeof(FontDownloadActivity));
     return false;
@@ -936,8 +936,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::TEXT_SETTINGS: {
-      auto textSettings = makeUniqueNoThrow<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                                  TextSettingsActivity::Tab::Family);
+      auto textSettings =
+          makeUniqueNoThrow<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
+                                                  TextSettingsActivity::Tab::Family, SilentRestartTarget::Reader);
       if (!textSettings) {
         LOG_ERR("ERS", "OOM: TextSettingsActivity (%u bytes)", static_cast<unsigned>(sizeof(TextSettingsActivity)));
         requestUpdate();

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -372,7 +372,7 @@ void KOReaderSyncActivity::onExit() {
   if (wifiActivated) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestartToReader();
+    silentRestart(SilentRestartTarget::Reader);
   }
 }
 

--- a/src/activities/settings/ClockSyncActivity.cpp
+++ b/src/activities/settings/ClockSyncActivity.cpp
@@ -37,7 +37,7 @@ void ClockSyncActivity::onExit() {
   if (shouldTearDownWifiOnExit && WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::SettingsDateTime);
   }
 }
 

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -38,8 +38,11 @@ std::atomic<bool> chineseFontPromptShownThisBoot{false};
 }  // namespace
 
 FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                           const Purpose purpose)
-    : Activity("FontDownload", renderer, mappedInput), purpose_(purpose), fontInstaller_(sdFontSystem.registry()) {}
+                                           const Purpose purpose, const SilentRestartTarget restartTarget)
+    : Activity("FontDownload", renderer, mappedInput),
+      purpose_(purpose),
+      restartTarget_(restartTarget),
+      fontInstaller_(sdFontSystem.registry()) {}
 
 #ifdef ENABLE_CHINESE_VERSION
 bool FontDownloadActivity::wasChineseFontPromptShownThisBoot() {
@@ -100,7 +103,7 @@ void FontDownloadActivity::onExit() {
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(restartTarget_);
   }
 }
 
@@ -505,7 +508,7 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(Manife
 
 void FontDownloadActivity::selectDownloadedFontAndPreview(const char* familyName) {
   auto textSettings = makeUniqueNoThrow<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                              TextSettingsActivity::Tab::Family);
+                                                              TextSettingsActivity::Tab::Family, restartTarget_);
 
   strncpy(SETTINGS.sdFontFamilyName, familyName, sizeof(SETTINGS.sdFontFamilyName) - 1);
   SETTINGS.sdFontFamilyName[sizeof(SETTINGS.sdFontFamilyName) - 1] = '\0';

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -5,6 +5,7 @@
 
 #include "FontInstaller.h"
 #include "SdCardFont.h"
+#include "SilentRestart.h"
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
@@ -35,8 +36,8 @@ class FontDownloadActivity : public Activity {
  public:
   enum class Purpose : uint8_t { Manage, PromptThenManage };
 
-  explicit FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                Purpose purpose = Purpose::Manage);
+  explicit FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, Purpose purpose,
+                                SilentRestartTarget restartTarget);
 
 #ifdef ENABLE_CHINESE_VERSION
   static bool wasChineseFontPromptShownThisBoot();
@@ -87,6 +88,7 @@ class FontDownloadActivity : public Activity {
 
   State state_ = WIFI_SELECTION;
   Purpose purpose_;
+  const SilentRestartTarget restartTarget_;
   FontInstaller fontInstaller_;
   ButtonNavigator buttonNavigator_;
 

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -70,7 +70,7 @@ void KOReaderAuthActivity::onExit() {
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::SettingsKOReader);
   }
 }
 

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -130,7 +130,7 @@ void OtaUpdateActivity::onExit() {
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
-    silentRestart();
+    silentRestart(SilentRestartTarget::SettingsCheckUpdates);
   }
 }
 

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -130,6 +130,23 @@ void SettingsActivity::onEnter() {
 
   rebuildSettingsLists();
 
+  if (initialAction != SettingAction::None) {
+    const std::vector<SettingInfo>* categories[] = {&displaySettings, &readerSettings, &controlsSettings,
+                                                    &systemSettings};
+    for (int category = 0; category < categoryCount; ++category) {
+      const auto& settings = *categories[category];
+      const auto setting = std::find_if(settings.begin(), settings.end(),
+                                        [this](const SettingInfo& info) { return info.action == initialAction; });
+      if (setting == settings.end()) continue;
+
+      selectedCategoryIndex = category;
+      selectedSettingIndex = static_cast<int>(setting - settings.begin()) + 1;
+      currentSettings = categories[category];
+      settingsCount = static_cast<int>(settings.size());
+      break;
+    }
+  }
+
   // Trigger first update
   requestUpdate();
 }
@@ -432,17 +449,20 @@ void SettingsActivity::toggleCurrentSetting() {
         startActivityForResult(std::make_unique<SdFirmwareUpdateActivity>(renderer, mappedInput), resultHandler);
         break;
       case SettingAction::DownloadFonts:
-        startActivityForResult(std::make_unique<FontDownloadActivity>(renderer, mappedInput),
-                               [this](const ActivityResult&) {
-                                 SETTINGS.saveToFile();
-                                 rebuildSettingsLists();
-                               });
+        startActivityForResult(
+            std::make_unique<FontDownloadActivity>(renderer, mappedInput, FontDownloadActivity::Purpose::Manage,
+                                                   SilentRestartTarget::SettingsManageFonts),
+            [this](const ActivityResult&) {
+              SETTINGS.saveToFile();
+              rebuildSettingsLists();
+            });
         break;
       case SettingAction::TextSettings:
         // ActivityManager owns this across render-loop frames, so it cannot be a
         // stack object. Use the nothrow factory because ESP32 builds disable exceptions.
         if (auto textSettings = makeUniqueNoThrow<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                                        TextSettingsActivity::Tab::Family)) {
+                                                                        TextSettingsActivity::Tab::Family,
+                                                                        SilentRestartTarget::SettingsText)) {
           startActivityForResult(std::move(textSettings), [this](const ActivityResult&) {
             // TextSettingsActivity persists every change before returning.
             rebuildSettingsLists();

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -162,6 +162,7 @@ struct SettingInfo {
 class SettingsActivity final : public Activity {
   ButtonNavigator buttonNavigator;
 
+  const SettingAction initialAction;
   int selectedCategoryIndex = 0;  // Currently selected category
   int selectedSettingIndex = 0;
   int settingsCount = 0;
@@ -188,8 +189,9 @@ class SettingsActivity final : public Activity {
   void syncQuickResumeTimeoutForSleepScreen(bool sleepScreenChanged, bool quickResumeTimeoutChanged);
 
  public:
-  explicit SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("Settings", renderer, mappedInput) {}
+  explicit SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                            SettingAction initialActionValue = SettingAction::None)
+      : Activity("Settings", renderer, mappedInput), initialAction(initialActionValue) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -42,8 +42,12 @@ constexpr StrId OK_OPTION[] = {StrId::STR_OK_BUTTON};
 }  // namespace
 
 TextSettingsActivity::TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                           const SdCardFontRegistry* registry, Tab initialTab)
-    : Activity("TextSettings", renderer, mappedInput), registry_(registry), tab_(initialTab) {}
+                                           const SdCardFontRegistry* registry, const Tab initialTab,
+                                           const SilentRestartTarget restartTarget)
+    : Activity("TextSettings", renderer, mappedInput),
+      registry_(registry),
+      restartTarget_(restartTarget),
+      tab_(initialTab) {}
 
 void TextSettingsActivity::onEnter() {
   Activity::onEnter();
@@ -545,8 +549,8 @@ void TextSettingsActivity::maybeOfferCompleteChineseFont() {
   }
 
   // ActivityManager owns the downloader across frames, so it must live on the heap.
-  auto downloader =
-      makeUniqueNoThrow<FontDownloadActivity>(renderer, mappedInput, FontDownloadActivity::Purpose::PromptThenManage);
+  auto downloader = makeUniqueNoThrow<FontDownloadActivity>(
+      renderer, mappedInput, FontDownloadActivity::Purpose::PromptThenManage, restartTarget_);
   if (!downloader) {
     LOG_ERR("FONT", "OOM allocating FontDownloadActivity (%zu bytes)", sizeof(FontDownloadActivity));
     return;

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "SilentRestart.h"
 #include "TextSettingsPreview.h"
 #include "activities/Activity.h"
 #include "components/OptionPopup.h"
@@ -23,7 +24,7 @@ class TextSettingsActivity final : public Activity {
   enum class Tab : uint8_t { Family, Size, Layout, Style, Count };
 
   TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const SdCardFontRegistry* registry,
-                       Tab initialTab = Tab::Family);
+                       Tab initialTab, SilentRestartTarget restartTarget);
 
   void onEnter() override;
   void onExit() override;
@@ -93,6 +94,7 @@ class TextSettingsActivity final : public Activity {
   };
 
   const SdCardFontRegistry* registry_;
+  const SilentRestartTarget restartTarget_;
   ButtonNavigator buttonNavigator_;
   OptionPopup optionPopup_;
   std::vector<TabInfo> tabs_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,9 +29,11 @@
 #include "ReadingStatsStore.h"
 #include "RecentBooksStore.h"
 #include "SdCardFontSystem.h"
+#include "SilentRestart.h"
 #include "activities/Activity.h"
 #include "activities/ActivityManager.h"
 #include "activities/settings/SdFirmwareUpdateActivity.h"
+#include "activities/settings/SettingsActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "images/LoadingIcon.h"
@@ -238,8 +240,6 @@ unsigned long t2 = 0;
 RTC_NOINIT_ATTR uint32_t silentRebootMagic;
 RTC_NOINIT_ATTR uint32_t silentRebootTarget;
 constexpr uint32_t SILENT_REBOOT_MAGIC = 0xC1EAB007;
-constexpr uint32_t SILENT_REBOOT_TARGET_HOME = 0;
-constexpr uint32_t SILENT_REBOOT_TARGET_READER = 1;
 
 // How the device is coming back to life, resolved once at boot. Both resume
 // flows suppress the splash and leave the panel holding its pre-boot frame; a
@@ -258,28 +258,57 @@ enum class BootResume : uint8_t {
 // startDeepSleep() does not return, so a set latch only ends at the wakeup reset.
 static bool deepSleepInProgress = false;
 
-void silentRestart() {
+void silentRestart(const SilentRestartTarget target) {
   if (deepSleepInProgress) return;  // sleeping supersedes the heap-defrag reboot
-  silentRebootTarget = SILENT_REBOOT_TARGET_HOME;
+  silentRebootTarget = static_cast<uint32_t>(target);
   silentRebootMagic = SILENT_REBOOT_MAGIC;
-  LOG_DBG("MAIN", "Silent restart (target=home)");
-  // E-ink retains the previous frame until Home's first paint lands (~2-3s).
+  LOG_DBG("MAIN", "Silent restart (target=%u)", static_cast<unsigned>(target));
+  // E-ink retains the previous frame until the target's first paint lands (~2-3s).
   // Without an overlay, users don't see the reboot and fire input through to
-  // Home. Select on the default selectorIndex=0 then opens the most-recent
-  // book, looking like a trampoline back to the reader they just exited.
+  // the target. On Home, Select on the default selectorIndex=0 can then open
+  // the most-recent book, looking like a trampoline back to the reader.
   GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
   delay(50);
   ESP.restart();
 }
 
-void silentRestartToReader() {
-  if (deepSleepInProgress) return;  // sleeping supersedes the heap-defrag reboot
-  silentRebootTarget = SILENT_REBOOT_TARGET_READER;
-  silentRebootMagic = SILENT_REBOOT_MAGIC;
-  LOG_DBG("MAIN", "Silent restart (target=reader)");
-  GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
-  delay(50);
-  ESP.restart();
+static void goToSilentRestartTarget(const SilentRestartTarget target) {
+  switch (target) {
+    case SilentRestartTarget::Home:
+      activityManager.goHome();
+      return;
+    case SilentRestartTarget::HomeOpds:
+      activityManager.goHome(HomeMenuItem::OPDS_BROWSER);
+      return;
+    case SilentRestartTarget::HomeFileTransfer:
+      activityManager.goHome(HomeMenuItem::FILE_TRANSFER);
+      return;
+    case SilentRestartTarget::SettingsCheckUpdates:
+      activityManager.goToSettings(SettingAction::CheckForUpdates);
+      return;
+    case SilentRestartTarget::SettingsManageFonts:
+      activityManager.goToSettings(SettingAction::DownloadFonts);
+      return;
+    case SilentRestartTarget::SettingsText:
+      activityManager.goToSettings(SettingAction::TextSettings);
+      return;
+    case SilentRestartTarget::SettingsDateTime:
+      activityManager.goToSettings(SettingAction::DateTime);
+      return;
+    case SilentRestartTarget::SettingsKOReader:
+      activityManager.goToSettings(SettingAction::KOReaderSync);
+      return;
+    case SilentRestartTarget::Reader:
+      if (!APP_STATE.openEpubPath.empty() && Storage.exists(APP_STATE.openEpubPath.c_str())) {
+        activityManager.goToReader(APP_STATE.openEpubPath);
+      } else {
+        activityManager.goHome();
+      }
+      return;
+    case SilentRestartTarget::Count:
+      activityManager.goHome();
+      return;
+  }
 }
 
 void waitForPowerRelease() {
@@ -413,8 +442,8 @@ void setup() {
   // Read-and-clear so a panic later in setup() doesn't loop into silent reboot.
   // Bound the target range too — RTC_NOINIT memory is uninitialized on cold boot.
   const bool isSilentReboot = (silentRebootMagic == SILENT_REBOOT_MAGIC);
-  const uint32_t snapshotTarget =
-      (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_READER) ? silentRebootTarget : 0;
+  const SilentRestartTarget snapshotTarget =
+      isSilentReboot ? decodeSilentRestartTarget(silentRebootTarget) : SilentRestartTarget::Home;
   silentRebootMagic = 0;
   silentRebootTarget = 0;
 
@@ -558,14 +587,10 @@ void setup() {
     activityManager.goToCrashReport();
   } else if (postOtaBoot) {
     activityManager.goHome();
-  } else if (resume == BootResume::Silent && snapshotTarget == SILENT_REBOOT_TARGET_READER &&
-             !APP_STATE.openEpubPath.empty()) {
-    activityManager.goToReader(APP_STATE.openEpubPath);
   } else if (resume == BootResume::Silent) {
-    // target == home (or reader with no open book): land on home — don't fall
-    // through to the sleep-wake "resume reader" logic, which fires on stale
-    // openEpubPath + lastSleepFromReader from a prior session.
-    activityManager.goHome();
+    // Don't fall through to the sleep-wake reader-resume logic, which can fire
+    // on stale openEpubPath + lastSleepFromReader from a prior session.
+    goToSilentRestartTarget(snapshotTarget);
   } else if (APP_STATE.openEpubPath.empty() || !APP_STATE.lastSleepFromReader ||
              mappedInputManager.isPressed(MappedInputManager::Button::Back) || APP_STATE.readerActivityLoadCount > 0) {
     // Boot to home screen if no book is open, last sleep was not from reader, back button is held, or reader activity


### PR DESCRIPTION
## Summary

- Preserve the semantic destination in the existing RTC NOINIT restart target and route directly to the relevant Home, Settings, or Reader location.
- Restore Settings selection by SettingAction and thread the return target through Wi-Fi restart flows.
- Keep one-shot consumption, safe fallback for unknown targets or missing reader paths, and existing deep-sleep, OTA, loading, and input-absorption behavior. No new Flash writes or heap allocations.

## Testing

- pio run
- pio run -e gh_release_cn
- git diff --check
- Hardware interaction matrix not run; requires device verification.