### PR TITLE
refactor(apps): add reusable app framework helpers

### DIFF
--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Logging.h>
+#include <Memory.h>
 
 #include <cassert>
 #include <memory>
@@ -60,6 +61,19 @@ class Activity {
   // Start a new activity without destroying the current one
   // Note: requestUpdate() will be invoked automatically once resultHandler finishes
   void startActivityForResult(std::unique_ptr<Activity>&& activity, ActivityResultHandler resultHandler);
+
+  template <typename T, typename... Args>
+  bool startActivityForResultWith(ActivityResultHandler resultHandler, Args&&... args) {
+    // The child is owned by ActivityManager across frames, so stack storage is
+    // not possible; keep its one allocation fallible.
+    auto activity = makeUniqueNoThrow<T>(renderer, mappedInput, std::forward<Args>(args)...);
+    if (!activity) {
+      LOG_ERR("ACT", "OOM: child activity (%u bytes)", static_cast<unsigned>(sizeof(T)));
+      return false;
+    }
+    startActivityForResult(std::move(activity), std::move(resultHandler));
+    return true;
+  }
 
   // Set the result to be passed back to the previous activity when this activity finishes
   void setResult(ActivityResult&& result);

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -311,29 +311,20 @@ void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
 }
 
 void ActivityManager::goToFileTransfer() {
-  replaceActivity(std::make_unique<CrossPointWebServerActivity>(renderer, mappedInput));
+  replaceActivityWith<CrossPointWebServerActivity>();
 }
 
-void ActivityManager::goToSettings() { replaceActivity(std::make_unique<SettingsActivity>(renderer, mappedInput)); }
+void ActivityManager::goToSettings() { replaceActivityWith<SettingsActivity>(); }
 
-void ActivityManager::goToUglyAvatar() { replaceActivity(std::make_unique<UglyAvatarActivity>(renderer, mappedInput)); }
+void ActivityManager::goToUglyAvatar() { replaceActivityWith<UglyAvatarActivity>(); }
 
 void ActivityManager::goToFileBrowser(std::string path) {
-  replaceActivity(std::make_unique<FileBrowserActivity>(renderer, mappedInput, std::move(path)));
+  replaceActivityWith<FileBrowserActivity>(std::move(path));
 }
 
-void ActivityManager::goToRecentBooks() {
-  replaceActivity(std::make_unique<RecentBooksActivity>(renderer, mappedInput));
-}
+void ActivityManager::goToRecentBooks() { replaceActivityWith<RecentBooksActivity>(); }
 
-void ActivityManager::goToInxRecent() {
-  auto activity = makeUniqueNoThrow<InxRecentActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: InxRecentActivity (%u bytes)", static_cast<unsigned>(sizeof(InxRecentActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToInxRecent() { replaceActivityWith<InxRecentActivity>(); }
 
 void ActivityManager::goToMainTab(const MainTab tab) {
   mainTabEntryReleasePending = false;
@@ -362,36 +353,30 @@ void ActivityManager::goToBrowser() {
   const auto& servers = OPDS_STORE.getServers();
   // Skip the server picker when there's only one server configured
   if (servers.size() == 1) {
-    replaceActivity(std::make_unique<OpdsBookBrowserActivity>(renderer, mappedInput, servers[0]));
+    replaceActivityWith<OpdsBookBrowserActivity>(servers[0]);
   } else {
-    replaceActivity(std::make_unique<OpdsServerListActivity>(renderer, mappedInput, true));
+    replaceActivityWith<OpdsServerListActivity>(true);
   }
 }
 
 void ActivityManager::goToReader(std::string path, const bool allowFastInitialRefresh) {
-  replaceActivity(std::make_unique<ReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh));
+  replaceActivityWith<ReaderActivity>(std::move(path), allowFastInitialRefresh);
 }
 
 void ActivityManager::goToSleep(bool fromTimeout) {
-  replaceActivity(std::make_unique<SleepActivity>(renderer, mappedInput, fromTimeout));
-  loop();  // Important: sleep screen must be rendered immediately, the caller will go to sleep right after this returns
+  if (replaceActivityWith<SleepActivity>(fromTimeout)) {
+    loop();  // The caller sleeps immediately after this returns, so render now.
+  }
 }
 
-void ActivityManager::goToBoot() { replaceActivity(std::make_unique<BootActivity>(renderer, mappedInput)); }
+void ActivityManager::goToBoot() { replaceActivityWith<BootActivity>(); }
 
 bool ActivityManager::goToPostOtaBoot(bool allowAutoPreload) {
-  // Activities outlive this call and are owned by ActivityManager, so this small allocation cannot use the stack.
-  auto activity = makeUniqueNoThrow<BootActivity>(renderer, mappedInput, BootActivity::Mode::PostOta, allowAutoPreload);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: BootActivity (%u bytes)", static_cast<unsigned>(sizeof(BootActivity)));
-    return false;
-  }
-  replaceActivity(std::move(activity));
-  return true;
+  return replaceActivityWith<BootActivity>(BootActivity::Mode::PostOta, allowAutoPreload);
 }
 
 void ActivityManager::goToFullScreenMessage(std::string message, EpdFontFamily::Style style) {
-  replaceActivity(std::make_unique<FullScreenMessageActivity>(renderer, mappedInput, std::move(message), style));
+  replaceActivityWith<FullScreenMessageActivity>(std::move(message), style);
 }
 
 void ActivityManager::goHome(HomeMenuItem initialMenuItem) {
@@ -415,102 +400,49 @@ void ActivityManager::goHome(HomeMenuItem initialMenuItem) {
       initialMenuItem = HomeMenuItem::SETTINGS_MENU;
     }
   }
-  replaceActivity(std::make_unique<HomeActivity>(renderer, mappedInput, initialMenuItem));
+  replaceActivityWith<HomeActivity>(initialMenuItem);
 }
-void ActivityManager::goToCrashReport() { replaceActivity(std::make_unique<CrashActivity>(renderer, mappedInput)); }
+void ActivityManager::goToCrashReport() { replaceActivityWith<CrashActivity>(); }
 
-void ActivityManager::goToApps() { replaceActivity(std::make_unique<AppsMenuActivity>(renderer, mappedInput)); }
+void ActivityManager::goToApps() { replaceActivityWith<AppsMenuActivity>(); }
 
-void ActivityManager::goToReadingStatsMenu() {
-  replaceActivity(std::make_unique<ReadingStatsMenuActivity>(renderer, mappedInput));
-}
+void ActivityManager::goToReadingStatsMenu() { replaceActivityWith<ReadingStatsMenuActivity>(); }
 
