### PR TITLE
feat: add X4 Pro beta build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           if-no-files-found: error
 
   build-sticky:
-    name: Build sticky
+    name: Build Sticky and X4 Pro
     # Match the default job's trusted-runner policy without exposing H2O to fork PRs.
     runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && 'h2o' || 'ubuntu-latest' }}
     steps:
@@ -180,10 +180,10 @@ jobs:
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
           restore-keys: pio-${{ runner.os }}-
 
-      - name: Build sticky firmware
+      - name: Build Sticky and X4 Pro firmware
         run: |
           set -euo pipefail
-          pio run -e sticky | tee pio.log
+          pio run -e sticky -e x4pro | tee pio.log
 
       - name: Extract firmware stats
         run: |

--- a/bin/ci-check
+++ b/bin/ci-check
@@ -17,8 +17,8 @@ echo "Checking formatting..."
 echo "Running cppcheck..."
 pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
 
-echo "Building default and sticky firmware..."
-pio run -e default -e sticky
+echo "Building default, Sticky, and X4 Pro firmware..."
+pio run -e default -e sticky -e x4pro
 
 echo "Running host unit tests..."
 cmake -S test -B build/test -G Ninja -DCMAKE_BUILD_TYPE=Release

--- a/docs/contributing/touch-and-ui.md
+++ b/docs/contributing/touch-and-ui.md
@@ -155,7 +155,7 @@ Because the back gesture arrives as `Button::Back`, most button-era activities g
 
 ## Building and testing on non-Xteink devices
 
-Each MCU family is its own binary: X3/X4 are ESP32-C3, Sticky and LilyGo T5 are ESP32-S3, M5Paper v1.1 is a classic ESP32. The Sticky env ships in `platformio.ini` (`pio run -e sticky`). Envs for other devices go in **`platformio.local.ini`**, a gitignored file that PlatformIO merges over `platformio.ini` (see `extra_configs`). Create it next to `platformio.ini`; personal envs, ports, and debug flags live there and never get committed.
+Each MCU family is its own binary: X3/X4 are ESP32-C3, X4 Pro, Sticky, and LilyGo T5 are ESP32-S3, M5Paper v1.1 is a classic ESP32. The X4 Pro and Sticky envs ship in `platformio.ini` (`pio run -e x4pro`, `pio run -e sticky`); the X4 Pro Beta build defaults to the Chinese firmware profile. Envs for other devices go in **`platformio.local.ini`**, a gitignored file that PlatformIO merges over `platformio.ini` (see `extra_configs`). Create it next to `platformio.ini`; personal envs, ports, and debug flags live there and never get committed.
 
 Both envs below extend the repo's `[base]`, so they build against the `freeink-sdk` submodule with all the normal deps and scripts.
 

--- a/docs/engineering/build-system.md
+++ b/docs/engineering/build-system.md
@@ -34,6 +34,8 @@
   * `gh_release_rc`: Release candidate (LOG_LEVEL=1)
   * `slim`: Minimal build (no serial logging)
   * `gh_release_cn`: Simplified-Chinese-only release with embedded CJK fonts (see [chinese-build.md](chinese-build.md))
+  * `sticky`: Seeed Sticky ESP32-S3 development build
+  * `x4pro`: Xteink X4 Pro ESP32-S3 experimental Chinese development build
   * `simulator`: Native X4 desktop simulator supplied by the pinned simulator fork
   * `simulator_x3`: Native X3 desktop simulator
   * `simulator_eego_a4`: Native 768x552 eego A4 product simulator
@@ -100,7 +102,8 @@ These flags in `platformio.ini` fundamentally affect firmware behavior:
   power sequencing needed to avoid the persistent ghosting seen with the
   weaker incremental `0x1C` path.
 - X3 is runtime-selected before display initialization and uses its UC81xx
-  driver and SPI configuration unchanged. Sticky likewise retains its
+  driver and SPI configuration unchanged. X4 Pro probes its SSD1677/UC81xx
+  controller once before display initialization. Sticky retains its
   board-specific SSD1677 waveform config.
 
 ---

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -7,6 +7,10 @@
 #include <XteinkDetect.h>
 #include <esp_sleep.h>
 
+#if FREEINK_DEVICE_X4PRO
+#include <soc/usb_serial_jtag_reg.h>
+#endif
+
 // Global HalGPIO instance
 HalGPIO gpio;
 
@@ -236,6 +240,28 @@ bool HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPre
   return true;
 }
 
