### PR TITLE
ci: add A4/M4 hardware beta publishing

### DIFF
--- a/.github/workflows/hardware-beta.yml
+++ b/.github/workflows/hardware-beta.yml
@@ -1,0 +1,192 @@
+name: Hardware Beta
+run-name: Hardware Beta / ${{ inputs.device }} / ${{ inputs.action }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      device:
+        description: Hardware target
+        required: true
+        type: choice
+        options:
+          - eego-a4
+          - mofei-m4
+      action:
+        description: Publish or remove the rolling prerelease
+        required: true
+        type: choice
+        options:
+          - publish
+          - unpublish
+
+permissions:
+  contents: write
+
+env:
+  BETA_REF: beta/s3-hardware
+  RELEASE_TAG: hardware-beta-${{ inputs.device }}
+  GITEE_REPO: x1abin/crossmux
+
+jobs:
+  build:
+    if: inputs.action == 'publish'
+    runs-on: h2o
+    outputs:
+      crossmux_sha: ${{ steps.source.outputs.crossmux_sha }}
+      can_publish: ${{ steps.source.outputs.can_publish }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.BETA_REF }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Record and validate source
+        id: source
+        env:
+          A4_REDISTRIBUTION_APPROVED: ${{ vars.A4_REDISTRIBUTION_APPROVED }}
+        run: |
+          set -euo pipefail
+          can_publish=true
+          if [ "${{ inputs.device }}" = "eego-a4" ] && [ "$A4_REDISTRIBUTION_APPROVED" != "true" ]; then
+            echo "::warning::A4 redistribution review is not approved; only the private artifact will be created"
+            can_publish=false
+          fi
+          git -C freeink-sdk fetch origin main:refs/remotes/origin/main
+          sdk_sha="$(git -C freeink-sdk rev-parse HEAD)"
+          if ! git -C freeink-sdk merge-base --is-ancestor "$sdk_sha" origin/main; then
+            echo "::error::SDK gitlink $sdk_sha is not contained in 0x1abin/freeink-sdk main"
+            exit 1
+          fi
+          echo "crossmux_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "can_publish=$can_publish" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: latest
+          enable-cache: false
+
+      - name: Install PlatformIO Core
+        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+
+      - name: Build and package
+        run: |
+          set -euo pipefail
+          case "${{ inputs.device }}" in
+            eego-a4) environment=eego_a4 ;;
+            mofei-m4) environment=mofei_m4 ;;
+            *) exit 2 ;;
+          esac
+          pio run -e "$environment"
+          python3 scripts/package_hardware_beta.py "${{ inputs.device }}"
+          (cd "dist/${{ inputs.device }}" && sha256sum --check SHA256SUMS)
+
+      - name: Upload private build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: hardware-beta-${{ inputs.device }}
+          path: dist/${{ inputs.device }}
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    if: inputs.action == 'publish' && needs.build.outputs.can_publish == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: hardware-beta-${{ inputs.device }}
+          path: dist
+
+      - name: Build release notes
+        run: |
+          cat > release-body.md <<EOF
+          # CrossMux ${{ inputs.device }} hardware beta
+
+          Simplified Chinese experimental build from \`${{ env.BETA_REF }}\`.
+
+          - CrossMux: \`${{ needs.build.outputs.crossmux_sha }}\`
+          - Partition profile: \`crossmux-sticky-v1\`
+          - Flash: ESP32-S3, DIO, 80 MHz, 16 MB
+
+          Back up the complete 16 MB flash before first installation. The recovery image is download-only.
+          EOF
+
+      - name: Publish rolling GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release delete "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          gh release create "$RELEASE_TAG" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "${{ needs.build.outputs.crossmux_sha }}" \
+            --title "CrossMux ${{ inputs.device }} Hardware Beta" \
+            --notes-file release-body.md \
+            --prerelease
+
+      - name: Verify GitHub release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir github-assets
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir github-assets
+          (cd github-assets && sha256sum --check SHA256SUMS)
+
+      - name: Mirror prerelease to Gitee
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: |
+          bash scripts/publish-gitee-release.sh \
+            "$GITEE_REPO" \
+            "$RELEASE_TAG" \
+            "CrossMux ${{ inputs.device }} Hardware Beta" \
+            "true" \
+            "${{ needs.build.outputs.crossmux_sha }}" \
+            release-body.md \
+            dist/*
+
+      - name: Verify Gitee release assets
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: |
+          set -euo pipefail
+          api="https://gitee.com/api/v5/repos/${GITEE_REPO}/releases/tags/${RELEASE_TAG}?access_token=${GITEE_TOKEN}"
+          mkdir gitee-assets
+          curl -fsS "$api" > gitee-release.json
+          while IFS=$'\t' read -r name url; do
+            curl -fsSL "$url" -o "gitee-assets/$name"
+          done < <(jq -r '.assets[] | select(.browser_download_url | contains("/releases/download/")) | [.name, .browser_download_url] | @tsv' gitee-release.json)
+          (cd gitee-assets && sha256sum --check SHA256SUMS)
+
+  unpublish:
+    if: inputs.action == 'unpublish'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+
+      - name: Remove Gitee prerelease
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: |
+          set -euo pipefail
+          api="https://gitee.com/api/v5/repos/${GITEE_REPO}"
+          release_id="$(curl -fsS "${api}/releases/tags/${RELEASE_TAG}?access_token=${GITEE_TOKEN}" | jq -r '.id // empty' || true)"
+          if [ -n "$release_id" ]; then
+            curl -fsS -X DELETE "${api}/releases/${release_id}?access_token=${GITEE_TOKEN}"
+          fi


### PR DESCRIPTION
## Summary

- Add a fixed `hardware-beta.yml` dispatch workflow for `eego-a4` and `mofei-m4`; callers can only choose `publish` or `unpublish`.
- Always build from `beta/s3-hardware`, package the existing manifest/segment/recovery assets, and upload a private CI artifact.
- Require the pinned FreeInk SDK gitlink to be contained in fork `main` before packaging.
- Publish rolling GitHub prereleases, mirror the same assets to Gitee, and verify both copies with `SHA256SUMS`.
- Remove both GitHub and Gitee rolling releases/tags on `unpublish`.

CrossMux base: `ec5190889362d64e4e215e4da7acea571e8ffca7`

Related hardware integration: #123.

## A4 redistribution gate

When `A4_REDISTRIBUTION_APPROVED` is not `true`, the A4 build still produces the private Actions artifact, but the public GitHub/Gitee prerelease job is skipped.

## Validation

- Workflow YAML parses successfully.
- `git diff --check` passes.
- The PR diff contains only `.github/workflows/hardware-beta.yml`.

## Merge and release gates

- Keep this PR Draft until the workflow and repository variables/secrets have been reviewed.
- This workflow must land on the default branch before `/beta-admin` can dispatch it.
- No workflow was dispatched and no Beta Release was created as part of this PR.
- Public A4 publishing remains blocked until the GSL/LUT redistribution review and NOTICE decision are complete.