-void ActivityManager::goToReadingStats() {
-  auto activity = makeUniqueNoThrow<ReadingStatsActivity>(renderer, mappedInput, true);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: ReadingStatsActivity (%u bytes)", static_cast<unsigned>(sizeof(ReadingStatsActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToReadingStats() { replaceActivityWith<ReadingStatsActivity>(true); }
 
-void ActivityManager::goToSudoku() { replaceActivity(std::make_unique<SudokuMenuActivity>(renderer, mappedInput)); }
+void ActivityManager::goToSudoku() { replaceActivityWith<SudokuMenuActivity>(); }
 
-void ActivityManager::goToSokoban() { replaceActivity(std::make_unique<SokobanGameActivity>(renderer, mappedInput)); }
+void ActivityManager::goToSokoban() { replaceActivityWith<SokobanGameActivity>(); }
 
-void ActivityManager::goToGomoku() { replaceActivity(std::make_unique<GomokuMenuActivity>(renderer, mappedInput)); }
+void ActivityManager::goToGomoku() { replaceActivityWith<GomokuMenuActivity>(); }
 
-void ActivityManager::goToMinesweeper() {
-  replaceActivity(std::make_unique<MinesweeperMenuActivity>(renderer, mappedInput));
-}
+void ActivityManager::goToMinesweeper() { replaceActivityWith<MinesweeperMenuActivity>(); }
 
 void ActivityManager::goToPixelSwitch() {
-  // ActivityManager owns this 1500-byte inline canvas across frames, so it
-  // cannot live on the caller's stack. Failure must not abort under -fno-exceptions.
-  auto activity = makeUniqueNoThrow<PixelSwitchActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: PixelSwitchActivity (%u bytes)", static_cast<unsigned>(sizeof(PixelSwitchActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
+  replaceActivityWith<PixelSwitchActivity>();
 }
 
-void ActivityManager::goToCalculator() {
-  auto activity = makeUniqueNoThrow<CalculatorActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: CalculatorActivity (%u bytes)", static_cast<unsigned>(sizeof(CalculatorActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToCalculator() { replaceActivityWith<CalculatorActivity>(); }
 
-void ActivityManager::goToWoodfish() {
-  auto activity = makeUniqueNoThrow<WoodfishActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: WoodfishActivity (%u bytes)", static_cast<unsigned>(sizeof(WoodfishActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToWoodfish() { replaceActivityWith<WoodfishActivity>(); }
 
-void ActivityManager::goToGame2048() { replaceActivity(std::make_unique<Game2048Activity>(renderer, mappedInput)); }
+void ActivityManager::goToGame2048() { replaceActivityWith<Game2048Activity>(); }
 
-void ActivityManager::goToAirPage() {
-  // Activities must outlive this call; ActivityManager takes ownership of this
-  // single allocation and releases it on navigation.
-  auto activity = makeUniqueNoThrow<AirPageActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: AirPageActivity (%u bytes)", static_cast<unsigned>(sizeof(AirPageActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToAirPage() { replaceActivityWith<AirPageActivity>(); }
 
-void ActivityManager::goToBuddy() {
-  auto activity = makeUniqueNoThrow<BuddyActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: BuddyActivity (%u bytes)", static_cast<unsigned>(sizeof(BuddyActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
-}
+void ActivityManager::goToBuddy() { replaceActivityWith<BuddyActivity>(); }
 
-void ActivityManager::goToStandby() { replaceActivity(std::make_unique<StandbyActivity>(renderer, mappedInput)); }
+void ActivityManager::goToStandby() { replaceActivityWith<StandbyActivity>(); }
 
 #ifdef ENABLE_CHINESE_VERSION
 void ActivityManager::goToChineseChess() {
-  replaceActivity(std::make_unique<ChineseChessMenuActivity>(renderer, mappedInput));
+  replaceActivityWith<ChineseChessMenuActivity>();
 }
 #endif
 
 #ifdef ENABLE_CHINESE_VERSION
 void ActivityManager::goToWeRead() {
-  auto activity = makeUniqueNoThrow<WeReadActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: WeReadActivity");
-    return;
-  }
-  replaceActivity(std::move(activity));
+  replaceActivityWith<WeReadActivity>();
 }
 #endif
 

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -310,17 +310,13 @@ void ActivityManager::replaceActivity(std::unique_ptr<Activity>&& newActivity) {
   }
 }
 
-void ActivityManager::goToFileTransfer() {
-  replaceActivityWith<CrossPointWebServerActivity>();
-}
+void ActivityManager::goToFileTransfer() { replaceActivityWith<CrossPointWebServerActivity>(); }
 
 void ActivityManager::goToSettings() { replaceActivityWith<SettingsActivity>(); }
 
 void ActivityManager::goToUglyAvatar() { replaceActivityWith<UglyAvatarActivity>(); }
 
-void ActivityManager::goToFileBrowser(std::string path) {
-  replaceActivityWith<FileBrowserActivity>(std::move(path));
-}
+void ActivityManager::goToFileBrowser(std::string path) { replaceActivityWith<FileBrowserActivity>(std::move(path)); }
 
 void ActivityManager::goToRecentBooks() { replaceActivityWith<RecentBooksActivity>(); }
 
@@ -418,9 +414,7 @@ void ActivityManager::goToGomoku() { replaceActivityWith<GomokuMenuActivity>(); 
 
 void ActivityManager::goToMinesweeper() { replaceActivityWith<MinesweeperMenuActivity>(); }
 
-void ActivityManager::goToPixelSwitch() {
-  replaceActivityWith<PixelSwitchActivity>();
-}
+void ActivityManager::goToPixelSwitch() { replaceActivityWith<PixelSwitchActivity>(); }
 
 void ActivityManager::goToCalculator() { replaceActivityWith<CalculatorActivity>(); }
 
@@ -435,15 +429,11 @@ void ActivityManager::goToBuddy() { replaceActivityWith<BuddyActivity>(); }
 void ActivityManager::goToStandby() { replaceActivityWith<StandbyActivity>(); }
 
 #ifdef ENABLE_CHINESE_VERSION
-void ActivityManager::goToChineseChess() {
-  replaceActivityWith<ChineseChessMenuActivity>();
-}
+void ActivityManager::goToChineseChess() { replaceActivityWith<ChineseChessMenuActivity>(); }
 #endif
 
 #ifdef ENABLE_CHINESE_VERSION
-void ActivityManager::goToWeRead() {
-  replaceActivityWith<WeReadActivity>();
-}
+void ActivityManager::goToWeRead() { replaceActivityWith<WeReadActivity>(); }
 #endif
 
 void ActivityManager::pushActivity(std::unique_ptr<Activity>&& activity) {

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -12,8 +12,8 @@
 
 #include "GfxRenderer.h"
 #include "Logging.h"
-#include "Memory.h"
 #include "MappedInputManager.h"
+#include "Memory.h"
 #include "activities/MainTab.h"
 #include "util/ScreenshotInfo.h"
 

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "GfxRenderer.h"
+#include "Logging.h"
+#include "Memory.h"
 #include "MappedInputManager.h"
 #include "activities/MainTab.h"
 #include "util/ScreenshotInfo.h"
@@ -83,6 +85,19 @@ class ActivityManager {
 
   // Will replace currentActivity and drop all activities on stack
   void replaceActivity(std::unique_ptr<Activity>&& newActivity);
+
+  // Activities must outlive the caller, so they cannot use stack storage. This
+  // keeps the single required heap allocation fallible under -fno-exceptions.
+  template <typename T, typename... Args>
+  bool replaceActivityWith(Args&&... args) {
+    auto activity = makeUniqueNoThrow<T>(renderer, mappedInput, std::forward<Args>(args)...);
+    if (!activity) {
+      LOG_ERR("ACT", "OOM: activity (%u bytes)", static_cast<unsigned>(sizeof(T)));
+      return false;
+    }
+    replaceActivity(std::move(activity));
+    return true;
+  }
 
   // goTo... functions are convenient wrapper for replaceActivity()
   void goToFileTransfer();

--- a/src/activities/apps/2048/Game2048Activity.cpp
+++ b/src/activities/apps/2048/Game2048Activity.cpp
@@ -157,17 +157,17 @@ void Game2048Activity::handleSlide(Game2048Board::Direction d) {
 }
 
 void Game2048Activity::promptNewGameConfirm() {
-  startActivityForResult(std::make_unique<ConfirmationActivity>(renderer, mappedInput, tr(STR_2048_CONFIRM_NEW),
-                                                                tr(STR_2048_CONFIRM_BODY)),
-                         [this](const ActivityResult& result) {
-                           if (result.isCancelled) {
-                             requestUpdate();
-                             return;
-                           }
-                           newGame();
-                           persistNow();
-                           requestUpdate();
-                         });
+  startActivityForResultWith<ConfirmationActivity>(
+      [this](const ActivityResult& result) {
+        if (result.isCancelled) {
+          requestUpdate();
+          return;
+        }
+        newGame();
+        persistNow();
+        requestUpdate();
+      },
+      tr(STR_2048_CONFIRM_NEW), tr(STR_2048_CONFIRM_BODY));
 }
 
 void Game2048Activity::persistNow() {

--- a/src/activities/apps/GameUi.cpp
+++ b/src/activities/apps/GameUi.cpp
@@ -4,6 +4,10 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "GfxRenderer.h"
+#include "MappedInputManager.h"
+#include "fontIds.h"
+
 void gameFormatElapsed(uint32_t ms, char* out, size_t outLen) {
   const uint32_t totalSec = ms / 1000;
   const uint32_t mm = (totalSec / 60) % 100;
@@ -52,4 +56,63 @@ Rect gameMenuPanelRect(const int screenWidth, const int screenHeight, const int 
   const int height = titleHeight + rowHeight * rowCount + 4;
   if (width > screenWidth || height > screenHeight) return Rect{};
   return Rect{(screenWidth - width) / 2, (screenHeight - height) / 2, width, height};
+}
+
+GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& panel, const int titleHeight,
+                                        const int rowHeight, const int itemCount, uint8_t& selected) {
+  if (itemCount <= 0 || itemCount > UINT8_MAX || panel.width <= 0 || panel.height <= 0 || titleHeight < 0 ||
+      rowHeight <= 0) {
+    return GameMenuInputResult::None;
+  }
+
+  int touched = -1;
+  const auto touch = input.rowTouch(touched, panel.y + titleHeight, rowHeight, itemCount, panel.x,
+                                    panel.x + panel.width, rowHeight);
+  if (touch != MappedInputManager::RowTouch::None) {
+    selected = static_cast<uint8_t>(touched);
+    return touch == MappedInputManager::RowTouch::Tap ? GameMenuInputResult::Activated
+                                                      : GameMenuInputResult::SelectionChanged;
+  }
+
+  if (input.wasPressed(MappedInputManager::Button::Up) || input.wasPressed(MappedInputManager::Button::Left)) {
+    selected = static_cast<uint8_t>((selected + itemCount - 1) % itemCount);
+    return GameMenuInputResult::SelectionChanged;
+  }
+  if (input.wasPressed(MappedInputManager::Button::Down) || input.wasPressed(MappedInputManager::Button::Right)) {
+    selected = static_cast<uint8_t>((selected + 1) % itemCount);
+    return GameMenuInputResult::SelectionChanged;
+  }
+  if (input.wasReleased(MappedInputManager::Button::Confirm)) return GameMenuInputResult::Activated;
+  if (input.wasReleased(MappedInputManager::Button::Back)) return GameMenuInputResult::Dismissed;
+  return GameMenuInputResult::None;
+}
+
+void gameDrawMenu(GfxRenderer& renderer, const Rect& panel, const int titleHeight, const int rowHeight,
+                  const char* title, const GameMenuItem* items, const int itemCount, const int selected) {
+  if (panel.width <= 0 || panel.height <= 0 || titleHeight < 0 || rowHeight <= 0 || !title || !items ||
+      itemCount <= 0) {
+    return;
+  }
+
+  renderer.fillRect(panel.x, panel.y, panel.width, panel.height, false);
+  renderer.drawRect(panel.x, panel.y, panel.width, panel.height, 2, true);
+  renderer.fillRect(panel.x + 2, panel.y + titleHeight, panel.width - 4, 1, true);
+
+  const int itemTextHeight = renderer.getTextHeight(UI_12_FONT_ID);
+  const int hintTextHeight = renderer.getTextHeight(UI_10_FONT_ID);
+  renderer.drawText(UI_12_FONT_ID, panel.x + 12, panel.y + gameCenterY(titleHeight, itemTextHeight), title);
+
+  for (int i = 0; i < itemCount; ++i) {
+    const int rowY = panel.y + titleHeight + i * rowHeight;
+    const bool inverted = i == selected;
+    if (inverted) renderer.fillRect(panel.x + 1, rowY, panel.width - 2, rowHeight, true);
+
+    const char* label = items[i].label ? items[i].label : "";
+    renderer.drawText(UI_12_FONT_ID, panel.x + 12, rowY + gameCenterY(rowHeight, itemTextHeight), label, !inverted);
+    const char* hint = items[i].hint;
+    if (!hint || hint[0] == '\0') continue;
+    const int hintWidth = renderer.getTextWidth(UI_10_FONT_ID, hint);
+    renderer.drawText(UI_10_FONT_ID, panel.x + panel.width - 12 - hintWidth,
+                      rowY + gameCenterY(rowHeight, hintTextHeight) + 2, hint, !inverted);
+  }
 }

--- a/src/activities/apps/GameUi.cpp
+++ b/src/activities/apps/GameUi.cpp
@@ -66,8 +66,8 @@ GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& p
   }
 
   int touched = -1;
-  const auto touch = input.rowTouch(touched, panel.y + titleHeight, rowHeight, itemCount, panel.x,
-                                    panel.x + panel.width, rowHeight);
+  const auto touch =
+      input.rowTouch(touched, panel.y + titleHeight, rowHeight, itemCount, panel.x, panel.x + panel.width, rowHeight);
   if (touch != MappedInputManager::RowTouch::None) {
     selected = static_cast<uint8_t>(touched);
     return touch == MappedInputManager::RowTouch::Tap ? GameMenuInputResult::Activated
@@ -87,7 +87,7 @@ GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& p
   return GameMenuInputResult::None;
 }
 
-void gameDrawMenu(GfxRenderer& renderer, const Rect& panel, const int titleHeight, const int rowHeight,
+void gameDrawMenu(const GfxRenderer& renderer, const Rect& panel, const int titleHeight, const int rowHeight,
                   const char* title, const GameMenuItem* items, const int itemCount, const int selected) {
   if (panel.width <= 0 || panel.height <= 0 || titleHeight < 0 || rowHeight <= 0 || !title || !items ||
       itemCount <= 0) {

--- a/src/activities/apps/GameUi.h
+++ b/src/activities/apps/GameUi.h
@@ -27,5 +27,5 @@ Rect gameTouchActionRect(int screenWidth, int screenHeight, int sidePadding, int
 Rect gameMenuPanelRect(int screenWidth, int screenHeight, int width, int titleHeight, int rowHeight, int rowCount);
 GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& panel, int titleHeight, int rowHeight,
                                         int itemCount, uint8_t& selected);
-void gameDrawMenu(GfxRenderer& renderer, const Rect& panel, int titleHeight, int rowHeight, const char* title,
+void gameDrawMenu(const GfxRenderer& renderer, const Rect& panel, int titleHeight, int rowHeight, const char* title,
                   const GameMenuItem* items, int itemCount, int selected);

--- a/src/activities/apps/GameUi.h
+++ b/src/activities/apps/GameUi.h
@@ -5,6 +5,16 @@
 
 #include "components/themes/BaseTheme.h"
 
+class GfxRenderer;
+class MappedInputManager;
+
+struct GameMenuItem {
+  const char* label;
+  const char* hint;
+};
+
+enum class GameMenuInputResult : uint8_t { None, SelectionChanged, Activated, Dismissed };
+
 inline int gameCenterY(int boxH, int textH) { return (boxH - textH) / 2; }
 inline int gameCenteredBlockY(int top, int bottom, int blockH) { return top + (bottom - top - blockH) / 2; }
 
@@ -15,3 +25,7 @@ bool gameIntersectionFromPoint(int originX, int originY, int pitch, int rows, in
                                int& column);
 Rect gameTouchActionRect(int screenWidth, int screenHeight, int sidePadding, int gap, int height, int index, int count);
 Rect gameMenuPanelRect(int screenWidth, int screenHeight, int width, int titleHeight, int rowHeight, int rowCount);
+GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& panel, int titleHeight, int rowHeight,
+                                        int itemCount, uint8_t& selected);
+void gameDrawMenu(GfxRenderer& renderer, const Rect& panel, int titleHeight, int rowHeight, const char* title,
+                  const GameMenuItem* items, int itemCount, int selected);

--- a/src/activities/apps/README.md
+++ b/src/activities/apps/README.md
@@ -59,17 +59,16 @@ In `src/activities/ActivityManager.{h,cpp}`:
 void goToMyApp();
 
 // .cpp
-#include <Memory.h>
 #include "apps/myapp/MyAppActivity.h"
 void ActivityManager::goToMyApp() {
-  auto activity = makeUniqueNoThrow<MyAppActivity>(renderer, mappedInput);
-  if (!activity) {
-    LOG_ERR("ACT", "OOM: MyAppActivity (%u bytes)", static_cast<unsigned>(sizeof(MyAppActivity)));
-    return;
-  }
-  replaceActivity(std::move(activity));
+  replaceActivityWith<MyAppActivity>();
 }
 ```
+
+`replaceActivityWith<T>(...)` and `startActivityForResultWith<T>(handler, ...)`
+prepend `renderer` and `mappedInput` to the constructor arguments, allocate with
+`makeUniqueNoThrow`, log OOM, and leave the current Activity in place on
+failure. Do not construct Activities with `std::make_unique`.
 
 ### 3. Assign an ID and append one row to `kAppEntries`
 
@@ -111,6 +110,22 @@ IDs 17 through 31 remain available.
 ### 5. (Optional) Stateless toy apps
 
 Some apps have no save state at all. Ugly Avatar is a single-screen generator that creates a new avatar on entry and exits cleanly. It skips both `GameSaveDebouncer` and any `*Store.{h,cpp}` layer, and its `Activity` is launched directly (no `*MenuActivity`). Use this pattern when the app has no "in-progress game" worth resuming; it cuts a few hundred lines and avoids persistent writes.
+
+### Reusable implementation patterns
+
+Choose the smallest pattern that fits:
+
+| App shape | Reference | Reuse |
+|---|---|---|
+| Stateless, single screen | `avatar/UglyAvatarActivity` | `Activity`, `GameUi` action geometry; no Store or menu Activity |
+| Stateful, single screen | `2048/Game2048Activity`, `woodfish/WoodfishActivity` | Board/state object plus `GameSaveDebouncer` or an app-specific idle checkpoint |
+| Board game with launcher | `sudoku/` | Separate Board, Store, MenuActivity, GameActivity; `GameUi` menu/input helpers |
+
+`GameMenuItem` is a fixed-array row descriptor (`label` plus optional `hint`).
+Use `gameHandleMenuInput()` for touch and logical-button navigation and switch
+exhaustively on its result. Use `gameDrawMenu()` for the matching modal. Keep
+rules, win detection, AI, and persistence in the game: they are not framework
+concerns.
 
 ---
 

--- a/src/activities/apps/avatar/UglyAvatarActivity.cpp
+++ b/src/activities/apps/avatar/UglyAvatarActivity.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Render.h>
 #include <esp_system.h>
 
@@ -13,8 +14,16 @@
 void UglyAvatarActivity::onEnter() {
   Activity::onEnter();
   LOG_DBG("AVATAR", "onEnter free heap=%u", static_cast<unsigned>(ESP.getFreeHeap()));
-  gen_ = std::make_unique<avatar::AvatarGenerator>();
-  data_ = std::make_unique<avatar::AvatarData>();
+  gen_ = makeUniqueNoThrow<avatar::AvatarGenerator>();
+  data_ = makeUniqueNoThrow<avatar::AvatarData>();
+  if (!gen_ || !data_) {
+    LOG_ERR("AVATAR", "OOM: generator=%u data=%u", static_cast<unsigned>(sizeof(avatar::AvatarGenerator)),
+            static_cast<unsigned>(sizeof(avatar::AvatarData)));
+    gen_.reset();
+    data_.reset();
+    activityManager.goToApps();
+    return;
+  }
   regenerate();
 }
 

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -18,7 +18,6 @@ using Kind = ChineseChessBoard::Kind;
 using Move = ChineseChessBoard::Move;
 
 constexpr int kStatusFont = UI_12_FONT_ID;
-constexpr int kModalItemFont = UI_12_FONT_ID;
 constexpr int kHeroFont = NOTOSERIF_16_FONT_ID;
 constexpr int kStatValueFont = NOTOSANS_16_FONT_ID;
 
@@ -216,29 +215,20 @@ void ChineseChessGameActivity::handleInputGameMenu() {
   constexpr int width = 320;
   const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
                                        rowHeight, MENU_ITEM_COUNT);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, MENU_ITEM_COUNT, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    menuSel = static_cast<uint8_t>(touched);
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) runMenuItem(menuSel);
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    menuSel = static_cast<uint8_t>((menuSel + MENU_ITEM_COUNT - 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    menuSel = static_cast<uint8_t>((menuSel + 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    runMenuItem(menuSel);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    resumeFromMenu();
-    requestUpdate();
+  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
+    case GameMenuInputResult::None:
+      return;
+    case GameMenuInputResult::SelectionChanged:
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Activated:
+      runMenuItem(menuSel);
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Dismissed:
+      resumeFromMenu();
+      requestUpdate();
+      return;
   }
 }
 
@@ -250,13 +240,12 @@ void ChineseChessGameActivity::handleInputGameOver() {
                                         metrics.contentSidePadding, metrics.menuSpacing, metrics.menuRowHeight, 1, 2);
   if (mappedInput.wasTapInRect(again.x, again.y, again.width, again.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    activityManager.replaceActivity(
-        std::make_unique<ChineseChessGameActivity>(renderer, mappedInput, mode, false, aiLevel));
+    activityManager.replaceActivityWith<ChineseChessGameActivity>(mode, false, aiLevel);
     return;
   }
   if (mappedInput.wasTapInRect(home.x, home.y, home.width, home.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    activityManager.replaceActivity(std::make_unique<ChineseChessMenuActivity>(renderer, mappedInput));
+    activityManager.replaceActivityWith<ChineseChessMenuActivity>();
   }
 }
 
@@ -416,12 +405,12 @@ void ChineseChessGameActivity::runMenuItem(uint8_t i) {
       const auto m = mode;
       const auto lv = aiLevel;
       ChineseChessStore::clear();
-      activityManager.replaceActivity(std::make_unique<ChineseChessGameActivity>(renderer, mappedInput, m, false, lv));
+      activityManager.replaceActivityWith<ChineseChessGameActivity>(m, false, lv);
       return;
     }
     case 4:  // Exit to menu
       flushSave();
-      activityManager.replaceActivity(std::make_unique<ChineseChessMenuActivity>(renderer, mappedInput));
+      activityManager.replaceActivityWith<ChineseChessMenuActivity>();
       return;
   }
 }
@@ -743,30 +732,11 @@ void ChineseChessGameActivity::renderGameMenu() {
   constexpr int rowH = 32;
   const Rect panel =
       gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  const int titleTextH = renderer.getTextHeight(kModalItemFont);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(kModalItemFont, x + 12, y + (titleH - titleTextH) / 2, tr(STR_GAME_GAME_MENU));
-
-  const char* labels[MENU_ITEM_COUNT] = {
-      tr(STR_GAME_RESUME), tr(STR_GOMOKU_UNDO), tr(STR_GOMOKU_RESIGN), tr(STR_GAME_NEW_GAME), tr(STR_GAME_EXIT),
+  const GameMenuItem items[MENU_ITEM_COUNT] = {
+      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), ""},      {tr(STR_GOMOKU_RESIGN), ""},
+      {tr(STR_GAME_NEW_GAME), ""}, {tr(STR_GAME_EXIT), ""},
   };
-
-  const int itemTextH = renderer.getTextHeight(kModalItemFont);
-  const int firstY = y + titleH;
-  for (int i = 0; i < MENU_ITEM_COUNT; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == menuSel);
-    if (inverted) renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    renderer.drawText(kModalItemFont, x + 12, rowY + (rowH - itemTextH) / 2, labels[i], !inverted);
-  }
+  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 
   const auto hints = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, hints.btn1, hints.btn2, hints.btn3, hints.btn4);

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -733,7 +733,7 @@ void ChineseChessGameActivity::renderGameMenu() {
   const Rect panel =
       gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
   const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), ""},      {tr(STR_GOMOKU_RESIGN), ""},
+      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), ""}, {tr(STR_GOMOKU_RESIGN), ""},
       {tr(STR_GAME_NEW_GAME), ""}, {tr(STR_GAME_EXIT), ""},
   };
   gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
@@ -115,8 +115,8 @@ void ChineseChessMenuActivity::handleAiDifficultyInput() {
     requestUpdate();
     if (touch == MappedInputManager::RowTouch::Tap) {
       ChineseChessStore::clear();
-      activityManager.replaceActivityWith<ChineseChessGameActivity>(
-          ChineseChessMode::VsAi, false, static_cast<ChineseChessAiLevel>(aiDifficultySel));
+      activityManager.replaceActivityWith<ChineseChessGameActivity>(ChineseChessMode::VsAi, false,
+                                                                    static_cast<ChineseChessAiLevel>(aiDifficultySel));
     }
     return;
   }

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
@@ -115,8 +115,8 @@ void ChineseChessMenuActivity::handleAiDifficultyInput() {
     requestUpdate();
     if (touch == MappedInputManager::RowTouch::Tap) {
       ChineseChessStore::clear();
-      activityManager.replaceActivity(std::make_unique<ChineseChessGameActivity>(
-          renderer, mappedInput, ChineseChessMode::VsAi, false, static_cast<ChineseChessAiLevel>(aiDifficultySel)));
+      activityManager.replaceActivityWith<ChineseChessGameActivity>(
+          ChineseChessMode::VsAi, false, static_cast<ChineseChessAiLevel>(aiDifficultySel));
     }
     return;
   }
@@ -131,8 +131,7 @@ void ChineseChessMenuActivity::handleAiDifficultyInput() {
   } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     ChineseChessStore::clear();
     const auto level = static_cast<ChineseChessAiLevel>(aiDifficultySel);
-    activityManager.replaceActivity(
-        std::make_unique<ChineseChessGameActivity>(renderer, mappedInput, ChineseChessMode::VsAi, false, level));
+    activityManager.replaceActivityWith<ChineseChessGameActivity>(ChineseChessMode::VsAi, false, level);
   } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     showingAiDifficulty = false;
     requestUpdate();
@@ -145,8 +144,7 @@ void ChineseChessMenuActivity::onSelect() {
   if (it.disabled) return;
   switch (it.kind) {
     case ItemKind::Continue:
-      activityManager.replaceActivity(
-          std::make_unique<ChineseChessGameActivity>(renderer, mappedInput, it.mode, true, resumeAiLevel));
+      activityManager.replaceActivityWith<ChineseChessGameActivity>(it.mode, true, resumeAiLevel);
       return;
     case ItemKind::NewGame:
       if (it.mode == ChineseChessMode::VsAi) {
@@ -156,8 +154,7 @@ void ChineseChessMenuActivity::onSelect() {
         return;
       }
       ChineseChessStore::clear();
-      activityManager.replaceActivity(
-          std::make_unique<ChineseChessGameActivity>(renderer, mappedInput, it.mode, false));
+      activityManager.replaceActivityWith<ChineseChessGameActivity>(it.mode, false);
       return;
     case ItemKind::Stats:
       showingStats = true;

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -16,8 +16,6 @@ namespace {
 
 // Centralized font roles, mirroring Sudoku.
 constexpr int kStatusFont = UI_12_FONT_ID;           // title bar / mode line
-constexpr int kModalItemFont = UI_12_FONT_ID;        // game-menu modal rows
-constexpr int kModalHintFont = UI_10_FONT_ID;        // game-menu modal right-side hints
 constexpr int kHeroFont = NOTOSERIF_16_FONT_ID;      // win-screen big title
 constexpr int kStatValueFont = NOTOSANS_16_FONT_ID;  // win-screen stat values + info-panel stat values
 
@@ -201,29 +199,20 @@ void GomokuGameActivity::handleInputGameMenu() {
   constexpr int width = 320;
   const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
                                        rowHeight, MENU_ITEM_COUNT);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, MENU_ITEM_COUNT, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    menuSel = static_cast<uint8_t>(touched);
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) runMenuItem(menuSel);
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    menuSel = static_cast<uint8_t>((menuSel + MENU_ITEM_COUNT - 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    menuSel = static_cast<uint8_t>((menuSel + 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    runMenuItem(menuSel);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    resumeFromMenu();
-    requestUpdate();
+  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
+    case GameMenuInputResult::None:
+      return;
+    case GameMenuInputResult::SelectionChanged:
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Activated:
+      runMenuItem(menuSel);
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Dismissed:
+      resumeFromMenu();
+      requestUpdate();
+      return;
   }
 }
 
@@ -235,13 +224,12 @@ void GomokuGameActivity::handleInputGameOver() {
                                         metrics.contentSidePadding, metrics.menuSpacing, metrics.menuRowHeight, 1, 2);
   if (mappedInput.wasTapInRect(again.x, again.y, again.width, again.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    activityManager.replaceActivity(
-        std::make_unique<GomokuGameActivity>(renderer, mappedInput, mode, board.boardSize, false, aiLevel));
+    activityManager.replaceActivityWith<GomokuGameActivity>(mode, board.boardSize, false, aiLevel);
     return;
   }
   if (mappedInput.wasTapInRect(home.x, home.y, home.width, home.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    activityManager.replaceActivity(std::make_unique<GomokuMenuActivity>(renderer, mappedInput));
+    activityManager.replaceActivityWith<GomokuMenuActivity>();
   }
 }
 
@@ -371,12 +359,12 @@ void GomokuGameActivity::runMenuItem(uint8_t i) {
       const uint8_t bs = board.boardSize;
       const auto lv = aiLevel;
       GomokuStore::clear();
-      activityManager.replaceActivity(std::make_unique<GomokuGameActivity>(renderer, mappedInput, m, bs, false, lv));
+      activityManager.replaceActivityWith<GomokuGameActivity>(m, bs, false, lv);
       return;
     }
     case 4:  // Exit to menu
       flushSave();
-      activityManager.replaceActivity(std::make_unique<GomokuMenuActivity>(renderer, mappedInput));
+      activityManager.replaceActivityWith<GomokuMenuActivity>();
       return;
   }
 }
@@ -644,45 +632,16 @@ void GomokuGameActivity::renderGameMenu() {
   constexpr int rowH = 32;
   const Rect panel =
       gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  const int titleTextH = renderer.getTextHeight(kModalItemFont);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(kModalItemFont, x + 12, y + gameCenterY(titleH, titleTextH), tr(STR_GAME_GAME_MENU));
-
-  const char* labels[MENU_ITEM_COUNT] = {
-      tr(STR_GAME_RESUME), tr(STR_GOMOKU_UNDO), tr(STR_GOMOKU_RESIGN), tr(STR_GAME_NEW_GAME), tr(STR_GAME_EXIT),
-  };
-
-  // Right-side hints
   char undoHint[24] = "";
   if (board.moveCount > 0) {
     snprintf(undoHint, sizeof(undoHint), tr(STR_GOMOKU_MOVE_FMT), static_cast<unsigned>(board.moveCount));
   }
-  const char* hints[MENU_ITEM_COUNT] = {"", undoHint, "", "", tr(STR_GAME_HOME)};
-
-  const int itemTextH = renderer.getTextHeight(kModalItemFont);
-  const int hintTextH = renderer.getTextHeight(kModalHintFont);
-  const int firstY = y + titleH;
-
-  for (int i = 0; i < MENU_ITEM_COUNT; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == menuSel);
-    if (inverted) {
-      renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    }
-    renderer.drawText(kModalItemFont, x + 12, rowY + gameCenterY(rowH, itemTextH), labels[i], !inverted);
-    if (hints[i] && hints[i][0] != '\0') {
-      const int hw = renderer.getTextWidth(kModalHintFont, hints[i]);
-      renderer.drawText(kModalHintFont, x + w - 12 - hw, rowY + gameCenterY(rowH, hintTextH) + 2, hints[i], !inverted);
-    }
-  }
+  const GameMenuItem items[MENU_ITEM_COUNT] = {
+      {tr(STR_GAME_RESUME), ""},          {tr(STR_GOMOKU_UNDO), undoHint},
+      {tr(STR_GOMOKU_RESIGN), ""},        {tr(STR_GAME_NEW_GAME), ""},
+      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
+  };
+  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }
 
 // ---------- Game Over screen ----------

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -637,9 +637,8 @@ void GomokuGameActivity::renderGameMenu() {
     snprintf(undoHint, sizeof(undoHint), tr(STR_GOMOKU_MOVE_FMT), static_cast<unsigned>(board.moveCount));
   }
   const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},          {tr(STR_GOMOKU_UNDO), undoHint},
-      {tr(STR_GOMOKU_RESIGN), ""},        {tr(STR_GAME_NEW_GAME), ""},
-      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
+      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), undoHint},        {tr(STR_GOMOKU_RESIGN), ""},
+      {tr(STR_GAME_NEW_GAME), ""}, {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
   };
   gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }

--- a/src/activities/apps/gomoku/GomokuMenuActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.cpp
@@ -123,9 +123,8 @@ void GomokuMenuActivity::handleAiDifficultyInput() {
     requestUpdate();
     if (touch == MappedInputManager::RowTouch::Tap) {
       GomokuStore::clear();
-      activityManager.replaceActivity(
-          std::make_unique<GomokuGameActivity>(renderer, mappedInput, GomokuMode::VsAi, pendingAiBoardSize, false,
-                                               static_cast<GomokuAiLevel>(aiDifficultySel)));
+      activityManager.replaceActivityWith<GomokuGameActivity>(GomokuMode::VsAi, pendingAiBoardSize, false,
+                                                              static_cast<GomokuAiLevel>(aiDifficultySel));
     }
     return;
   }
@@ -140,8 +139,7 @@ void GomokuMenuActivity::handleAiDifficultyInput() {
   } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     GomokuStore::clear();
     const auto level = static_cast<GomokuAiLevel>(aiDifficultySel);
-    activityManager.replaceActivity(std::make_unique<GomokuGameActivity>(renderer, mappedInput, GomokuMode::VsAi,
-                                                                         pendingAiBoardSize, false, level));
+    activityManager.replaceActivityWith<GomokuGameActivity>(GomokuMode::VsAi, pendingAiBoardSize, false, level);
   } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     showingAiDifficulty = false;
     requestUpdate();
@@ -154,8 +152,7 @@ void GomokuMenuActivity::onSelect() {
   if (it.disabled) return;  // legacy guard; no items currently use it
   switch (it.kind) {
     case ItemKind::Continue:
-      activityManager.replaceActivity(
-          std::make_unique<GomokuGameActivity>(renderer, mappedInput, it.mode, it.boardSize, true, resumeAiLevel));
+      activityManager.replaceActivityWith<GomokuGameActivity>(it.mode, it.boardSize, true, resumeAiLevel);
       return;
     case ItemKind::NewGame:
       if (it.mode == GomokuMode::VsAi) {
@@ -167,8 +164,7 @@ void GomokuMenuActivity::onSelect() {
         return;
       }
       GomokuStore::clear();
-      activityManager.replaceActivity(
-          std::make_unique<GomokuGameActivity>(renderer, mappedInput, it.mode, it.boardSize, false));
+      activityManager.replaceActivityWith<GomokuGameActivity>(it.mode, it.boardSize, false);
       return;
     case ItemKind::Stats:
       showingStats = true;

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -18,8 +18,6 @@ namespace {
 
 // Centralized font roles. All ≤16 pt so OMIT_LARGE_READER_FONTS builds work.
 constexpr int kStatusFont = UI_12_FONT_ID;             // title bar
-constexpr int kModalItemFont = UI_12_FONT_ID;          // game-menu modal rows
-constexpr int kModalHintFont = UI_10_FONT_ID;          // game-menu modal right-side hints
 constexpr int kHeroFont = NOTOSERIF_16_FONT_ID;        // end-screen big title
 constexpr int kStatValueFont = NOTOSANS_16_FONT_ID;    // end-screen stat columns
 constexpr int kNumberFontBig = NOTOSERIF_16_FONT_ID;   // cell digit (Easy/Medium)
@@ -323,29 +321,20 @@ void MinesweeperGameActivity::handleInputGameMenu() {
   constexpr int width = 340;
   const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
                                        rowHeight, MENU_ITEM_COUNT);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, MENU_ITEM_COUNT, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    menuSel = static_cast<uint8_t>(touched);
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) runMenuItem(menuSel);
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    menuSel = static_cast<uint8_t>((menuSel + MENU_ITEM_COUNT - 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    menuSel = static_cast<uint8_t>((menuSel + 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    runMenuItem(menuSel);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    resumeFromMenu();
-    requestUpdate();
+  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
+    case GameMenuInputResult::None:
+      return;
+    case GameMenuInputResult::SelectionChanged:
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Activated:
+      runMenuItem(menuSel);
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Dismissed:
+      resumeFromMenu();
+      requestUpdate();
+      return;
   }
 }
 
@@ -376,12 +365,12 @@ void MinesweeperGameActivity::runMenuItem(uint8_t i) {
     case 5: {  // New Game (same difficulty, new layout)
       const auto diff = difficulty;
       MinesweeperStore::clear();
-      activityManager.replaceActivity(std::make_unique<MinesweeperGameActivity>(renderer, mappedInput, diff, false));
+      activityManager.replaceActivityWith<MinesweeperGameActivity>(diff, false);
       return;
     }
     case 6:  // Exit to Minesweeper menu
       flushSave();
-      activityManager.replaceActivity(std::make_unique<MinesweeperMenuActivity>(renderer, mappedInput));
+      activityManager.replaceActivityWith<MinesweeperMenuActivity>();
       return;
   }
 }
@@ -395,12 +384,12 @@ void MinesweeperGameActivity::handleInputEnd() {
   if (mappedInput.wasTapInRect(again.x, again.y, again.width, again.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const auto diff = difficulty;
-    activityManager.replaceActivity(std::make_unique<MinesweeperGameActivity>(renderer, mappedInput, diff, false));
+    activityManager.replaceActivityWith<MinesweeperGameActivity>(diff, false);
     return;
   }
   if (mappedInput.wasTapInRect(home.x, home.y, home.width, home.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    activityManager.replaceActivity(std::make_unique<MinesweeperMenuActivity>(renderer, mappedInput));
+    activityManager.replaceActivityWith<MinesweeperMenuActivity>();
   }
 }
 
@@ -687,29 +676,9 @@ void MinesweeperGameActivity::renderGameMenu() {
   constexpr int rowH = 32;
   const Rect panel =
       gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 340, titleH, rowH, MENU_ITEM_COUNT);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  const int titleTextH = renderer.getTextHeight(kModalItemFont);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(kModalItemFont, x + 12, y + gameCenterY(titleH, titleTextH), tr(STR_GAME_GAME_MENU));
-
-  // Item 2 label changes based on current cell state.
   const bool isFlagged =
       (cursorR < board.rows && cursorC < board.cols && board.at(cursorR, cursorC).state == MinesweeperBoard::Flagged);
   const char* flagItemLabel = isFlagged ? tr(STR_MINESWEEPER_UNFLAG_HERE) : tr(STR_MINESWEEPER_FLAG_HERE);
-
-  const char* labels[MENU_ITEM_COUNT] = {
-      tr(STR_GAME_RESUME),         tr(STR_MINESWEEPER_TOGGLE_MODE), flagItemLabel,     tr(STR_MINESWEEPER_USE_HINT),
-      tr(STR_MINESWEEPER_RESTART), tr(STR_GAME_NEW_GAME),           tr(STR_GAME_EXIT),
-  };
-
-  // Right-side hints.
   const char* hintMode = flagMode ? tr(STR_MINESWEEPER_MODE_FLAG) : tr(STR_MINESWEEPER_MODE_DIG);
   char hintHint[16];
   if (hintsLeft > 0) {
@@ -717,22 +686,11 @@ void MinesweeperGameActivity::renderGameMenu() {
   } else {
     snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_MINESWEEPER_NO_HINTS));
   }
-  const char* hints[MENU_ITEM_COUNT] = {"", hintMode, "", hintHint, "", "", tr(STR_GAME_HOME)};
-
-  const int itemTextH = renderer.getTextHeight(kModalItemFont);
-  const int hintTextH = renderer.getTextHeight(kModalHintFont);
-  const int firstY = y + titleH;
-
-  for (int i = 0; i < MENU_ITEM_COUNT; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == menuSel);
-    if (inverted) {
-      renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    }
-    renderer.drawText(kModalItemFont, x + 12, rowY + gameCenterY(rowH, itemTextH), labels[i], !inverted);
-    if (hints[i] && hints[i][0] != '\0') {
-      const int hw = renderer.getTextWidth(kModalHintFont, hints[i]);
-      renderer.drawText(kModalHintFont, x + w - 12 - hw, rowY + gameCenterY(rowH, hintTextH) + 2, hints[i], !inverted);
-    }
-  }
+  const GameMenuItem items[MENU_ITEM_COUNT] = {
+      {tr(STR_GAME_RESUME), ""},                 {tr(STR_MINESWEEPER_TOGGLE_MODE), hintMode},
+      {flagItemLabel, ""},                       {tr(STR_MINESWEEPER_USE_HINT), hintHint},
+      {tr(STR_MINESWEEPER_RESTART), ""},         {tr(STR_GAME_NEW_GAME), ""},
+      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
+  };
+  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -687,9 +687,12 @@ void MinesweeperGameActivity::renderGameMenu() {
     snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_MINESWEEPER_NO_HINTS));
   }
   const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},                 {tr(STR_MINESWEEPER_TOGGLE_MODE), hintMode},
-      {flagItemLabel, ""},                       {tr(STR_MINESWEEPER_USE_HINT), hintHint},
-      {tr(STR_MINESWEEPER_RESTART), ""},         {tr(STR_GAME_NEW_GAME), ""},
+      {tr(STR_GAME_RESUME), ""},
+      {tr(STR_MINESWEEPER_TOGGLE_MODE), hintMode},
+      {flagItemLabel, ""},
+      {tr(STR_MINESWEEPER_USE_HINT), hintHint},
+      {tr(STR_MINESWEEPER_RESTART), ""},
+      {tr(STR_GAME_NEW_GAME), ""},
       {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
   };
   gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);

--- a/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
@@ -107,13 +107,11 @@ void MinesweeperMenuActivity::onSelect() {
   const Item& it = items[selected];
   switch (it.kind) {
     case ItemKind::Continue:
-      activityManager.replaceActivity(
-          std::make_unique<MinesweeperGameActivity>(renderer, mappedInput, it.difficulty, true));
+      activityManager.replaceActivityWith<MinesweeperGameActivity>(it.difficulty, true);
       return;
     case ItemKind::NewGame:
       MinesweeperStore::clear();
-      activityManager.replaceActivity(
-          std::make_unique<MinesweeperGameActivity>(renderer, mappedInput, it.difficulty, false));
+      activityManager.replaceActivityWith<MinesweeperGameActivity>(it.difficulty, false);
       return;
     case ItemKind::Stats:
       showingStats = true;

--- a/src/activities/apps/reading-stats/BookReadingAdjustmentActivity.cpp
+++ b/src/activities/apps/reading-stats/BookReadingAdjustmentActivity.cpp
@@ -71,16 +71,17 @@ void BookReadingAdjustmentActivity::initializeSelectedDate() {
 }
 
 void BookReadingAdjustmentActivity::openDateSelection() {
-  startActivityForResult(std::make_unique<ReadingDateSelectionActivity>(renderer, mappedInput, selectedDayOrdinal),
-                         [this](const ActivityResult& result) {
-                           if (!result.isCancelled) {
-                             if (const auto* page = std::get_if<PageResult>(&result.data)) {
-                               selectedDayOrdinal = page->page;
-                               lastApplyFailed = false;
-                             }
-                           }
-                           requestUpdate();
-                         });
+  startActivityForResultWith<ReadingDateSelectionActivity>(
+      [this](const ActivityResult& result) {
+        if (!result.isCancelled) {
+          if (const auto* page = std::get_if<PageResult>(&result.data)) {
+            selectedDayOrdinal = page->page;
+            lastApplyFailed = false;
+          }
+        }
+        requestUpdate();
+      },
+      selectedDayOrdinal);
 }
 
 int32_t BookReadingAdjustmentActivity::getSelectedDeltaMs() const {

--- a/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
@@ -35,12 +35,12 @@ void ReadingDayDetailActivity::openSelectedBook() {
     return;
   }
 
-  startActivityForResult(
-      std::make_unique<ReadingStatsDetailActivity>(renderer, mappedInput, entries[selectedIndex].book->path),
+  startActivityForResultWith<ReadingStatsDetailActivity>(
       [this](const ActivityResult&) {
         refreshEntries();
         requestUpdate();
-      });
+      },
+      entries[selectedIndex].book->path);
 }
 
 void ReadingDayDetailActivity::onEnter() {

--- a/src/activities/apps/reading-stats/ReadingHeatmapActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingHeatmapActivity.cpp
@@ -486,8 +486,8 @@ void ReadingHeatmapActivity::loop() {
       if (cells[static_cast<size_t>(index)].inViewedMonth) {
         selectedDayOrdinal = cells[static_cast<size_t>(index)].dayOrdinal;
         if (tapped) {
-          startActivityForResultWith<ReadingDayDetailActivity>(
-              [this](const ActivityResult&) { requestUpdate(); }, selectedDayOrdinal);
+          startActivityForResultWith<ReadingDayDetailActivity>([this](const ActivityResult&) { requestUpdate(); },
+                                                               selectedDayOrdinal);
         } else {
           requestUpdate();
         }

--- a/src/activities/apps/reading-stats/ReadingHeatmapActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingHeatmapActivity.cpp
@@ -486,8 +486,8 @@ void ReadingHeatmapActivity::loop() {
       if (cells[static_cast<size_t>(index)].inViewedMonth) {
         selectedDayOrdinal = cells[static_cast<size_t>(index)].dayOrdinal;
         if (tapped) {
-          startActivityForResult(std::make_unique<ReadingDayDetailActivity>(renderer, mappedInput, selectedDayOrdinal),
-                                 [this](const ActivityResult&) { requestUpdate(); });
+          startActivityForResultWith<ReadingDayDetailActivity>(
+              [this](const ActivityResult&) { requestUpdate(); }, selectedDayOrdinal);
         } else {
           requestUpdate();
         }
@@ -497,8 +497,8 @@ void ReadingHeatmapActivity::loop() {
   }
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    startActivityForResult(std::make_unique<ReadingDayDetailActivity>(renderer, mappedInput, selectedDayOrdinal),
-                           [this](const ActivityResult&) { requestUpdate(); });
+    startActivityForResultWith<ReadingDayDetailActivity>([this](const ActivityResult&) { requestUpdate(); },
+                                                         selectedDayOrdinal);
     return;
   }
 

--- a/src/activities/apps/reading-stats/ReadingStatsActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsActivity.cpp
@@ -409,11 +409,10 @@ void ReadingStatsActivity::loop() {
 void ReadingStatsActivity::openSelectedEntry() {
   const auto& books = READING_STATS.getBooks();
   if (selectedIndex == 0) {
-    startActivityForResult(std::make_unique<ReadingStatsExtendedActivity>(renderer, mappedInput),
-                           [this](const ActivityResult&) {
-                             guardBackReturn();
-                             requestUpdate();
-                           });
+    startActivityForResultWith<ReadingStatsExtendedActivity>([this](const ActivityResult&) {
+      guardBackReturn();
+      requestUpdate();
+    });
     return;
   }
   const int bookIndex = selectedIndex - 1;
@@ -421,11 +420,12 @@ void ReadingStatsActivity::openSelectedEntry() {
     return;
   }
 
-  startActivityForResult(std::make_unique<ReadingStatsDetailActivity>(renderer, mappedInput, books[bookIndex].path),
-                         [this](const ActivityResult&) {
-                           guardBackReturn();
-                           requestUpdate();
-                         });
+  startActivityForResultWith<ReadingStatsDetailActivity>(
+      [this](const ActivityResult&) {
+        guardBackReturn();
+        requestUpdate();
+      },
+      books[bookIndex].path);
 }
 
 void ReadingStatsActivity::confirmRemoveSelectedBook() {
@@ -437,17 +437,17 @@ void ReadingStatsActivity::confirmRemoveSelectedBook() {
 
   const ReadingBookStats selectedBook = books[bookIndex];
   const int currentSelection = selectedIndex;
-  startActivityForResult(std::make_unique<ConfirmationActivity>(renderer, mappedInput, tr(STR_DELETE_STATS_ENTRY),
-                                                                getBookTitle(selectedBook)),
-                         [this, selectedBook, currentSelection](const ActivityResult& result) {
-                           if (!result.isCancelled && READING_STATS.removeBook(selectedBook.path)) {
-                             const int bookCount = static_cast<int>(READING_STATS.getBooks().size());
-                             selectedIndex = InxStatisticsGeometry::clampView(currentSelection, bookCount);
-                           }
+  startActivityForResultWith<ConfirmationActivity>(
+      [this, selectedBook, currentSelection](const ActivityResult& result) {
+        if (!result.isCancelled && READING_STATS.removeBook(selectedBook.path)) {
+          const int bookCount = static_cast<int>(READING_STATS.getBooks().size());
+          selectedIndex = InxStatisticsGeometry::clampView(currentSelection, bookCount);
+        }
 
-                           guardBackReturn();
-                           requestUpdate(true);
-                         });
+        guardBackReturn();
+        requestUpdate(true);
+      },
+      tr(STR_DELETE_STATS_ENTRY), getBookTitle(selectedBook));
 }
 
 void ReadingStatsActivity::guardBackReturn() {

--- a/src/activities/apps/reading-stats/ReadingStatsDetailActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsDetailActivity.cpp
@@ -432,12 +432,12 @@ void ReadingStatsDetailActivity::openAdjustment() {
     return;
   }
 
-  startActivityForResult(
-      std::make_unique<BookReadingAdjustmentActivity>(renderer, mappedInput, book->path, getDisplayTitle(*book)),
+  startActivityForResultWith<BookReadingAdjustmentActivity>(
       [this](const ActivityResult&) {
         guardChildReturn();
         requestUpdate();
-      });
+      },
+      book->path, getDisplayTitle(*book));
 }
 
 void ReadingStatsDetailActivity::guardChildReturn() {

--- a/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
@@ -54,20 +54,16 @@ void ReadingStatsMenuActivity::openSelected() {
   // Leaves call finish() on Back, so pushing them returns control here.
   switch (kEntries[selected].screen) {
     case StatsScreen::Stats:
-      startActivityForResult(std::make_unique<ReadingStatsActivity>(renderer, mappedInput),
-                             [](const ActivityResult&) {});
+      startActivityForResultWith<ReadingStatsActivity>([](const ActivityResult&) {});
       break;
     case StatsScreen::Heatmap:
-      startActivityForResult(std::make_unique<ReadingHeatmapActivity>(renderer, mappedInput),
-                             [](const ActivityResult&) {});
+      startActivityForResultWith<ReadingHeatmapActivity>([](const ActivityResult&) {});
       break;
     case StatsScreen::Profile:
-      startActivityForResult(std::make_unique<ReadingProfileActivity>(renderer, mappedInput),
-                             [](const ActivityResult&) {});
+      startActivityForResultWith<ReadingProfileActivity>([](const ActivityResult&) {});
       break;
     case StatsScreen::Achievements:
-      startActivityForResult(std::make_unique<AchievementsActivity>(renderer, mappedInput),
-                             [](const ActivityResult&) {});
+      startActivityForResultWith<AchievementsActivity>([](const ActivityResult&) {});
       break;
   }
 }

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -739,9 +739,12 @@ void SudokuGameActivity::renderGameMenu() {
     snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_SUDOKU_NO_HINTS));
   }
   const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},              {tr(STR_SUDOKU_TOGGLE_NOTES), hintNotes},
-      {tr(STR_SUDOKU_USE_HINT), hintHint},     {tr(STR_SUDOKU_CHECK_ERRORS), ""},
-      {tr(STR_SUDOKU_RESTART), ""},           {tr(STR_GAME_NEW_GAME), ""},
+      {tr(STR_GAME_RESUME), ""},
+      {tr(STR_SUDOKU_TOGGLE_NOTES), hintNotes},
+      {tr(STR_SUDOKU_USE_HINT), hintHint},
+      {tr(STR_SUDOKU_CHECK_ERRORS), ""},
+      {tr(STR_SUDOKU_RESTART), ""},
+      {tr(STR_GAME_NEW_GAME), ""},
       {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
   };
   gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -22,8 +22,6 @@ constexpr int kBigDigitFont = NOTOSERIF_16_FONT_ID;   // fixed (given) digits + 
 constexpr int kUserDigitFont = NOTOSERIF_14_FONT_ID;  // user-input digits — smaller = thinner & lighter
 constexpr int kNotesFont = NOTOSANS_12_FONT_ID;       // 3×3 candidate notes
 constexpr int kStatusFont = UI_12_FONT_ID;            // title bar / mode line
-constexpr int kModalItemFont = UI_12_FONT_ID;         // game-menu modal rows
-constexpr int kModalHintFont = UI_10_FONT_ID;         // game-menu right-side hints
 constexpr int kHeroFont = NOTOSERIF_16_FONT_ID;       // win-screen "Solved!"
 constexpr int kStatValueFont = NOTOSANS_16_FONT_ID;   // win-screen stat columns
 
@@ -126,12 +124,12 @@ void SudokuGameActivity::handleInputWon() {
   if (mappedInput.wasTapInRect(again.x, again.y, again.width, again.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const auto diff = difficulty;
-    activityManager.replaceActivity(std::make_unique<SudokuGameActivity>(renderer, mappedInput, diff, false));
+    activityManager.replaceActivityWith<SudokuGameActivity>(diff, false);
     return;
   }
   if (mappedInput.wasTapInRect(home.x, home.y, home.width, home.height) ||
       mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    activityManager.replaceActivity(std::make_unique<SudokuMenuActivity>(renderer, mappedInput));
+    activityManager.replaceActivityWith<SudokuMenuActivity>();
   }
 }
 
@@ -146,29 +144,20 @@ void SudokuGameActivity::handleInputGameMenu() {
   constexpr int width = 320;
   const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
                                        rowHeight, MENU_ITEM_COUNT);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, MENU_ITEM_COUNT, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    menuSel = static_cast<uint8_t>(touched);
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) runMenuItem(menuSel);
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    menuSel = static_cast<uint8_t>((menuSel + MENU_ITEM_COUNT - 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    menuSel = static_cast<uint8_t>((menuSel + 1) % MENU_ITEM_COUNT);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    runMenuItem(menuSel);
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    resumeFromMenu();
-    requestUpdate();
+  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
+    case GameMenuInputResult::None:
+      return;
+    case GameMenuInputResult::SelectionChanged:
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Activated:
+      runMenuItem(menuSel);
+      requestUpdate();
+      return;
+    case GameMenuInputResult::Dismissed:
+      resumeFromMenu();
+      requestUpdate();
+      return;
   }
 }
 
@@ -196,12 +185,12 @@ void SudokuGameActivity::runMenuItem(uint8_t i) {
     case 5: {  // New game (same difficulty)
       const auto diff = difficulty;
       SudokuStore::clear();
-      activityManager.replaceActivity(std::make_unique<SudokuGameActivity>(renderer, mappedInput, diff, false));
+      activityManager.replaceActivityWith<SudokuGameActivity>(diff, false);
       return;
     }
     case 6:  // Exit to Sudoku menu
       flushSave();
-      activityManager.replaceActivity(std::make_unique<SudokuMenuActivity>(renderer, mappedInput));
+      activityManager.replaceActivityWith<SudokuMenuActivity>();
       return;
   }
 }
@@ -742,25 +731,6 @@ void SudokuGameActivity::renderGameMenu() {
   constexpr int rowH = 32;
   const Rect panel =
       gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  // Title bar.
-  const int titleTextH = renderer.getTextHeight(kModalItemFont);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(kModalItemFont, x + 12, y + gameCenterY(titleH, titleTextH), tr(STR_GAME_GAME_MENU));
-
-  const char* labels[MENU_ITEM_COUNT] = {
-      tr(STR_GAME_RESUME),    tr(STR_SUDOKU_TOGGLE_NOTES), tr(STR_SUDOKU_USE_HINT), tr(STR_SUDOKU_CHECK_ERRORS),
-      tr(STR_SUDOKU_RESTART), tr(STR_GAME_NEW_GAME),       tr(STR_GAME_EXIT),
-  };
-
-  // Right-side hints (i18n-driven; no hardcoded English).
   const char* hintNotes = notesMode ? tr(STR_SUDOKU_MODE_NOTES) : tr(STR_SUDOKU_MODE_NORMAL);
   char hintHint[16];
   if (hintsLeft > 0) {
@@ -768,22 +738,11 @@ void SudokuGameActivity::renderGameMenu() {
   } else {
     snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_SUDOKU_NO_HINTS));
   }
-  const char* hints[MENU_ITEM_COUNT] = {"", hintNotes, hintHint, "", "", "", tr(STR_GAME_HOME)};
-
-  const int itemTextH = renderer.getTextHeight(kModalItemFont);
-  const int hintTextH = renderer.getTextHeight(kModalHintFont);
-  const int firstY = y + titleH;
-
-  for (int i = 0; i < MENU_ITEM_COUNT; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == menuSel);
-    if (inverted) {
-      renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    }
-    renderer.drawText(kModalItemFont, x + 12, rowY + gameCenterY(rowH, itemTextH), labels[i], !inverted);
-    if (hints[i] && hints[i][0] != '\0') {
-      const int hw = renderer.getTextWidth(kModalHintFont, hints[i]);
-      renderer.drawText(kModalHintFont, x + w - 12 - hw, rowY + gameCenterY(rowH, hintTextH) + 2, hints[i], !inverted);
-    }
-  }
+  const GameMenuItem items[MENU_ITEM_COUNT] = {
+      {tr(STR_GAME_RESUME), ""},              {tr(STR_SUDOKU_TOGGLE_NOTES), hintNotes},
+      {tr(STR_SUDOKU_USE_HINT), hintHint},     {tr(STR_SUDOKU_CHECK_ERRORS), ""},
+      {tr(STR_SUDOKU_RESTART), ""},           {tr(STR_GAME_NEW_GAME), ""},
+      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
+  };
+  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }

--- a/src/activities/apps/sudoku/SudokuMenuActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuMenuActivity.cpp
@@ -98,12 +98,11 @@ void SudokuMenuActivity::onSelect() {
   const Item& it = items[selected];
   switch (it.kind) {
     case ItemKind::Continue:
-      activityManager.replaceActivity(std::make_unique<SudokuGameActivity>(renderer, mappedInput, it.difficulty, true));
+      activityManager.replaceActivityWith<SudokuGameActivity>(it.difficulty, true);
       return;
     case ItemKind::NewGame:
       SudokuStore::clear();
-      activityManager.replaceActivity(
-          std::make_unique<SudokuGameActivity>(renderer, mappedInput, it.difficulty, false));
+      activityManager.replaceActivityWith<SudokuGameActivity>(it.difficulty, false);
       return;
     case ItemKind::Stats:
       showingStats = true;

--- a/test/game_ui/CMakeLists.txt
+++ b/test/game_ui/CMakeLists.txt
@@ -3,5 +3,6 @@ add_executable(GameUiTest
   ${REPO_ROOT}/src/activities/apps/GameUi.cpp
 )
 target_link_libraries(GameUiTest PRIVATE crosspoint_test_common GTest::gtest_main)
+target_include_directories(GameUiTest BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/stubs)
 target_include_directories(GameUiTest PRIVATE ${REPO_ROOT}/src)
 gtest_discover_tests(GameUiTest)

--- a/test/game_ui/GameUiTest.cpp
+++ b/test/game_ui/GameUiTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include "GfxRenderer.h"
+#include "MappedInputManager.h"
 #include "activities/apps/GameUi.h"
 
 TEST(GameUiTouchGeometry, GridRejectsOutsideAndMapsEdges) {
@@ -60,4 +62,58 @@ TEST(GameUiTouchGeometry, MenuPanelCentersAndRejectsInvalidGeometry) {
 
   EXPECT_EQ(gameMenuPanelRect(480, 800, 0, 28, 32, 7).width, 0);
   EXPECT_EQ(gameMenuPanelRect(480, 100, 320, 28, 32, 7).height, 0);
+}
+
+TEST(GameUiMenuInput, RejectsEmptyAndHandlesTouch) {
+  MappedInputManager input;
+  const Rect panel{80, 272, 320, 256};
+  uint8_t selected = 0;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 0, selected), GameMenuInputResult::None);
+
+  input.touch = MappedInputManager::RowTouch::Down;
+  input.touchedRow = 2;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
+  EXPECT_EQ(selected, 2);
+
+  input.touch = MappedInputManager::RowTouch::Tap;
+  input.touchedRow = 3;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Activated);
+  EXPECT_EQ(selected, 3);
+}
+
+TEST(GameUiMenuInput, WrapsSelectionAndReportsActions) {
+  MappedInputManager input;
+  const Rect panel{80, 272, 320, 256};
+  uint8_t selected = 0;
+
+  input.hasPressed = true;
+  input.pressed = MappedInputManager::Button::Up;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
+  EXPECT_EQ(selected, 3);
+
+  input.pressed = MappedInputManager::Button::Down;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
+  EXPECT_EQ(selected, 0);
+
+  input.hasPressed = false;
+  input.hasReleased = true;
+  input.released = MappedInputManager::Button::Confirm;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Activated);
+  input.released = MappedInputManager::Button::Back;
+  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Dismissed);
+}
+
+TEST(GameUiMenuDrawing, SkipsEmptyHints) {
+  GfxRenderer renderer;
+  const GameMenuItem items[] = {{"Resume", ""}, {"Exit", "Home"}};
+  gameDrawMenu(renderer, Rect{80, 300, 320, 96}, 28, 32, "Menu", items, 2, 1);
+
+  ASSERT_EQ(renderer.textCalls.size(), 4u);
+  EXPECT_EQ(renderer.textCalls[0].text, "Menu");
+  EXPECT_EQ(renderer.textCalls[1].text, "Resume");
+  EXPECT_EQ(renderer.textCalls[2].text, "Exit");
+  EXPECT_EQ(renderer.textCalls[3].text, "Home");
+  EXPECT_TRUE(renderer.textCalls[1].black);
+  EXPECT_FALSE(renderer.textCalls[2].black);
+  EXPECT_FALSE(renderer.textCalls[3].black);
 }

--- a/test/game_ui/stubs/GfxRenderer.h
+++ b/test/game_ui/stubs/GfxRenderer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class GfxRenderer {
+ public:
+  struct TextCall {
+    int font;
+    std::string text;
+    bool black;
+  };
+
+  std::vector<TextCall> textCalls;
+  int fillCount = 0;
+  int rectCount = 0;
+
+  void fillRect(int, int, int, int, bool) { ++fillCount; }
+  void drawRect(int, int, int, int, int, bool) { ++rectCount; }
+  int getTextHeight(int) const { return 12; }
+  int getTextWidth(int, const char* text) const { return static_cast<int>(std::string(text).size()) * 6; }
+  void drawText(int font, int, int, const char* text, bool black = true) {
+    textCalls.push_back({font, text, black});
+  }
+};

--- a/test/game_ui/stubs/GfxRenderer.h
+++ b/test/game_ui/stubs/GfxRenderer.h
@@ -11,15 +11,15 @@ class GfxRenderer {
     bool black;
   };
 
-  std::vector<TextCall> textCalls;
-  int fillCount = 0;
-  int rectCount = 0;
+  mutable std::vector<TextCall> textCalls;
+  mutable int fillCount = 0;
+  mutable int rectCount = 0;
 
-  void fillRect(int, int, int, int, bool) { ++fillCount; }
-  void drawRect(int, int, int, int, int, bool) { ++rectCount; }
+  void fillRect(int, int, int, int, bool) const { ++fillCount; }
+  void drawRect(int, int, int, int, int, bool) const { ++rectCount; }
   int getTextHeight(int) const { return 12; }
   int getTextWidth(int, const char* text) const { return static_cast<int>(std::string(text).size()) * 6; }
-  void drawText(int font, int, int, const char* text, bool black = true) {
+  void drawText(int font, int, int, const char* text, bool black = true) const {
     textCalls.push_back({font, text, black});
   }
 };

--- a/test/game_ui/stubs/MappedInputManager.h
+++ b/test/game_ui/stubs/MappedInputManager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+class MappedInputManager {
+ public:
+  enum class Button { Back, Confirm, Left, Right, Up, Down };
+  enum class RowTouch : uint8_t { None, Down, Tap };
+
+  RowTouch touch = RowTouch::None;
+  int touchedRow = -1;
+  Button pressed = Button::Back;
+  Button released = Button::Up;
+  bool hasPressed = false;
+  bool hasReleased = false;
+
+  RowTouch rowTouch(int& row, int, int, int, int, int, int) const {
+    row = touchedRow;
+    return touch;
+  }
+  bool wasPressed(Button button) const { return hasPressed && pressed == button; }
+  bool wasReleased(Button button) const { return hasReleased && released == button; }
+};


### PR DESCRIPTION
## Summary

* Add fallible Activity construction helpers that preserve the current page on OOM.
* Share fixed-array game menu input and rendering across Sudoku, Gomoku, Minesweeper, and Chinese Chess.
* Document the minimal app patterns and add host coverage for the shared menu behavior.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR does not add an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is an internal framework refactor; no stock-firmware feature replacement applies.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Validation

* 308/308 host tests passed.
* PlatformIO default, gh_release_cn, and simulator builds passed.
* Static RAM unchanged at 51,740 bytes; linked DRAM unchanged at 118,725 bytes.
* Flash increased by 3,364 bytes; rodata decreased by 192 bytes.

## Additional Context

No persistence format changes and no new resident heap allocations.

### AI Usage

Did you use AI tools to help write this code? YES