+#if FREEINK_DEVICE_X4PRO
+// X4 Pro has no confirmed VBUS GPIO. A USB data host is observable through the
+// USB Serial/JTAG SOF counter; keep the last positive result across nearby polls.
+static bool usbHostSofActive() {
+  static uint32_t lastFrame = 0;
+  static unsigned long lastAdvanceMs = 0;
+  static bool seeded = false;
+  if (!seeded) {
+    seeded = true;
+    lastFrame = REG_READ(USB_SERIAL_JTAG_FRAM_NUM_REG);
+    delay(3);  // A connected host advances the 1 kHz SOF counter within this window.
+  }
+  const uint32_t frame = REG_READ(USB_SERIAL_JTAG_FRAM_NUM_REG);
+  if (frame != lastFrame) {
+    lastFrame = frame;
+    lastAdvanceMs = millis();
+    return true;
+  }
+  return lastAdvanceMs != 0 && millis() - lastAdvanceMs < 1500;
+}
+#endif
+
 bool HalGPIO::isUsbConnected() const {
   if (deviceIsX3()) {
     // X3: infer USB/charging via BQ27220 Current() register (0x0C, signed mA).
@@ -250,7 +276,11 @@ bool HalGPIO::isUsbConnected() const {
     return false;
   }
   if (BoardConfig::ACTIVE.usbDetect < 0) {
+#if FREEINK_DEVICE_X4PRO
+    return usbHostSofActive();
+#else
     return false;
+#endif
   }
   return digitalRead(BoardConfig::ACTIVE.usbDetect) == HIGH;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -360,6 +360,30 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
 
+; --- Xteink X4 Pro — ESP32-S3 N16R8, SSD1677/UC81xx + GT911 + dual frontlight
+; Experimental hardware target: local SD firmware updates only; remote OTA and
+; AirPage stay hidden until both panel batches and the peripherals pass hardware QA.
+;   pio run -e x4pro -t upload
+[env:x4pro]
+extends = base
+board = esp32-s3-devkitc1-n16r8
+board_build.mcu = esp32s3
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_X4PRO=1
+  -DBOARD_HAS_PSRAM
+  -DUSE_BLOCK_DEVICE_INTERFACE=1
+  -DCROSSPOINT_EXPERIMENTAL_HARDWARE=1
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
+  -DENABLE_CHINESE_VERSION
+  -DCROSSMUX_HOST=\"${crossmux.cn_host}\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2
+build_src_filter =
+  ${base.build_src_filter}
+  +<activities/apps/chinese-chess/>
+  +<activities/apps/weread/>
+
 ; --- EEGO A4 — ESP32-S3 N16R8, 768x552 UC8279C + GSLX680 --------------------
 ; Experimental hardware target: local SD firmware updates only; remote OTA and
 ; AirPage stay hidden until the target completes the hardware release gate.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include <Logging.h>
 #include <SPI.h>
 #include <WiFi.h>
+#include <XteinkDetect.h>
 #include <builtinFonts/all.h>
 
 #include <cstring>
@@ -350,6 +351,16 @@ void enterDeepSleep(bool fromTimeout = false) {
 }
 
 bool setupDisplayAndFonts(bool seamless = false) {
+#if FREEINK_DEVICE_X4PRO
+  // X4 Pro batches use SSD1677 or UC81xx. Resolve the controller before
+  // display.begin(); C3 X3/X4 already do this once in HalGPIO::begin().
+  static bool controllerResolved = false;
+  if (!controllerResolved) {
+    controllerResolved = true;
+    freeink::applyXteinkDisplayController();
+  }
+#endif
+
   display.begin(seamless);
   renderer.begin();
   activityManager.begin();
@@ -478,9 +489,8 @@ void setup() {
       break;
   }
 
-  // Recovery firmware mode: hold left side button (BTN_UP) together with the power button at
-  // boot to skip directly to the SD-card firmware update screen. Useful on devices where USB
-  // flashing has been locked down (e.g. recent X3 firmware).
+  // Recovery firmware mode: hold a side button together with power at boot. X4 Pro uses
+  // BTN_DOWN/GPIO7 because BTN_UP/GPIO0 is an ESP32-S3 boot strap; other boards keep BTN_UP.
   bool recoveryFirmwareMode = false;
   if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
     // Refresh the cached button state a few times — isPressed() needs ~half a second to settle
@@ -491,9 +501,10 @@ void setup() {
       gpio.update();
       delay(10);
     }
-    if (gpio.isPressed(HalGPIO::BTN_UP)) {
+    const uint8_t recoveryButton = BoardConfig::isX4Pro() ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP;
+    if (gpio.isPressed(recoveryButton)) {
       recoveryFirmwareMode = true;
-      LOG_INF("MAIN", "Recovery firmware mode (UP + POWER held at boot)");
+      LOG_INF("MAIN", "Recovery firmware mode (%s + POWER held at boot)", BoardConfig::isX4Pro() ? "DOWN" : "UP");
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,9 @@
 #include <Logging.h>
 #include <SPI.h>
 #include <WiFi.h>
+#if FREEINK_DEVICE_X4PRO
 #include <XteinkDetect.h>
+#endif
 #include <builtinFonts/all.h>
 
 #include <cstring>


### PR DESCRIPTION
## Summary
- add the Chinese-by-default X4 Pro ESP32-S3 development environment
- probe SSD1677/UC81xx before display initialization and use GPIO7 for recovery
- add USB Serial/JTAG SOF detection when no board VBUS pin exists
- extend the existing build-sticky CI job and local CI command without release assets

## Validation
- pio run -e default -e sticky -e x4pro -e eego_a4 -e mofei_m4
- pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
- 322 host tests
- modified-file clang-format check and git diff --check
- X4 Pro firmware: 5538576 bytes of 6553600-byte app slot

## Pending hardware validation
- both SSD1677 and UC8179 batches
- GT911, buttons, dual frontlight, SDMMC, RTC, CW2017, recovery and USB sleep/wake
- Sticky display, touch, SD and sleep/wake smoke test