### PR TITLE
fix: refine calculator result spacing

### DIFF
--- a/src/activities/apps/calculator/CalculatorActivity.cpp
+++ b/src/activities/apps/calculator/CalculatorActivity.cpp
@@ -15,6 +15,7 @@ constexpr int kRows = 5;
 constexpr int kKeyCount = kColumns * kRows;
 constexpr int kInitialSelection = 9;
 constexpr int kMinimumRoundedKeyGap = 4;
+constexpr int kMinimumSectionSpacing = 12;
 
 constexpr std::array<calculator::Key, kKeyCount> kKeys = {
     calculator::Key::Clear,  calculator::Key::ToggleSign, calculator::Key::Percent,   calculator::Key::Divide,
@@ -37,6 +38,7 @@ struct CalculatorLayout {
 
 CalculatorLayout layoutFor(const GfxRenderer& renderer) {
   const auto& metrics = UITheme::getInstance().getMetrics();
+  const int sectionSpacing = std::max(metrics.verticalSpacing, kMinimumSectionSpacing);
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, true);
   int viewTop, viewRight, viewBottom, viewLeft;
   renderer.getOrientedViewableTRBL(&viewTop, &viewRight, &viewBottom, &viewLeft);
@@ -53,7 +55,7 @@ CalculatorLayout layoutFor(const GfxRenderer& renderer) {
   const int displayHeight = std::max(112, availableHeight / 4);
   const Rect displayArea{left, displayTop, width, displayHeight};
 
-  const int gridTop = displayArea.y + displayArea.height + metrics.verticalSpacing;
+  const int gridTop = displayArea.y + displayArea.height + sectionSpacing;
   const int gap = metrics.optionPopupSelectionRadius > 0
                       ? std::max({kMinimumRoundedKeyGap, metrics.menuSpacing, metrics.keyboardKeySpacing})
                       : 0;
@@ -217,18 +219,19 @@ void CalculatorActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
   const auto& metrics = UITheme::getInstance().getMetrics();
+  const int sectionSpacing = std::max(metrics.verticalSpacing, kMinimumSectionSpacing);
   const CalculatorLayout layout = layoutFor(renderer);
   GUI.drawHeader(renderer, layout.header, tr(STR_CALCULATOR_TITLE));
 
   const char* expression = state_.expressionText();
   const int expressionWidth = renderer.getTextWidth(UI_12_FONT_ID, expression);
-  const int expressionY = layout.display.y + metrics.verticalSpacing;
+  const int expressionY = layout.display.y + sectionSpacing;
   renderer.drawText(UI_12_FONT_ID, layout.display.x + layout.display.width - expressionWidth, expressionY, expression);
 
   const char* result = state_.hasError() ? tr(STR_CALCULATOR_ERROR) : state_.resultText();
   const int resultWidth = renderer.getTextWidth(NOTOSANS_18_FONT_ID, result, EpdFontFamily::BOLD);
-  const int resultHeight = renderer.getTextHeight(NOTOSANS_18_FONT_ID);
-  const int resultY = layout.display.y + layout.display.height - resultHeight - metrics.verticalSpacing;
+  const int resultLineHeight = renderer.getLineHeight(NOTOSANS_18_FONT_ID);
+  const int resultY = layout.display.y + layout.display.height - resultLineHeight - sectionSpacing;
   renderer.drawText(NOTOSANS_18_FONT_ID, layout.display.x + layout.display.width - resultWidth, resultY, result, true,
                     EpdFontFamily::BOLD);
   renderer.drawLine(layout.display.x, layout.display.y + layout.display.height - 1,

--- a/src/activities/apps/calculator/CalculatorActivity.cpp
+++ b/src/activities/apps/calculator/CalculatorActivity.cpp
@@ -234,8 +234,6 @@ void CalculatorActivity::render(RenderLock&&) {
   const int resultY = layout.display.y + layout.display.height - resultLineHeight - sectionSpacing;
   renderer.drawText(NOTOSANS_18_FONT_ID, layout.display.x + layout.display.width - resultWidth, resultY, result, true,
                     EpdFontFamily::BOLD);
-  renderer.drawLine(layout.display.x, layout.display.y + layout.display.height - 1,
-                    layout.display.x + layout.display.width - 1, layout.display.y + layout.display.height - 1, true);
 
   const EpdFontFamily::Style keyStyle =
       metrics.optionPopupOptionFontBold ? EpdFontFamily::BOLD : EpdFontFamily::REGULAR;


### PR DESCRIPTION
## Summary

- carry forward the calculator result/keypad spacing fix after #128, with a theme-independent minimum of 12 px
- remove the divider below the result while preserving the title divider, key borders, and backspace icon
- keep results and the localized error state in bold `NOTOSANS_18_FONT_ID`, the largest existing embedded numeric font size

No font assets, generated files, allocations, public APIs, calculation behavior, or input mappings are added or changed, so this follow-up adds no font-related Flash/RAM cost.

## Validation

- `./bin/clang-format-fix -g --check`
- `git diff --check`
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`
- X4 and X3 simulator builds
- default and sticky firmware builds
- full host suite: 304/304 tests passed
- automated X3/X4 simulator screenshots across Classic, Lyra, Lyra Extended, RoundedRaff, Lyra Carousel, and INX
- visually checked `0`, `100`, a 12-digit result, scientific notation, and the localized error state
