### PR TITLE
feat(weread): center login QR layout

### DIFF
--- a/src/activities/apps/weread/WeReadQrLayout.h
+++ b/src/activities/apps/weread/WeReadQrLayout.h
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace WeReadQrLayout {
+
+constexpr int kMaxSide = 400;
+
+struct Layout {
+  int x;
+  int y;
+  int side;
+  int textY;
+};
+
+constexpr int min(const int left, const int right) { return left < right ? left : right; }
+
+constexpr Layout calculate(const int x, const int y, const int width, const int height, const int sidePadding,
+                           const int textGap, const int lineHeight, const int sourceSide = kMaxSide) {
+  const int widthLimit = width - sidePadding * 2;
+  const int footerHeight = textGap + lineHeight * 2;
+  const int heightLimit = height - footerHeight * 2;
+  const int constrained = min(kMaxSide, min(sourceSide, min(widthLimit, heightLimit)));
+  const int side = constrained > 0 ? constrained : 1;
+  const int imageX = x + (width - side) / 2;
+  const int imageY = y + (height - side) / 2;
+  return {imageX, imageY, side, imageY + side + textGap};
+}
+
+constexpr Layout kX4Portrait = calculate(0, 80, 480, 700, 16, 8, 20);
+static_assert(kX4Portrait.side == 400 && kX4Portrait.x == 40);
+static_assert((kX4Portrait.y - 80) * 2 == 700 - kX4Portrait.side);
+static_assert(kX4Portrait.textY + 40 <= 780);
+
+constexpr Layout kX3Portrait = calculate(0, 80, 528, 692, 16, 8, 20);
+static_assert(kX3Portrait.side == 400 && kX3Portrait.x == 64);
+static_assert(kX3Portrait.textY + 40 <= 772);
+
+constexpr Layout kX4Landscape = calculate(0, 80, 800, 380, 16, 8, 20);
+static_assert(kX4Landscape.side == 284);
+static_assert(kX4Landscape.textY + 40 <= 460);
+
+constexpr Layout kX3Landscape = calculate(0, 80, 792, 428, 16, 8, 20);
+static_assert(kX3Landscape.side == 332);
+static_assert(kX3Landscape.textY + 40 <= 508);
+
+constexpr Layout kSmallBitmap = calculate(0, 80, 480, 700, 16, 8, 20, 320);
+static_assert(kSmallBitmap.side == 320 && kSmallBitmap.x == 80);
+static_assert((kSmallBitmap.y - 80) * 2 == 700 - kSmallBitmap.side);
+
+}  // namespace WeReadQrLayout

--- a/src/activities/apps/weread/webapi/WeReadActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadActivity.cpp
@@ -21,6 +21,7 @@
 #include "SdCardFontSystem.h"
 #include "SilentRestart.h"
 #include "WeReadBrowseActivity.h"
+#include "activities/apps/weread/WeReadQrLayout.h"
 #include "activities/apps/weread/WeReadTouchGeometry.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/ConfirmationActivity.h"
@@ -2307,15 +2308,13 @@ void WeReadActivity::render(RenderLock&&) {
       }
       const int lineHeight = renderer.getLineHeight(UI_10_FONT_ID);
       const int textGap = SubpageLayout::relatedGap(metrics);
-      const int qrLimit = content.height - textGap - lineHeight * 2;
-      const int qrSide = std::max(1, std::min(content.width * 4 / 5, qrLimit));
-      const int groupHeight = qrSide + textGap + lineHeight * 2;
-      const int qrY = content.y + std::max(0, (content.height - groupHeight) / 2);
-      QrUtils::drawQrCode(renderer, Rect{(width - qrSide) / 2, qrY, qrSide, qrSide}, qrUrl_);
-      renderer.drawCenteredText(UI_10_FONT_ID, qrY + qrSide + textGap, tr(STR_WEREAD_SCAN_LOGIN));
+      const auto layout = WeReadQrLayout::calculate(content.x, content.y, content.width, content.height,
+                                                    metrics.contentSidePadding, textGap, lineHeight);
+      QrUtils::drawQrCode(renderer, Rect{layout.x, layout.y, layout.side, layout.side}, qrUrl_);
+      renderer.drawCenteredText(UI_10_FONT_ID, layout.textY, tr(STR_WEREAD_SCAN_LOGIN));
       char target[64];
       snprintf(target, sizeof(target), "\"%s\"", tr(STR_WEREAD_TITLE));
-      renderer.drawCenteredText(UI_10_FONT_ID, qrY + qrSide + textGap + lineHeight, target);
+      renderer.drawCenteredText(UI_10_FONT_ID, layout.textY + lineHeight, target);
       break;
     }
     case State::Syncing: {


### PR DESCRIPTION
## Summary

- Share a constexpr QR layout helper.
- Center a QR up to 400x400 while reserving symmetric prompt space.
- Keep the latest touch-enabled Web UI unchanged outside login rendering.

## Validation

- `pio run -e gh_release_cn`