### PR TITLE
fix(ci): trigger Gitee mirror before beta publish

### DIFF
--- a/scripts/publish-gitee-release.sh
+++ b/scripts/publish-gitee-release.sh
@@ -43,6 +43,10 @@ if [ -z "${GITEE_TOKEN:-}" ]; then
 fi
 
 if [ "$TAG" != "nightly" ]; then
+  echo "Triggering Gitee pull mirror for ${TAG}"
+  if ! curl -fsS -X POST "${API}/remote_mirror/pull?access_token=${GITEE_TOKEN}" -o /dev/null; then
+    echo "::warning::Gitee pull mirror trigger failed; waiting in case a sync is already running"
+  fi
   gitee_git="https://gitee.com/${REPO}.git"
   for attempt in $(seq 1 30); do
     synced_commit="$(git ls-remote "$gitee_git" "refs/tags/${TAG}^{}" 2>/dev/null | cut -f1)"


### PR DESCRIPTION
## Summary

- Trigger Gitee's configured pull mirror before waiting for a non-nightly release tag.
- Keep the existing bounded tag/commit verification as the hard gate.
- Treat a trigger error as a warning because Gitee rejects duplicate/recent sync requests while an existing sync may still complete.

## Why

The first M4 hardware Beta publish created and verified the GitHub prerelease, but Gitee remained at `main@eb1fac3a` and never received `hardware-beta-mofei-m4`. CrossMux has no GitHub mirror webhook, so passive polling cannot start a manually configured Gitee pull mirror.

Gitee documents `POST /api/v5/repos/:owner/:repo/remote_mirror/pull` as the manual/webhook trigger for a pull mirror: https://gitee.com/help/articles/4336

## Validation

- `bash -n scripts/publish-gitee-release.sh`
- `git diff --check`

After merge, rerun `Hardware Beta / mofei-m4 / publish`; the workflow must still pass the existing Gitee asset SHA-256 verification before the release is considered complete.
