### PR TITLE
fix(web): stabilize large file-manager responses

### DIFF
--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -97,6 +97,25 @@ clang-format -i src/**/*.cpp src/**/*.h
    - Add `vTaskDelay(1)` in tight loops
    - Check for blocking I/O operations
 
+### Distinguishing TCP Stalls, Watchdogs, and Restarts
+
+- A task-watchdog failure prints the task watchdog banner and subscribed task
+  names before the register dump. A later `RTC_SW_CPU_RST` is the panic restart
+  path; it does not make the original failure an intentional software restart.
+- A normal software restart has no preceding watchdog or panic report. Check
+  the earlier application log for an expected transition such as leaving
+  network mode before treating the reset reason itself as a crash.
+- A slow HTTP reader can fill the TCP send window and keep a synchronous SDK
+  write waiting for several seconds. Correlate the request URI and elapsed
+  time with the serial log. Do not classify this as OOM solely from the minimum
+  historical heap value; also inspect current free heap and the largest
+  allocatable block.
+- Web request handlers execute on the task that calls `handleClient()`. Do not
+  subscribe that task to the task watchdog merely so handlers can feed it: a
+  legitimate SDK network wait can then be misclassified as a CPU lockup. Keep
+  explicit watchdog resets conditional so other platform configurations remain
+  compatible.
+
 **Verification Steps**:
 1. Check serial output for stack traces
 2. Monitor heap with `ESP.getFreeHeap()` before/after operations

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,7 @@ This document shows common issues and possible solutions while using the device 
 - [Troubleshooting](#troubleshooting)
     - [Cannot See the Device on the Network](#cannot-see-the-device-on-the-network)
     - [Connection Drops or Times Out](#connection-drops-or-times-out)
+    - [Large File List Stalls](#large-file-list-stalls)
     - [Upload Fails](#upload-fails)
     - [Saved Password Not Working](#saved-password-not-working)
 
@@ -35,6 +36,27 @@ This document shows common issues and possible solutions while using the device 
 2. Check signal strength on the device (should be at least `||` or better)
 3. Avoid interference from other devices
 4. Try a different Wi-Fi network if available
+
+### Large File List Stalls
+
+**Problem:** The file manager remains loading, disconnects, or the device
+restarts when the SD card contains hundreds of entries.
+
+**Checks:**
+
+1. Keep a serial monitor open and look for a task-watchdog banner, panic, or an
+   unexpected boot sequence. Record the current free heap and largest
+   allocatable block before and after repeated requests.
+2. In the browser Network panel, confirm `/api/status` completes before
+   `/api/files` begins. Inspect the `/api/files` status and whether its chunked
+   response finishes.
+3. Repeat with a small directory and a 200--500 entry directory. A valid
+   response must parse as one JSON array, including empty directories.
+4. To diagnose a slow client, pause reading an HTTP response for more than ten
+   seconds. A compressed page response may be aborted, but the device should
+   remain running and accept a later request.
+5. If `/api/files` returns HTTP `503`, restart network mode and inspect the
+   startup log for failure to reserve the 1400-byte file-list buffer.
 
 ### Upload Fails
 

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -85,6 +85,12 @@ Response:
 Hidden dotfiles are omitted unless the device setting `showHiddenFiles` is
 enabled. `System Volume Information` and `XTCache` are always hidden/protected.
 
+The response schema is unchanged for large directories. Entries are scanned
+once and streamed as a chunked response in bounded batches, so the complete
+listing is never retained in RAM. If the server could not reserve its 1400-byte
+batch buffer when network mode started, this endpoint returns HTTP `503` with
+`{"error":"Insufficient memory"}` instead of starting a partial JSON response.
+
 ### `GET /download`
 
 Downloads a file from the SD card.

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -5,6 +5,7 @@
 #include <HalGPIO.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_efuse.h>
 #include <esp_efuse_table.h>
@@ -46,6 +47,7 @@ namespace {
 constexpr const char* HIDDEN_ITEMS[] = {"System Volume Information", "XTCache"};
 constexpr uint16_t UDP_PORTS[] = {54982, 48123, 39001, 44044, 59678};
 constexpr uint16_t LOCAL_UDP_PORT = 8134;
+constexpr size_t FILE_LIST_BATCH_CAPACITY = 1400;
 
 // Static pointer for WebSocket callback (WebSocketsServer requires C-style callback)
 CrossPointWebServer* wsInstance = nullptr;
@@ -218,6 +220,11 @@ void CrossPointWebServer::begin() {
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
 
+  // Reuse one request buffer for the server lifetime to avoid repeated heap churn.
+  fileListBatch = makeUniqueNoThrow<char[]>(FILE_LIST_BATCH_CAPACITY);
+  if (!fileListBatch) {
+    LOG_ERR("WEB", "OOM: %zu-byte file list response buffer", FILE_LIST_BATCH_CAPACITY);
+  }
 
   running = true;
 
@@ -248,6 +255,7 @@ void CrossPointWebServer::abortWsUpload(const char* tag) {
 void CrossPointWebServer::stop() {
   if (!running || !server) {
     LOG_DBG("WEB", "stop() called but already stopped (running=%d, server=%p)", running, server.get());
+    fileListBatch.reset();
     return;
   }
 
@@ -285,6 +293,7 @@ void CrossPointWebServer::stop() {
   delay(10);
 
   server.reset();
+  fileListBatch.reset();
   LOG_DBG("WEB", "Web server stopped and deleted");
   LOG_DBG("WEB", "[MEM] Free heap after delete server: %d bytes", ESP.getFreeHeap());
 
@@ -488,7 +497,7 @@ void CrossPointWebServer::handleStatus() const {
   server->send(200, "application/json", response);
 }
 
-void CrossPointWebServer::scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const {
+void CrossPointWebServer::scanFiles(const char* path, const std::function<bool(const FileInfo&)>& callback) const {
   HalFile root = Storage.open(path);
   if (!root) {
     LOG_DBG("WEB", "Failed to open directory: %s", path);
@@ -506,6 +515,7 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
   HalFile file = root.openNextFile();
   char name[500];
   while (file) {
+    bool keepScanning = true;
     file.getName(name, sizeof(name));
     auto fileName = String(name);
 
@@ -535,10 +545,11 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
         info.isEpub = isEpubFile(info.name);
       }
 
-      callback(info);
+      keepScanning = callback(info);
     }
 
     file.close();
+    if (!keepScanning) break;
     yield();                          // Yield to allow WiFi and other tasks to process during long scans
     resetTaskWatchdogIfSubscribed();  // Reset watchdog to prevent timeout on large directories
     file = root.openNextFile();
@@ -567,39 +578,98 @@ void CrossPointWebServer::handleFileListData() const {
     }
   }
 
-  server->setContentLength(CONTENT_LENGTH_UNKNOWN);
-  server->send(200, "application/json", "");
-  server->sendContent("[");
+  if (!fileListBatch) {
+    LOG_ERR("WEB", "Cannot serve file list: %zu-byte response buffer unavailable", FILE_LIST_BATCH_CAPACITY);
+    server->send(503, "application/json", "{\"error\":\"Insufficient memory\"}");
+    return;
+  }
+
   char output[512];
   constexpr size_t outputSize = sizeof(output);
-  bool seenFirst = false;
   JsonDocument doc;
-
-  scanFiles(currentPath.c_str(), [this, &output, &doc, seenFirst](const FileInfo& info) mutable {
+  const auto serializeFileInfo = [&](const FileInfo& info) {
     doc.clear();
     doc["name"] = info.name;
     doc["size"] = info.size;
     doc["isDirectory"] = info.isDirectory;
     doc["isEpub"] = info.isEpub;
 
-    const size_t written = serializeJson(doc, output, outputSize);
-    if (written >= outputSize) {
-      // JSON output truncated; skip this entry to avoid sending malformed JSON
+    const size_t measured = measureJson(doc);
+    if (measured >= outputSize) {
       LOG_DBG("WEB", "Skipping file entry with oversized JSON for name: %s", info.name.c_str());
-      return;
+      return static_cast<size_t>(0);
     }
 
-    if (seenFirst) {
-      server->sendContent(",");
-    } else {
-      seenFirst = true;
-    }
-    server->sendContent(output);
-  });
-  server->sendContent("]");
-  // End of streamed response, empty chunk to signal client
+    const size_t written = serializeJson(doc, output, outputSize);
+    return written;
+  };
+
+  const unsigned long responseStart = millis();
+#ifdef SIMULATOR
+  server->setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server->send(200, "application/json", "");
+#else
+  server->chunkResponseBegin("application/json");
+#endif
+
+  char* batch = fileListBatch.get();
+  size_t batchLen = 0;
+  size_t entryCount = 0;
+  size_t responseBytes = 0;
+  bool responseOpen = server->client().connected();
+  const auto flushBatch = [&]() {
+    if (batchLen == 0) return true;
+#ifdef SIMULATOR
+    server->sendContent(batch, batchLen);
+#else
+    server->chunkWrite(batch, batchLen);
+#endif
+    responseBytes += batchLen;
+    batchLen = 0;
+    responseOpen = server->client().connected();
+    return responseOpen;
+  };
+
+  batch[batchLen++] = '[';
+
+  if (responseOpen)
+    scanFiles(currentPath.c_str(), [&](const FileInfo& info) {
+      if (!server->client().connected()) {
+        responseOpen = false;
+        return false;
+      }
+      const size_t written = serializeFileInfo(info);
+      if (written == 0) return true;
+
+      const size_t required = written + (entryCount > 0 ? 1 : 0);
+      if (batchLen + required > FILE_LIST_BATCH_CAPACITY && !flushBatch()) return false;
+      if (entryCount > 0) batch[batchLen++] = ',';
+      memcpy(batch + batchLen, output, written);
+      batchLen += written;
+      ++entryCount;
+      return true;
+    });
+
+  if (responseOpen) {
+    if (batchLen + 1 > FILE_LIST_BATCH_CAPACITY) flushBatch();
+  }
+  if (responseOpen) {
+    batch[batchLen++] = ']';
+    flushBatch();
+  }
+
+  // Always finish the framework's chunked-response state, including disconnects.
+#ifdef SIMULATOR
   server->sendContent("");
-  LOG_DBG("WEB", "Served file listing page for path: %s", currentPath.c_str());
+#else
+  server->chunkResponseEnd();
+#endif
+  const unsigned long elapsed = millis() - responseStart;
+  if (responseOpen) {
+    LOG_INF("WEB", "Served %zu file entries (%zu bytes) in %lu ms", entryCount, responseBytes, elapsed);
+  } else {
+    LOG_ERR("WEB", "File list client disconnected after %zu entries and %lu ms", entryCount, elapsed);
+  }
 }
 
 void CrossPointWebServer::handleDownload() const {

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -212,13 +212,6 @@ void CrossPointWebServer::begin() {
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
 
-  // All request handlers run on the task that calls handleClient(). Register
-  // that task before any handler can call esp_task_wdt_reset().
-  const esp_err_t watchdogResult = esp_task_wdt_add(nullptr);
-  watchdogTaskRegistered = watchdogResult == ESP_OK;
-  if (!watchdogTaskRegistered) {
-    LOG_ERR("WEB", "Failed to register web server task with watchdog: %s", esp_err_to_name(watchdogResult));
-  }
 
   running = true;
 
@@ -249,10 +242,6 @@ void CrossPointWebServer::abortWsUpload(const char* tag) {
 void CrossPointWebServer::stop() {
   if (!running || !server) {
     LOG_DBG("WEB", "stop() called but already stopped (running=%d, server=%p)", running, server.get());
-    if (watchdogTaskRegistered) {
-      esp_task_wdt_delete(nullptr);
-      watchdogTaskRegistered = false;
-    }
     return;
   }
 
@@ -292,11 +281,6 @@ void CrossPointWebServer::stop() {
   server.reset();
   LOG_DBG("WEB", "Web server stopped and deleted");
   LOG_DBG("WEB", "[MEM] Free heap after delete server: %d bytes", ESP.getFreeHeap());
-
-  if (watchdogTaskRegistered) {
-    esp_task_wdt_delete(nullptr);
-    watchdogTaskRegistered = false;
-  }
 
   // Note: Static upload variables (uploadFileName, uploadPath, uploadError) are declared
   // later in the file and will be cleared when they go out of scope or on next upload

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -8,9 +8,15 @@
 #include <WiFi.h>
 #include <esp_efuse.h>
 #include <esp_efuse_table.h>
+#ifndef SIMULATOR
+#include <lwip/sockets.h>
+#endif
 
 #include <algorithm>
 #include <cctype>
+#ifndef SIMULATOR
+#include <cerrno>
+#endif
 
 #include "CrossPointSettings.h"
 #include "FontInstaller.h"
@@ -349,20 +355,76 @@ CrossPointWebServer::WsUploadStatus CrossPointWebServer::getWsUploadStatus() con
   return status;
 }
 
-static void sendHtmlContent(WebServer* server, const char* data, size_t len) {
+#ifndef SIMULATOR
+static bool writeClientWithDeadline(NetworkClient& client, const char* data, size_t length,
+                                    unsigned long responseStart) {
+  constexpr unsigned long SEND_STALL_MS = 10000;
+  constexpr unsigned long RESPONSE_DEADLINE_MS = 60000;
+  size_t offset = 0;
+  unsigned long lastProgress = millis();
+
+  while (offset < length) {
+    const unsigned long now = millis();
+    if (now - lastProgress >= SEND_STALL_MS || now - responseStart >= RESPONSE_DEADLINE_MS) return false;
+
+    const int socketFd = client.fd();
+    if (socketFd < 0) return false;
+
+    const ssize_t written = ::send(socketFd, data + offset, length - offset, MSG_DONTWAIT);
+    if (written > 0) {
+      offset += static_cast<size_t>(written);
+      lastProgress = millis();
+      continue;
+    }
+    if (written == 0 || (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR && errno != ENOMEM)) {
+      return false;
+    }
+    delay(1);
+  }
+  return true;
+}
+#endif
+
+static bool sendCompressedContent(WebServer* server, const char* contentType, const char* data, size_t len) {
+#ifdef SIMULATOR
   server->sendHeader("Content-Encoding", "gzip");
-  server->send_P(200, "text/html", data, len);
+  server->send_P(200, contentType, data, len);
+  return true;
+#else
+  constexpr size_t CHUNK_SIZE = 1400;
+  server->sendHeader("Content-Encoding", "gzip");
+  server->setContentLength(len);
+
+  const unsigned long responseStart = millis();
+  server->send(200, contentType, "");
+  if (!server->client().connected()) {
+    LOG_ERR("WEB", "Aborting %s response header after %lu ms", server->uri().c_str(), millis() - responseStart);
+    server->client().stop();
+    return false;
+  }
+
+  for (size_t offset = 0; offset < len; offset += CHUNK_SIZE) {
+    const size_t chunkLength = std::min(CHUNK_SIZE, len - offset);
+    if (!writeClientWithDeadline(server->client(), data + offset, chunkLength, responseStart)) {
+      LOG_ERR("WEB", "Aborting %s response body after %lu ms", server->uri().c_str(), millis() - responseStart);
+      server->client().stop();
+      return false;
+    }
+  }
+  return true;
+#endif
 }
 
 void CrossPointWebServer::handleRoot() const {
-  sendHtmlContent(server.get(), HomePageHtml, sizeof(HomePageHtml));
-  LOG_DBG("WEB", "Served root page");
+  if (sendCompressedContent(server.get(), "text/html", HomePageHtml, sizeof(HomePageHtml))) {
+    LOG_DBG("WEB", "Served root page");
+  }
 }
 
 void CrossPointWebServer::handleJszip() const {
-  server->sendHeader("Content-Encoding", "gzip");
-  server->send_P(200, "application/javascript", jszip_minJs, jszip_minJsCompressedSize);
-  LOG_DBG("WEB", "Served jszip.min.js");
+  if (sendCompressedContent(server.get(), "application/javascript", jszip_minJs, jszip_minJsCompressedSize)) {
+    LOG_DBG("WEB", "Served jszip.min.js");
+  }
 }
 
 void CrossPointWebServer::handleNotFound() const {
@@ -487,7 +549,7 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
 bool CrossPointWebServer::isEpubFile(const String& filename) const { return FsHelpers::hasEpubExtension(filename); }
 
 void CrossPointWebServer::handleFileList() const {
-  sendHtmlContent(server.get(), FilesPageHtml, sizeof(FilesPageHtml));
+  sendCompressedContent(server.get(), "text/html", FilesPageHtml, sizeof(FilesPageHtml));
 }
 
 void CrossPointWebServer::handleFileListData() const {
@@ -1150,8 +1212,9 @@ void CrossPointWebServer::handleDelete() const {
 }
 
 void CrossPointWebServer::handleSettingsPage() const {
-  sendHtmlContent(server.get(), SettingsPageHtml, sizeof(SettingsPageHtml));
-  LOG_DBG("WEB", "Served settings page");
+  if (sendCompressedContent(server.get(), "text/html", SettingsPageHtml, sizeof(SettingsPageHtml))) {
+    LOG_DBG("WEB", "Served settings page");
+  }
 }
 
 void CrossPointWebServer::handleGetSettings() const {
@@ -1763,8 +1826,9 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
 // --- Font management handlers ---
 
 void CrossPointWebServer::handleFontsPage() const {
-  sendHtmlContent(server.get(), FontsPageHtml, sizeof(FontsPageHtml));
-  LOG_DBG("WEB", "Served fonts page");
+  if (sendCompressedContent(server.get(), "text/html", FontsPageHtml, sizeof(FontsPageHtml))) {
+    LOG_DBG("WEB", "Served fonts page");
+  }
 }
 
 void CrossPointWebServer::handleFontList() const {

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -72,7 +72,6 @@ class CrossPointWebServer {
   std::unique_ptr<WebServer> server = nullptr;
   std::unique_ptr<WebSocketsServer> wsServer = nullptr;
   bool running = false;
-  bool watchdogTaskRegistered = false;
   bool apMode = false;  // true when running in AP mode, false for STA mode
   uint16_t port = 80;
   uint16_t wsPort = 81;  // WebSocket port

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -71,6 +71,7 @@ class CrossPointWebServer {
  private:
   std::unique_ptr<WebServer> server = nullptr;
   std::unique_ptr<WebSocketsServer> wsServer = nullptr;
+  std::unique_ptr<char[]> fileListBatch = nullptr;
   bool running = false;
   bool apMode = false;  // true when running in AP mode, false for STA mode
   uint16_t port = 80;
@@ -84,7 +85,7 @@ class CrossPointWebServer {
   void abortWsUpload(const char* tag);
 
   // File scanning
-  void scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const;
+  void scanFiles(const char* path, const std::function<bool(const FileInfo&)>& callback) const;
   String formatFileSize(size_t bytes) const;
   bool isEpubFile(const String& filename) const;
 

--- a/src/network/html/en/FilesPage.html
+++ b/src/network/html/en/FilesPage.html
@@ -1934,8 +1934,8 @@
   }
 
   async function hydrate() {
-    // Fetch CrossPoint version
-    fetchVersion();
+    // Sequential: parallel connections can stall the device's single-client web server.
+    await fetchVersion();
 
     // Close modals when clicking overlay - call proper cleanup functions
     document.querySelectorAll('.modal-overlay').forEach(function(overlay) {

--- a/src/network/html/zh-CN/FilesPage.html
+++ b/src/network/html/zh-CN/FilesPage.html
@@ -1911,8 +1911,8 @@
   }
 
   async function hydrate() {
-    // Fetch CrossPoint version
-    fetchVersion();
+    // Sequential: parallel connections can stall the device's single-client web server.
+    await fetchVersion();
 
     // Close modals when clicking overlay - call proper cleanup functions
     document.querySelectorAll('.modal-overlay').forEach(function(overlay) {


### PR DESCRIPTION
## Summary

- stop subscribing the Arduino loop task to TWDT during Web service lifetime
- bound compressed static-resource socket writes while restoring native single-pass chunked JSON streaming for `/api/files`
- serialize status and file-list page initialization and document diagnosis/verification

## Validation

- `./bin/clang-format-fix -g --check`
- `git diff --check`
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`
- CMake/Ninja unit tests: 287/287 passed
- `pio run -e default -e sticky -e simulator -e simulator_x3`
- `pio run -e gh_release_cn`
- GitHub Actions: all checks passed

## X3 hardware validation

Flashed the final `gh_release_cn` image (`d73730e47a424a3df68fedff20bdf208d8a33a24100fe408b59d2e74a30f23d5`) over USB and monitored at 115200 baud.

- repeated 23-entry responses completed in 29–46 ms
- 200 entries / 14,976 bytes completed in 291 ms (about 11 response batches)
- 96 entries / 10,005 bytes completed in 170 ms
- a client navigation aborted `/files` after 823 ms; the device then served another file-list request in 21 ms
- post-request free heap recovered to 41–46 KB, with the largest block at 31–34 KB and no downward trend
- no task watchdog, panic, register dump, or unexpected reset occurred
- observed `RTC_SW_CPU_RST` events were the existing manual-exit `silentRestart()` path, confirmed during the test