### PR TITLE
fix: persist OTA nightly channel

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -218,6 +218,7 @@ void CrossPointSettings::toJson(JsonDocument& doc) const {
   if (dictionaryName[0] != '\0') {
     doc["dictionaryName"] = dictionaryName;
   }
+  doc["otaNightlyEnabled"] = otaNightlyEnabled;
 
   // Language -- managed by LanguageSelectActivity, not in SettingsList.
   // Stored as ISO code string ("EN", "DE", ...) for stability across enum reorders.
@@ -362,6 +363,8 @@ bool CrossPointSettings::fromJson(JsonVariantConst doc) {
 #endif
   // Dictionary folder name — uses dynamic getter/setter in SettingsList, load manually
   copyToField(dictionaryName, doc["dictionaryName"] | "", sizeof(dictionaryName));
+  otaNightlyEnabled =
+      clamp(static_cast<uint8_t>(doc["otaNightlyEnabled"] | 0), static_cast<uint8_t>(2), static_cast<uint8_t>(0));
 
   // Language -- stored as code string for stability across enum reorders.
   if (doc["language"].is<const char*>()) {

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -352,6 +352,8 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   uint8_t language = defaultLanguageIndex();
   // Quick Resume: keep current content visible with moon icon instead of showing a static sleep screen.
   uint8_t quickResumeSleepScreen = QUICK_RESUME_NEVER;
+  // OTA update channel preference (0 = stable, 1 = nightly).
+  uint8_t otaNightlyEnabled = 0;
   // Reading Analytics suite settings.
   // Daily reading goal target (DAILY_GOAL_TARGET enum index).
   uint8_t dailyGoalTarget = DAILY_GOAL_30_MIN;

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -5,6 +5,7 @@
 #include <Memory.h>
 #include <WiFi.h>
 
+#include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "SdCardFontSystem.h"
 #include "SilentRestart.h"
@@ -82,7 +83,7 @@ void OtaUpdateActivity::onEnter() {
   Activity::onEnter();
 
   state = READY;
-  selectedChannel = OtaUpdater::Channel::Stable;
+  selectedChannel = SETTINGS.otaNightlyEnabled ? OtaUpdater::Channel::Nightly : OtaUpdater::Channel::Stable;
   selectedReadyRow = CHECK_UPDATES_ROW;
   waitForConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
   requestUpdate();
@@ -96,6 +97,8 @@ void OtaUpdateActivity::activateReadyRow() {
     case NIGHTLY_ROW:
       selectedChannel =
           selectedChannel == OtaUpdater::Channel::Stable ? OtaUpdater::Channel::Nightly : OtaUpdater::Channel::Stable;
+      SETTINGS.otaNightlyEnabled = selectedChannel == OtaUpdater::Channel::Nightly;
+      SETTINGS.saveToFile();
       requestUpdate();
       break;
     case READY_ROW_COUNT:


### PR DESCRIPTION
## Summary
- persist the OTA Nightly toggle in settings.json
- restore the selected OTA channel when reopening the update screen
- keep Stable as the default for existing settings files

## Validation
- pio run
- pio run -e gh_release_cn
- ./bin/clang-format-fix -g --check
- git diff --check