### PR TITLE
fix(ci): push beta tag to Gitee explicitly

### DIFF
--- a/scripts/publish-gitee-release.sh
+++ b/scripts/publish-gitee-release.sh
@@ -43,11 +43,13 @@ if [ -z "${GITEE_TOKEN:-}" ]; then
 fi
 
 if [ "$TAG" != "nightly" ]; then
-  echo "Triggering Gitee pull mirror for ${TAG}"
-  if ! curl -fsS -X POST "${API}/remote_mirror/pull?access_token=${GITEE_TOKEN}" -o /dev/null; then
-    echo "::warning::Gitee pull mirror trigger failed; waiting in case a sync is already running"
-  fi
   gitee_git="https://gitee.com/${REPO}.git"
+  gitee_user="${REPO%%/*}"
+  auth_header="$(printf '%s:%s' "$gitee_user" "$GITEE_TOKEN" | base64 | tr -d '\n')"
+  git fetch origin "$COMMITISH"
+  git -c http.extraHeader="Authorization: Basic ${auth_header}" \
+    push --force "$gitee_git" "${COMMITISH}:refs/tags/${TAG}"
+  unset auth_header
   for attempt in $(seq 1 30); do
     synced_commit="$(git ls-remote "$gitee_git" "refs/tags/${TAG}^{}" 2>/dev/null | cut -f1)"
     if [ -z "$synced_commit" ]; then


### PR DESCRIPTION
## Summary

- Push the rolling non-nightly release tag and its commit object directly to Gitee using the existing `GITEE_TOKEN`.
- Keep the exact Gitee tag/commit verification before creating the mirrored release.
- Remove the remote-mirror trigger added in #133 because `x1abin/crossmux` has no configured Gitee Pull Mirror and the endpoint returns 404.

## Why

Two M4 Beta attempts created and verified the GitHub prerelease but were rolled back because Gitee never received `hardware-beta-mofei-m4`. The second run proved that `/remote_mirror/pull` returns 404 for this repository. A release tag targeting the Beta branch therefore has to be transferred explicitly; the release and attachment API cannot reference a commit that Gitee does not have.

Authentication uses an in-memory HTTP Basic header derived from the Gitee repository owner and the existing masked token. The remote URL and logs do not contain the token.

## Validation

- `bash -n scripts/publish-gitee-release.sh`
- `git diff --check`

After merge, `Hardware Beta / mofei-m4 / publish` remains gated by both GitHub and Gitee `SHA256SUMS` verification.
