### PR TITLE
feat(weread): promote locally opened shelf books

### DIFF
--- a/lib/WeReadWebApi/src/WeReadClient.cpp
+++ b/lib/WeReadWebApi/src/WeReadClient.cpp
@@ -559,7 +559,11 @@ void shelfObjectStart(void* raw) {
 void shelfObjectEnd(void* raw) {
   auto& ctx = *static_cast<ShelfJsonContext*>(raw);
   if (ctx.inBook && ctx.depth == ctx.bookDepth) {
-    if (ctx.current.bookId[0] && !ctx.writer.append(&ctx.current)) ctx.writeFailed = true;
+    if (ctx.current.bookId[0]) {
+      ctx.current.readUpdateTime =
+          std::max(ctx.current.readUpdateTime, WeReadStore::cachedShelfReadUpdateTime(ctx.current.bookId));
+      if (!ctx.writer.append(&ctx.current)) ctx.writeFailed = true;
+    }
     ctx.inBook = false;
     ctx.bookDepth = -1;
   }

--- a/lib/WeReadWebApi/src/WeReadStore.cpp
+++ b/lib/WeReadWebApi/src/WeReadStore.cpp
@@ -425,6 +425,55 @@ ShelfSortResult sortShelfByRecent() {
   return sorted.finish() ? ShelfSortResult::Ok : ShelfSortResult::StorageError;
 }
 
+uint32_t cachedShelfReadUpdateTime(const char* bookId) {
+  if (!bookId || !bookId[0]) return 0;
+  HalFile shelf;
+  uint32_t count = 0;
+  if (!openShelf(shelf, count)) return 0;
+  uint32_t latest = 0;
+  ShelfRecord record;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (!readShelfRecord(shelf, i, record)) return 0;
+    if (strcmp(record.bookId, bookId) == 0) latest = std::max(latest, record.readUpdateTime);
+  }
+  return latest;
+}
+
+ShelfSortResult promoteShelfBook(const char* bookId, const uint32_t timestamp) {
+  if (!bookId || !bookId[0] || timestamp == 0) return ShelfSortResult::Ok;
+  IndexWriter promoted;
+  {
+    HalFile source;
+    uint32_t count = 0;
+    if (!openShelf(source, count)) return ShelfSortResult::StorageError;
+    ShelfRecord selected;
+    uint32_t selectedIndex = count;
+    for (uint32_t i = 0; i < count; ++i) {
+      ShelfRecord record;
+      if (!readShelfRecord(source, i, record)) return ShelfSortResult::StorageError;
+      if (selectedIndex == count && strcmp(record.bookId, bookId) == 0) {
+        selected = record;
+        selectedIndex = i;
+      }
+    }
+    if (selectedIndex == count) return ShelfSortResult::Ok;
+    selected.readUpdateTime = std::max(selected.readUpdateTime, timestamp);
+    if (!promoted.begin(kShelfPath, kShelfMagic, sizeof(ShelfRecord)) || !promoted.append(&selected)) {
+      promoted.abort();
+      return ShelfSortResult::StorageError;
+    }
+    for (uint32_t i = 0; i < count; ++i) {
+      if (i == selectedIndex) continue;
+      ShelfRecord record;
+      if (!readShelfRecord(source, i, record) || !promoted.append(&record)) {
+        promoted.abort();
+        return ShelfSortResult::StorageError;
+      }
+    }
+  }
+  return promoted.finish() ? ShelfSortResult::Ok : ShelfSortResult::StorageError;
+}
+
 bool openToc(const std::string& path, HalFile& file, uint32_t& count) {
   return readIndexHeader(path.c_str(), kTocMagic, sizeof(TocRecord), file, count);
 }

--- a/lib/WeReadWebApi/src/WeReadStore.h
+++ b/lib/WeReadWebApi/src/WeReadStore.h
@@ -168,6 +168,8 @@ bool clearCache();
 
 bool openShelf(HalFile& file, uint32_t& count);
 ShelfSortResult sortShelfByRecent();
+uint32_t cachedShelfReadUpdateTime(const char* bookId);
+ShelfSortResult promoteShelfBook(const char* bookId, uint32_t timestamp);
 bool openToc(const std::string& path, HalFile& file, uint32_t& count);
 bool openImageIndex(const std::string& path, HalFile& file, uint32_t& count);
 bool openImageWorkIndex(const std::string& path, HalFile& file, uint32_t& count);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -50,6 +50,7 @@
 #include "util/AchievementPopupUtils.h"
 #include "util/BookmarkUtil.h"
 #include "util/ScreenshotUtil.h"
+#include "util/TimeUtils.h"
 
 namespace {
 // pagesPerRefresh now comes from SETTINGS.getRefreshFrequency()
@@ -218,6 +219,12 @@ void EpubReaderActivity::onEnter() {
   if (WeReadStore::findBookIdForPath(epub->getPath(), wereadBookId_, sizeof(wereadBookId_)) &&
       strncmp(wereadBookId_, "MP_WXS_", 7) == 0) {
     wereadBookId_[0] = '\0';
+  }
+  if (wereadBookId_[0]) {
+    const uint32_t timestamp = TimeUtils::getCurrentValidTimestamp();
+    if (timestamp != 0 && WeReadStore::promoteShelfBook(wereadBookId_, timestamp) != WeReadStore::ShelfSortResult::Ok) {
+      LOG_ERR("WR", "Failed to promote recently opened shelf book");
+    }
   }
 #endif
 

--- a/test/weread_webapi/WeReadStoreTest.cpp
+++ b/test/weread_webapi/WeReadStoreTest.cpp
@@ -326,10 +326,43 @@ TEST_F(WeReadStoreTest, SortsLargeShelfByRecentReadingWithStableTiesAndUnreadLas
   EXPECT_STREQ(record.bookId, "book-000");
 }
 
+TEST_F(WeReadStoreTest, PreservesCachedReadingTimeAndPromotesLocalOpenAtomically) {
+  ASSERT_TRUE(WeReadStore::ensureRoot());
+  WeReadStore::IndexWriter shelf;
+  ASSERT_TRUE(shelf.begin(WeReadStore::kShelfPath, WeReadStore::kShelfMagic, sizeof(WeReadStore::ShelfRecord)));
+  for (uint32_t i = 0; i < 3; ++i) {
+    WeReadStore::ShelfRecord record;
+    snprintf(record.bookId, sizeof(record.bookId), "book-%u", static_cast<unsigned>(i));
+    record.readUpdateTime = 300 - i * 100;
+    ASSERT_TRUE(shelf.append(&record));
+  }
+  ASSERT_TRUE(shelf.finish());
+
+  EXPECT_EQ(WeReadStore::cachedShelfReadUpdateTime("book-1"), 200U);
+  EXPECT_EQ(WeReadStore::cachedShelfReadUpdateTime("missing"), 0U);
+  ASSERT_EQ(WeReadStore::promoteShelfBook("book-2", 300), WeReadStore::ShelfSortResult::Ok);
+
+  HalFile file;
+  uint32_t count = 0;
+  ASSERT_TRUE(WeReadStore::openShelf(file, count));
+  ASSERT_EQ(count, 3U);
+  WeReadStore::ShelfRecord record;
+  ASSERT_TRUE(WeReadStore::readShelfRecord(file, 0, record));
+  EXPECT_STREQ(record.bookId, "book-2");
+  EXPECT_EQ(record.readUpdateTime, 300U);
+  ASSERT_TRUE(WeReadStore::readShelfRecord(file, 1, record));
+  EXPECT_STREQ(record.bookId, "book-0");
+  EXPECT_FALSE(Storage.exists("/.crosspoint/weread/shelf.bin.part"));
+
+  EXPECT_EQ(WeReadStore::promoteShelfBook("missing", 400), WeReadStore::ShelfSortResult::Ok);
+  EXPECT_EQ(WeReadStore::promoteShelfBook("book-1", 0), WeReadStore::ShelfSortResult::Ok);
+}
+
 TEST_F(WeReadStoreTest, RejectsCorruptShelfSortWithoutLeavingPartialReplacement) {
   ASSERT_TRUE(WeReadStore::ensureRoot());
   ASSERT_TRUE(Storage.writeFile(WeReadStore::kShelfPath, "corrupt"));
   EXPECT_EQ(WeReadStore::sortShelfByRecent(), WeReadStore::ShelfSortResult::StorageError);
+  EXPECT_EQ(WeReadStore::promoteShelfBook("book", 100), WeReadStore::ShelfSortResult::StorageError);
   EXPECT_FALSE(Storage.exists("/.crosspoint/weread/shelf.bin.part"));
   EXPECT_TRUE(Storage.exists(WeReadStore::kShelfPath));
 }


### PR DESCRIPTION
## Summary

- Promote a locally opened WeRead EPUB to the top of the shelf.
- Preserve the newer of cached local and server reading timestamps.
- Keep the shelf replacement atomic.

## Validation

- 29 WeReadStore tests passed