### PR TITLE
feat: unify WeRead shelf navigation

### DIFF
--- a/src/activities/apps/weread/WeReadActivity.cpp
+++ b/src/activities/apps/weread/WeReadActivity.cpp
@@ -92,42 +92,12 @@ constexpr int kLandscapeShelfRows = 2;
 constexpr unsigned long kShelfPageHoldMs = 700;
 constexpr int kNoShelfSelection = -1;
 
-enum class ShelfVerticalDirection : uint8_t { Up, Down };
-
-constexpr int shelfVerticalIndex(const int currentIndex, const int totalItems, const int columns,
-                                 const int itemsPerPage, const ShelfVerticalDirection direction) {
-  if (currentIndex < 0 || currentIndex >= totalItems || columns <= 0 || itemsPerPage < columns) return 0;
-
-  const int pageStart = currentIndex / itemsPerPage * itemsPerPage;
-  const int pageEnd = std::min(pageStart + itemsPerPage, totalItems);
-  const int pageIndex = currentIndex - pageStart;
-  const int column = pageIndex % columns;
-
-  switch (direction) {
-    case ShelfVerticalDirection::Up:
-      if (pageIndex >= columns) return currentIndex - columns;
-      return pageStart > 0 ? pageStart - columns + column : currentIndex;
-    case ShelfVerticalDirection::Down: {
-      const int nextRowIndex = currentIndex + columns;
-      if (nextRowIndex < pageEnd) return nextRowIndex;
-      const int currentRowStart = pageStart + pageIndex / columns * columns;
-      const int lastRowStart = pageStart + (pageEnd - pageStart - 1) / columns * columns;
-      if (currentRowStart < lastRowStart) return pageEnd - 1;
-      if (pageEnd >= totalItems) return currentIndex;
-      return std::min(pageEnd + column, totalItems - 1);
-    }
-  }
-  return currentIndex;
+constexpr int previousShelfIndexOrTab(const int currentIndex) {
+  return currentIndex > 0 ? currentIndex - 1 : kNoShelfSelection;
 }
 
-static_assert(shelfVerticalIndex(1, 20, 3, 9, ShelfVerticalDirection::Down) == 4);
-static_assert(shelfVerticalIndex(7, 20, 3, 9, ShelfVerticalDirection::Down) == 10);
-static_assert(shelfVerticalIndex(8, 11, 3, 9, ShelfVerticalDirection::Down) == 10);
-static_assert(shelfVerticalIndex(10, 20, 3, 9, ShelfVerticalDirection::Up) == 7);
-static_assert(shelfVerticalIndex(1, 20, 3, 9, ShelfVerticalDirection::Up) == 1);
-static_assert(shelfVerticalIndex(10, 11, 3, 9, ShelfVerticalDirection::Down) == 10);
-static_assert(shelfVerticalIndex(10, 13, 3, 9, ShelfVerticalDirection::Down) == 12);
-static_assert(shelfVerticalIndex(7, 14, 5, 10, ShelfVerticalDirection::Down) == 12);
+static_assert(previousShelfIndexOrTab(0) == kNoShelfSelection);
+static_assert(previousShelfIndexOrTab(4) == 3);
 
 constexpr bool canIncrementShelfFrame(const int frameSelection, const int frameItemsPerPage, const int selectedIndex,
                                       const int itemsPerPage) {
@@ -1488,63 +1458,67 @@ void WeReadActivity::handleShelfInput() {
   const auto layout =
       shelfGridLayout(renderer, mainContentBounds(), metrics.contentSidePadding, metrics.verticalSpacing);
   const int itemsPerPage = layout.itemsPerPage;
-  const int columns = layout.columns;
 
-  switch (shelfSideGesture_) {
-    case ShelfSideGesture::Idle:
-      if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
-        shelfSideGesture_ = ShelfSideGesture::UpPressed;
-      } else if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
-        shelfSideGesture_ = ShelfSideGesture::DownPressed;
+  switch (shelfNavigationGesture_) {
+    case ShelfNavigationGesture::Idle:
+      if (mappedInput.wasPressed(MappedInputManager::Button::NavPrevious)) {
+        shelfNavigationGesture_ = ShelfNavigationGesture::PreviousPressed;
+      } else if (mappedInput.wasPressed(MappedInputManager::Button::NavNext)) {
+        shelfNavigationGesture_ = ShelfNavigationGesture::NextPressed;
       } else {
         break;
       }
       return;
-    case ShelfSideGesture::UpPressed:
-    case ShelfSideGesture::DownPressed: {
-      const bool movingUp = shelfSideGesture_ == ShelfSideGesture::UpPressed;
-      const auto button = movingUp ? MappedInputManager::Button::Up : MappedInputManager::Button::Down;
-      const auto direction = movingUp ? ShelfVerticalDirection::Up : ShelfVerticalDirection::Down;
+    case ShelfNavigationGesture::PreviousPressed:
+    case ShelfNavigationGesture::NextPressed:
+    case ShelfNavigationGesture::PreviousPageHandled:
+    case ShelfNavigationGesture::NextPageHandled: {
+      const bool previous = shelfNavigationGesture_ == ShelfNavigationGesture::PreviousPressed ||
+                            shelfNavigationGesture_ == ShelfNavigationGesture::PreviousPageHandled;
+      const bool pageHandled = shelfNavigationGesture_ == ShelfNavigationGesture::PreviousPageHandled ||
+                               shelfNavigationGesture_ == ShelfNavigationGesture::NextPageHandled;
+      const auto button = previous ? MappedInputManager::Button::NavPrevious : MappedInputManager::Button::NavNext;
       if (mappedInput.wasReleased(button)) {
-        shelfSideGesture_ = ShelfSideGesture::Idle;
+        shelfNavigationGesture_ = ShelfNavigationGesture::Idle;
+        shelfLastPageTurnAt_ = 0;
+        if (pageHandled) return;
+
         const int selected = shelfSelected_.load();
-        if (movingUp && selected < columns) {
+        const int target = previous ? previousShelfIndexOrTab(selected) : ButtonNavigator::nextIndex(selected, count);
+        if (target == kNoShelfSelection) {
           mainFocus_.store(MainFocus::Tabs);
           requestUpdate();
           return;
         }
-        moveShelfSelection(shelfVerticalIndex(selected, count, columns, itemsPerPage, direction), itemsPerPage);
+        moveShelfSelection(target, itemsPerPage);
         return;
       }
-      if (mappedInput.isPressed(button) && mappedInput.getHeldTime() >= kShelfPageHoldMs) {
-        shelfSideGesture_ = ShelfSideGesture::PageHandled;
-        if (count > itemsPerPage) {
-          const int selected = shelfSelected_.load();
-          const int target = movingUp ? ButtonNavigator::previousPageIndex(selected, count, itemsPerPage)
-                                      : ButtonNavigator::nextPageIndex(selected, count, itemsPerPage);
-          moveShelfSelection(target, itemsPerPage);
-        }
+
+      if (!mappedInput.isPressed(button)) {
+        shelfNavigationGesture_ = ShelfNavigationGesture::Idle;
+        shelfLastPageTurnAt_ = 0;
+        return;
+      }
+
+      const uint32_t now = millis();
+      if ((!pageHandled && mappedInput.getHeldTime() < kShelfPageHoldMs) ||
+          (pageHandled && now - shelfLastPageTurnAt_ < kShelfPageHoldMs)) {
+        return;
+      }
+
+      shelfNavigationGesture_ =
+          previous ? ShelfNavigationGesture::PreviousPageHandled : ShelfNavigationGesture::NextPageHandled;
+      shelfLastPageTurnAt_ = now;
+      if (count > itemsPerPage) {
+        const int selected = shelfSelected_.load();
+        const int target = previous ? ButtonNavigator::previousPageIndex(selected, count, itemsPerPage)
+                                    : ButtonNavigator::nextPageIndex(selected, count, itemsPerPage);
+        moveShelfSelection(target, itemsPerPage);
       }
       return;
     }
-    case ShelfSideGesture::PageHandled:
-      if (!mappedInput.isPressed(MappedInputManager::Button::Up) &&
-          !mappedInput.isPressed(MappedInputManager::Button::Down)) {
-        shelfSideGesture_ = ShelfSideGesture::Idle;
-      }
-      return;
   }
 
-  const bool swapFrontDirections = mappedInput.isNavDirectionSwapped();
-  const auto previousButton =
-      swapFrontDirections ? MappedInputManager::Button::Right : MappedInputManager::Button::Left;
-  const auto nextButton = swapFrontDirections ? MappedInputManager::Button::Left : MappedInputManager::Button::Right;
-  buttonNavigator_.onPressAndContinuous({previousButton}, [this, count, itemsPerPage] {
-    moveShelfSelection(ButtonNavigator::previousIndex(shelfSelected_.load(), count), itemsPerPage);
-  });
-  buttonNavigator_.onPressAndContinuous({nextButton}, [this, count, itemsPerPage] {
-    moveShelfSelection(ButtonNavigator::nextIndex(shelfSelected_.load(), count), itemsPerPage);
-  });
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     resetShelfCoverLoading();
     activateSelected();

--- a/src/activities/apps/weread/WeReadActivity.h
+++ b/src/activities/apps/weread/WeReadActivity.h
@@ -49,7 +49,13 @@ class WeReadActivity final : public Activity {
   enum class Job : uint8_t { Sync, Detail, Download };
   enum class DetailAction : uint8_t { Introduction, Read, Browse, Cache, Images };
   enum class PostProcessNotice : uint8_t { None, Waiting, LongWait };
-  enum class ShelfSideGesture : uint8_t { Idle, UpPressed, DownPressed, PageHandled };
+  enum class ShelfNavigationGesture : uint8_t {
+    Idle,
+    PreviousPressed,
+    NextPressed,
+    PreviousPageHandled,
+    NextPageHandled
+  };
   static constexpr int kDetailActionCount = 5;
   static constexpr int kDetailListActionCount = kDetailActionCount - 1;
   static constexpr int kMaxIntroPages = 128;
@@ -78,7 +84,8 @@ class WeReadActivity final : public Activity {
   std::atomic<bool> shelfFrameInvalidated_{true};
   int shelfCoverPageStart_ = -1;
   int shelfCoverCursor_ = 0;
-  ShelfSideGesture shelfSideGesture_ = ShelfSideGesture::Idle;
+  ShelfNavigationGesture shelfNavigationGesture_ = ShelfNavigationGesture::Idle;
+  uint32_t shelfLastPageTurnAt_ = 0;
   int detailSelected_ = 0;
   int introPage_ = 0;
   int introPageCount_ = 1;


### PR DESCRIPTION
## Summary

* **Goal:** Make all four direction buttons use the same linear navigation behavior on the WeRead shelf.
* **Changes:** Left/up move to the previous book, right/down move to the next book, moving previous from the first book returns focus to the top tabs, and holding any direction button turns full pages repeatedly at the existing 700 ms interval. A handled long press does not trigger an extra short-press action on release.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this fixes navigation inside CrossMux's existing WeRead shelf).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, so maintainer coordination for those areas is not required.

Phase 0 history: Not applicable.

## Additional Context

* Validation:
  * `git diff --check`
  * `pio run -e gh_release_cn`
  * `pio run -e simulator`
* The simulator build reports pre-existing exhaustive-switch warnings in unrelated files; `WeReadActivity` introduces no new warning.
* No new dependency, heap allocation, or public API is introduced. Memory impact is one `uint32_t` gesture timestamp in `WeReadActivity`.
* Hardware verification of short/long presses, continuous page turns, and first/last-page wrapping is still pending, so this PR is opened as a draft.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
