### PR TITLE
fix(weread): detect large TXT metadata

### DIFF
--- a/src/activities/apps/weread/WeReadClient.cpp
+++ b/src/activities/apps/weread/WeReadClient.cpp
@@ -1432,21 +1432,17 @@ bool containsAllowedXhtmlTag(const std::string& path, uint8_t* buffer, const siz
   return true;
 }
 
-bool smallFileContains(const std::string& path, const char* needle) {
+bool probePrimaryResponse(const std::string& path, WeReadProtocol::PrimaryResponseProbe& probe, uint8_t* buffer,
+                          const size_t bufferSize, uint64_t& responseBytes) {
   HalFile file;
-  if (!needle || !needle[0] || !Storage.openFileForRead("WR", path, file) || file.fileSize() > 2048) return false;
-  char buffer[256] = {};
-  size_t carry = 0;
-  while (file.available()) {
-    const int got = file.read(buffer + carry, sizeof(buffer) - 1 - carry);
-    if (got <= 0) break;
-    buffer[carry + static_cast<size_t>(got)] = '\0';
-    if (strstr(buffer, needle)) return true;
-    const size_t keep = std::min(strlen(needle) - 1, carry + static_cast<size_t>(got));
-    memmove(buffer, buffer + carry + static_cast<size_t>(got) - keep, keep);
-    carry = keep;
+  if (!buffer || bufferSize == 0 || !Storage.openFileForRead("WR", path, file)) return false;
+  responseBytes = file.fileSize64();
+  if (!probe.reset()) return false;
+  while (file.available() && !probe.finished()) {
+    const int got = file.read(buffer, bufferSize);
+    if (got <= 0 || !probe.feed(buffer, static_cast<size_t>(got))) return false;
   }
-  return false;
+  return true;
 }
 
 bool smallFileIsEmptyObject(const std::string& path) {
@@ -3563,7 +3559,6 @@ Operation::Event Operation::downloadNextImage() {
 
 Operation::Event Operation::inspectPrimary() {
   const std::string raw0 = bookDir_ + "/shard0.part";
-  if (smallFileContains(raw0, "-2012")) return reauthenticateChapter();
   switch (WeReadProtocol::classifyChapterResponse(responseStatus_, smallFileIsEmptyObject(raw0))) {
     case WeReadProtocol::ChapterResponse::Content:
       break;
@@ -3574,16 +3569,32 @@ Operation::Event Operation::inspectPrimary() {
     case WeReadProtocol::ChapterResponse::Error:
       return fail(Error::Protocol);
   }
-  uint8_t prefix[4] = {};
-  if (!readPrefix(raw0, prefix, sizeof(prefix))) return fail(Error::Integrity);
-  if (prefix[0] == 'P' && prefix[1] == 'K' && prefix[2] == 3 && prefix[3] == 4) {
-    return finishWholeBook(raw0);
+
+  WeReadProtocol::PrimaryResponseProbe probe(url_, sizeof(url_));
+  uint64_t responseBytes = 0;
+  const auto integrityFailure = [this, &responseBytes](const char* classification) {
+    LOG_ERR("WR", "primary invalid: chapter=%u status=%d bytes=%llu class=%s", static_cast<unsigned>(chapterIndex_),
+            responseStatus_, static_cast<unsigned long long>(responseBytes), classification);
+    return fail(Error::Integrity);
+  };
+  if (!probePrimaryResponse(raw0, probe, ioBuffer_, sizeof(ioBuffer_), responseBytes)) {
+    return integrityFailure("read");
   }
-  if (smallFileContains(raw0, "\"bookId\"")) {
+  if (probe.sessionExpired()) return reauthenticateChapter();
+  if (probe.textMetadata()) {
+    LOG_DBG("WR", "primary classified: chapter=%u status=%d bytes=%llu format=txt",
+            static_cast<unsigned>(chapterIndex_), responseStatus_, static_cast<unsigned long long>(responseBytes));
     phase_ = Phase::FetchText0;
     return Event::None;
   }
-  if (!validateShard(raw0)) return fail(Error::Integrity);
+  if (probe.jsonObject()) return integrityFailure("json");
+
+  uint8_t prefix[4] = {};
+  if (!readPrefix(raw0, prefix, sizeof(prefix))) return integrityFailure("short");
+  if (prefix[0] == 'P' && prefix[1] == 'K' && prefix[2] == 3 && prefix[3] == 4) {
+    return finishWholeBook(raw0);
+  }
+  if (!validateShard(raw0)) return integrityFailure("shard");
   phase_ = Phase::FetchEpub1;
   return Event::None;
 }

--- a/src/activities/apps/weread/WeReadProtocol.cpp
+++ b/src/activities/apps/weread/WeReadProtocol.cpp
@@ -596,6 +596,43 @@ bool PsvtsExtractor::feed(const uint8_t* data, const size_t len) {
   return true;
 }
 
+bool PrimaryResponseProbe::reset() {
+  sessionErrorOffset_ = 0;
+  state_ = State::LeadingWhitespace;
+  sessionExpired_ = false;
+  return bookId_.reset();
+}
+
+bool PrimaryResponseProbe::feed(const uint8_t* data, const size_t len) {
+  if (!data && len != 0) return false;
+  size_t jsonOffset = 0;
+  switch (state_) {
+    case State::LeadingWhitespace:
+      while (jsonOffset < len && std::isspace(data[jsonOffset])) ++jsonOffset;
+      if (jsonOffset == len) return true;
+      state_ = data[jsonOffset] == '{' ? State::Json : State::NonJson;
+      if (state_ == State::NonJson) return true;
+      break;
+    case State::Json:
+      break;
+    case State::NonJson:
+      return true;
+  }
+
+  if (!bookId_.feed(data + jsonOffset, len - jsonOffset)) return false;
+  static constexpr char kSessionError[] = "-2012";
+  for (size_t i = jsonOffset; i < len && !sessionExpired_; ++i) {
+    const uint8_t value = data[i];
+    if (value == static_cast<uint8_t>(kSessionError[sessionErrorOffset_])) {
+      ++sessionErrorOffset_;
+      sessionExpired_ = sessionErrorOffset_ == sizeof(kSessionError) - 1;
+    } else {
+      sessionErrorOffset_ = value == static_cast<uint8_t>(kSessionError[0]) ? 1 : 0;
+    }
+  }
+  return true;
+}
+
 bool XhtmlTagProbe::reset() {
   nameLength_ = 0;
   state_ = State::SearchOpen;

--- a/src/activities/apps/weread/WeReadProtocol.h
+++ b/src/activities/apps/weread/WeReadProtocol.h
@@ -122,6 +122,26 @@ class PsvtsExtractor {
   State state_ = State::SearchKey;
 };
 
+class PrimaryResponseProbe {
+ public:
+  PrimaryResponseProbe(char* bookId, size_t bookIdSize) : bookId_(bookId, bookIdSize, "bookId") {}
+
+  bool reset();
+  bool feed(const uint8_t* data, size_t len);
+  bool finished() const { return state_ == State::NonJson || sessionExpired_; }
+  bool jsonObject() const { return state_ == State::Json; }
+  bool textMetadata() const { return jsonObject() && bookId_.complete(); }
+  bool sessionExpired() const { return jsonObject() && sessionExpired_; }
+
+ private:
+  enum class State : uint8_t { LeadingWhitespace, Json, NonJson };
+
+  PsvtsExtractor bookId_;
+  size_t sessionErrorOffset_ = 0;
+  State state_ = State::LeadingWhitespace;
+  bool sessionExpired_ = false;
+};
+
 class XhtmlTagProbe {
  public:
   bool reset();

--- a/test/weread/WeReadProtocolTest.cpp
+++ b/test/weread/WeReadProtocolTest.cpp
@@ -345,6 +345,41 @@ TEST(WeReadProtocol, RejectsMissingInvalidAndOversizedPsvts) {
   EXPECT_STREQ(shortOutput, "");
 }
 
+TEST(WeReadProtocol, ProbesLargeTxtMetadataWithoutMisclassifyingShards) {
+  constexpr size_t markerOffset = 9 * 256 - 1;
+  std::string metadata = R"({"padding":")";
+  metadata.append(markerOffset - metadata.size() - 2, 'x');
+  metadata += R"(","bookId":"CB_GAm03Y0342QR75T75MEvp9F5"})";
+  ASSERT_EQ(metadata.find("\"bookId\""), markerOffset);
+  ASSERT_GT(metadata.size(), 2048U);
+
+  char bookId[64];
+  WeReadProtocol::PrimaryResponseProbe probe(bookId, sizeof(bookId));
+  ASSERT_TRUE(probe.reset());
+  for (size_t offset = 0; offset < metadata.size(); offset += 256) {
+    const size_t count = std::min<size_t>(256, metadata.size() - offset);
+    ASSERT_TRUE(probe.feed(reinterpret_cast<const uint8_t*>(metadata.data() + offset), count));
+  }
+  EXPECT_TRUE(probe.jsonObject());
+  EXPECT_TRUE(probe.textMetadata());
+  EXPECT_FALSE(probe.sessionExpired());
+  EXPECT_STREQ(bookId, "CB_GAm03Y0342QR75T75MEvp9F5");
+
+  constexpr char shard[] = R"(0123456789abcdef0123456789abcdefbody "bookId":"fake")";
+  ASSERT_TRUE(probe.reset());
+  ASSERT_TRUE(probe.feed(reinterpret_cast<const uint8_t*>(shard), sizeof(shard) - 1));
+  EXPECT_TRUE(probe.finished());
+  EXPECT_FALSE(probe.jsonObject());
+  EXPECT_FALSE(probe.textMetadata());
+
+  constexpr char expired[] = R"(
+    {"bookId":"CB_GAm03Y0342QR75T75MEvp9F5","errCode":-2012})";
+  ASSERT_TRUE(probe.reset());
+  ASSERT_TRUE(probe.feed(reinterpret_cast<const uint8_t*>(expired), sizeof(expired) - 1));
+  EXPECT_TRUE(probe.jsonObject());
+  EXPECT_TRUE(probe.sessionExpired());
+}
+
 TEST(WeReadProtocol, DetectsAllowedXhtmlTagsAcrossEveryChunkBoundary) {
   constexpr char xhtml[] = "preview text<div class=\"chapter\">full text</div>";
   for (size_t split = 0; split <= sizeof(xhtml) - 1; ++split) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix WeRead caching for self-imported TXT books whose `e_0` metadata exceeds 2 KiB.
* **What changes are included?**
  * Stream-probe JSON primary responses for `bookId` and `-2012` without a response-size cap.
  * Preserve ZIP, EPUB shard, empty-object, HTTP error, and reauthentication behavior.
  * Add regression coverage for large metadata across read boundaries and non-JSON false positives.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (Not applicable; this PR does not touch those areas.)

## Additional Context

Caching WeRead book `CB_GAm03Y0342QR75T75MEvp9F5` failed after `e_0` with `phase=27 error=7` because TXT metadata larger than 2 KiB was sent through EPUB shard MD5 validation.

The probe reuses the operation's existing I/O and URL buffers. It adds no heap allocation and changes neither public APIs nor cache formats. Diagnostic logs contain only the chapter index, HTTP status, byte count, and response classification.

Verification:

- WeRead host tests: 66/66 passed.
- `./bin/ci-check`: passed (formatting, cppcheck, default/sticky firmware builds, 305/305 host tests).
- `pio run -e gh_release_cn`: passed.
- `git diff --check`: passed.

Device/account verification still required before marking ready:

- Cache `CB_GAm03Y0342QR75T75MEvp9F5` through `e_0 -> t_0 -> t_1` and confirm `/WeRead/*.epub` is generated.
- Cache a normal EPUB as a regression check.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
