### PR TITLE
fix: release SD font before network startup

### DIFF
--- a/src/NetworkStartup.cpp
+++ b/src/NetworkStartup.cpp
@@ -1,0 +1,23 @@
+#include "NetworkStartup.h"
+
+#include <FontCacheManager.h>
+#include <GfxRenderer.h>
+#include <WiFi.h>
+
+#include "SdCardFontSystem.h"
+#include "activities/RenderLock.h"
+
+namespace NetworkStartup {
+
+void prepare(GfxRenderer& renderer) {
+  RenderLock lock;
+  sdFontSystem.releaseLoadedFont(renderer);
+  if (auto* fontCache = renderer.getFontCacheManager()) fontCache->clearCache();
+}
+
+bool setMode(GfxRenderer& renderer, const wifi_mode_t mode) {
+  prepare(renderer);
+  return WiFi.mode(mode);
+}
+
+}  // namespace NetworkStartup

--- a/src/NetworkStartup.cpp
+++ b/src/NetworkStartup.cpp
@@ -4,12 +4,56 @@
 #include <GfxRenderer.h>
 #include <WiFi.h>
 
+#if !defined(SIMULATOR)
+#include <esp_heap_caps.h>
+#include <sdkconfig.h>
+#endif
+
 #include "SdCardFontSystem.h"
 #include "activities/RenderLock.h"
+
+namespace {
+
+constexpr size_t MIN_FREE_PSRAM = 256 * 1024;
+constexpr size_t MIN_FREE_INTERNAL = 64 * 1024;
+constexpr size_t MIN_LARGEST_INTERNAL_BLOCK = 32 * 1024;
+
+struct MemorySnapshot {
+  size_t freePsram;
+  size_t freeInternal;
+  size_t largestInternalBlock;
+};
+
+constexpr bool shouldReleaseRenderMemory(const MemorySnapshot& memory) {
+  return memory.freePsram < MIN_FREE_PSRAM || memory.freeInternal < MIN_FREE_INTERNAL ||
+         memory.largestInternalBlock < MIN_LARGEST_INTERNAL_BLOCK;
+}
+
+static_assert(shouldReleaseRenderMemory({0, MIN_FREE_INTERNAL, MIN_LARGEST_INTERNAL_BLOCK}));
+static_assert(shouldReleaseRenderMemory({MIN_FREE_PSRAM - 1, MIN_FREE_INTERNAL, MIN_LARGEST_INTERNAL_BLOCK}));
+static_assert(shouldReleaseRenderMemory({MIN_FREE_PSRAM, MIN_FREE_INTERNAL - 1, MIN_LARGEST_INTERNAL_BLOCK}));
+static_assert(shouldReleaseRenderMemory({MIN_FREE_PSRAM, MIN_FREE_INTERNAL, MIN_LARGEST_INTERNAL_BLOCK - 1}));
+static_assert(!shouldReleaseRenderMemory({MIN_FREE_PSRAM, MIN_FREE_INTERNAL, MIN_LARGEST_INTERNAL_BLOCK}));
+
+MemorySnapshot readMemorySnapshot() {
+#if defined(SIMULATOR)
+  return {MIN_FREE_PSRAM, MIN_FREE_INTERNAL, MIN_LARGEST_INTERNAL_BLOCK};
+#elif defined(BOARD_HAS_PSRAM) && defined(CONFIG_SPIRAM_USE_MALLOC) && CONFIG_SPIRAM_USE_MALLOC
+  constexpr uint32_t INTERNAL_CAPS = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+  return {heap_caps_get_free_size(MALLOC_CAP_SPIRAM), heap_caps_get_free_size(INTERNAL_CAPS),
+          heap_caps_get_largest_free_block(INTERNAL_CAPS)};
+#else
+  return {};
+#endif
+}
+
+}  // namespace
 
 namespace NetworkStartup {
 
 void prepare(GfxRenderer& renderer) {
+  if (!shouldReleaseRenderMemory(readMemorySnapshot())) return;
+
   RenderLock lock;
   sdFontSystem.releaseLoadedFont(renderer);
   if (auto* fontCache = renderer.getFontCacheManager()) fontCache->clearCache();

--- a/src/NetworkStartup.h
+++ b/src/NetworkStartup.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <esp_wifi_types.h>
+#include <WiFi.h>
 
 class GfxRenderer;
 
 namespace NetworkStartup {
 
-// Release rebuildable render memory before the Wi-Fi driver starts allocating.
+// Preserve render memory when PSRAM/internal SRAM headroom is healthy; otherwise
+// release it before the Wi-Fi driver starts allocating.
 void prepare(GfxRenderer& renderer);
 
 // The only entry point for enabling STA/AP mode in application code.

--- a/src/NetworkStartup.h
+++ b/src/NetworkStartup.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <esp_wifi_types.h>
+
+class GfxRenderer;
+
+namespace NetworkStartup {
+
+// Release rebuildable render memory before the Wi-Fi driver starts allocating.
+void prepare(GfxRenderer& renderer);
+
+// The only entry point for enabling STA/AP mode in application code.
+bool setMode(GfxRenderer& renderer, wifi_mode_t mode);
+
+}  // namespace NetworkStartup

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -13,7 +13,7 @@ struct Rect;
 class AirPageActivity final : public Activity {
  public:
   explicit AirPageActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("AirPage", renderer, mappedInput) {}
+      : Activity("AirPage", renderer, mappedInput), connection_(renderer) {}
 
   void onEnter() override;
   void onExit() override;

--- a/src/activities/apps/airpage/AirPageConnection.cpp
+++ b/src/activities/apps/airpage/AirPageConnection.cpp
@@ -11,6 +11,7 @@
 #include <iterator>
 
 #include "AirPageDeviceId.h"
+#include "NetworkStartup.h"
 #include "WifiCredentialStore.h"
 
 namespace airpage {
@@ -48,6 +49,7 @@ AirPageConnection::Event AirPageConnection::begin(const bool realtime) {
 
   resetRetryWindow();
   if (wifiConnected()) {
+    NetworkStartup::prepare(renderer_);
     ownsWifi_ = realtime_;
     state_ = realtime_ ? State::BrokerConnecting : State::WifiOnline;
     return Event::StateChanged;
@@ -254,7 +256,7 @@ bool AirPageConnection::startWifiAssociation() {
   }
 
   WiFi.persistent(false);
-  WiFi.mode(WIFI_STA);
+  NetworkStartup::setMode(renderer_, WIFI_STA);
   WiFi.disconnect(true, true);
   delay(100);
   if (credential->password.empty()) {

--- a/src/activities/apps/airpage/AirPageConnection.h
+++ b/src/activities/apps/airpage/AirPageConnection.h
@@ -5,6 +5,8 @@
 
 #include <cstdint>
 
+class GfxRenderer;
+
 namespace airpage {
 
 class AirPageConnection final {
@@ -29,7 +31,7 @@ class AirPageConnection final {
     PushRequested,
   };
 
-  AirPageConnection() : mqtt_(mqttNet_) {}
+  explicit AirPageConnection(GfxRenderer& renderer) : renderer_(renderer), mqtt_(mqttNet_) {}
 
   Event begin(bool realtime);
   void stop();
@@ -60,6 +62,7 @@ class AirPageConnection final {
   uint32_t retryWindowStartedMs_ = 0;
   uint32_t nextRetryAtMs_ = 0;
 
+  GfxRenderer& renderer_;
   WiFiClient mqttNet_;
   PubSubClient mqtt_;
 };

--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <string>
 
+#include "../../../NetworkStartup.h"
 #include "../../../WifiCredentialStore.h"
 #include "../../../components/UITheme.h"
 #include "../../../fontIds.h"
@@ -176,6 +177,7 @@ void PixelSwitchActivity::startCanvas() {
     return;
   }
 
+  NetworkStartup::prepare(renderer);
   broughtWifiUp_ = true;
   wifiSelectionFailed_ = false;
   wifiRetryActive_ = false;
@@ -281,7 +283,7 @@ bool PixelSwitchActivity::startSavedWifiAssociation() {
   }
 
   WiFi.persistent(false);
-  WiFi.mode(WIFI_STA);
+  NetworkStartup::setMode(renderer, WIFI_STA);
   WiFi.disconnect(true, true);
   delay(100);
   if (pass.empty()) {

--- a/src/activities/apps/standby/StandbyActivity.cpp
+++ b/src/activities/apps/standby/StandbyActivity.cpp
@@ -17,6 +17,7 @@
 #include "../../ActivityResult.h"
 #include "../../network/WifiSelectionActivity.h"
 #include "CrossPointSettings.h"
+#include "NetworkStartup.h"
 #ifdef ENABLE_CHINESE_VERSION
 #include "ChineseCalendarFace.h"
 #endif
@@ -178,6 +179,7 @@ void StandbyActivity::startTimeSync() {
   // Another activity (e.g. Settings → WiFi) may have already connected the
   // device. Skip our own WiFi.begin in that case and request a clock sync.
   if (WiFi.status() == WL_CONNECTED) {
+    NetworkStartup::prepare(renderer);
     LOG_DBG("STANDBY", "WiFi already connected, skipping silent attempt");
     beginClockSync();
     return;
@@ -218,7 +220,7 @@ bool StandbyActivity::trySilentWifiConnect() {
   }
 
   WiFi.persistent(false);
-  WiFi.mode(WIFI_STA);
+  NetworkStartup::setMode(renderer, WIFI_STA);
   // Fresh-slate disconnect (radio off + erase cached AP) so the next begin()
   // latches the exact creds we just loaded, not whatever the radio retained
   // from a previous session. The disconnect(false) form used by the teardown

--- a/src/activities/apps/weread/webapi/WeReadActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadActivity.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "CrossPointState.h"
-#include "SdCardFontSystem.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "WeReadBrowseActivity.h"
 #include "activities/apps/weread/WeReadTouchGeometry.h"
@@ -401,11 +401,7 @@ static_assert(sizeof(WeReadChapterRangeActivity) <= 1024, "WeRead chapter select
 void WeReadActivity::onEnter() {
   Activity::onEnter();
   if (!WeReadBrowse::clearLegacyWorkspace()) LOG_ERR("WR", "legacy browse workspace cleanup failed");
-  {
-    RenderLock lock(*this);
-    sdFontSystem.releaseLoadedFont(renderer);
-    if (auto* fontCache = renderer.getFontCacheManager()) fontCache->clearCache();
-  }
+  NetworkStartup::prepare(renderer);
   disclaimerSelected_ = 0;
   disclaimerSaveFailed_ = false;
   manageSelected_ = 0;

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
@@ -19,6 +19,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "ProgressMapper.h"
 #include "ReadingStatsStore.h"
 #include "SilentRestart.h"
@@ -89,6 +90,7 @@ void WeReadProgressSyncActivity::onEnter() {
     return;
   }
 
+  NetworkStartup::prepare(renderer);
   wifiActivated_ = true;
   if (WiFi.status() == WL_CONNECTED) {
     state_ = State::Starting;

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -10,6 +10,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/KeyboardEntryActivity.h"
@@ -474,6 +475,7 @@ void OpdsBookBrowserActivity::performSearch(const std::string& query) {
 
 void OpdsBookBrowserActivity::checkAndConnectWifi() {
   if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0, 0, 0, 0)) {
+    NetworkStartup::prepare(renderer);
     state = BrowserState::LOADING;
     statusMessage = tr(STR_LOADING);
     requestUpdate();
@@ -487,8 +489,12 @@ void OpdsBookBrowserActivity::launchWifiSelection() {
   state = BrowserState::WIFI_SELECTION;
   requestUpdate();
 
-  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
-                         [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
+  if (!startActivityForResultWith<WifiSelectionActivity>(
+          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); })) {
+    state = BrowserState::ERROR;
+    errorMessage = tr(STR_MEMORY_ERROR);
+    requestUpdate();
+  }
 }
 
 void OpdsBookBrowserActivity::onWifiSelectionComplete(const bool connected) {

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -6,6 +6,7 @@
 #include <WiFi.h>
 
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "WifiSelectionActivity.h"
 #include "components/SubpageLayout.h"
@@ -34,16 +35,19 @@ void CalibreConnectActivity::onEnter() {
   exitRequested = false;
 
   if (WiFi.status() != WL_CONNECTED) {
-    startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
-                           [this](const ActivityResult& result) {
-                             if (!result.isCancelled) {
-                               const auto& wifi = std::get<WifiResult>(result.data);
-                               connectedIP = wifi.ip;
-                               connectedSSID = wifi.ssid;
-                             }
-                             onWifiSelectionComplete(!result.isCancelled);
-                           });
+    if (!startActivityForResultWith<WifiSelectionActivity>([this](const ActivityResult& result) {
+          if (!result.isCancelled) {
+            const auto& wifi = std::get<WifiResult>(result.data);
+            connectedIP = wifi.ip;
+            connectedSSID = wifi.ssid;
+          }
+          onWifiSelectionComplete(!result.isCancelled);
+        })) {
+      state = CalibreConnectState::ERROR;
+      requestUpdate();
+    }
   } else {
+    NetworkStartup::prepare(renderer);
     connectedIP = WiFi.localIP().toString().c_str();
     connectedSSID = WiFi.SSID().c_str();
     startWebServer();

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -11,6 +11,7 @@
 
 #include "MappedInputManager.h"
 #include "NetworkModeSelectionActivity.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "WifiSelectionActivity.h"
 #include "activities/network/CalibreConnectActivity.h"
@@ -141,20 +142,18 @@ void CrossPointWebServerActivity::onNetworkModeSelected(const NetworkMode mode) 
 
   if (mode == NetworkMode::JOIN_NETWORK) {
     // STA mode - launch WiFi selection
-    LOG_DBG("WEBACT", "Turning on WiFi (STA mode)...");
-    WiFi.mode(WIFI_STA);
-
     state = WebServerActivityState::WIFI_SELECTION;
     LOG_DBG("WEBACT", "Launching WifiSelectionActivity...");
-    startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
-                           [this](const ActivityResult& result) {
-                             if (!result.isCancelled) {
-                               const auto& wifi = std::get<WifiResult>(result.data);
-                               connectedIP = wifi.ip;
-                               connectedSSID = wifi.ssid;
-                             }
-                             onWifiSelectionComplete(!result.isCancelled);
-                           });
+    if (!startActivityForResultWith<WifiSelectionActivity>([this](const ActivityResult& result) {
+          if (!result.isCancelled) {
+            const auto& wifi = std::get<WifiResult>(result.data);
+            connectedIP = wifi.ip;
+            connectedSSID = wifi.ssid;
+          }
+          onWifiSelectionComplete(!result.isCancelled);
+        })) {
+      onGoHome();
+    }
   } else {
     // AP mode - start access point
     state = WebServerActivityState::AP_STARTING;
@@ -195,7 +194,7 @@ void CrossPointWebServerActivity::startAccessPoint() {
   LOG_DBG("WEBACT", "Free heap before AP start: %d bytes", ESP.getFreeHeap());
 
   // Configure and start the AP
-  WiFi.mode(WIFI_AP);
+  NetworkStartup::setMode(renderer, WIFI_AP);
   delay(100);
 
   // Start soft AP

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "WifiCredentialStore.h"
 #include "activities/util/KeyboardEntryActivity.h"
 #include "components/SubpageLayout.h"
@@ -84,6 +85,8 @@ void drawPromptOptions(const GfxRenderer& renderer, const WifiPromptLayout& layo
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
 
+  NetworkStartup::prepare(renderer);
+
   // Load saved WiFi credentials - SD card operations need lock as we use SPI
   // for both
   {
@@ -111,7 +114,7 @@ void WifiSelectionActivity::onEnter() {
 
   // The STA netif does not exist until station mode is enabled.
   uint8_t mac[6] = {};
-  const bool macReady = WiFi.mode(WIFI_STA) && WiFi.macAddress(mac);
+  const bool macReady = NetworkStartup::setMode(renderer, WIFI_STA) && WiFi.macAddress(mac);
   char macStr[64];
   if (macReady) {
     snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS), mac[0], mac[1], mac[2],
@@ -170,7 +173,7 @@ void WifiSelectionActivity::startWifiScan(const bool autoScan) {
   requestUpdate();
 
   // Set WiFi mode to station
-  WiFi.mode(WIFI_STA);
+  NetworkStartup::setMode(renderer, WIFI_STA);
   WiFi.disconnect();
   delay(100);
 
@@ -422,7 +425,7 @@ void WifiSelectionActivity::attemptConnection() {
   requestUpdate();
 
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
-  WiFi.mode(WIFI_STA);
+  NetworkStartup::setMode(renderer, WIFI_STA);
   WiFi.disconnect(true, true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
   delay(100);
 

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -17,6 +17,7 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "ReaderUtils.h"
 #include "SilentRestart.h"
 #include "activities/ActivityManager.h"
@@ -351,6 +352,7 @@ void KOReaderSyncActivity::onEnter() {
   }
 
   // Past this point every path uses WiFi.
+  NetworkStartup::prepare(renderer);
   wifiActivated = true;
 
   // Check if already connected (e.g. from settings page auth)
@@ -362,8 +364,12 @@ void KOReaderSyncActivity::onEnter() {
 
   // Launch WiFi selection subactivity
   LOG_DBG("KOSync", "Launching WifiSelectionActivity...");
-  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
-                         [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
+  if (!startActivityForResultWith<WifiSelectionActivity>(
+          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); })) {
+    state = SYNC_FAILED;
+    statusMessage = tr(STR_MEMORY_ERROR);
+    requestUpdate();
+  }
 }
 
 void KOReaderSyncActivity::onExit() {

--- a/src/activities/settings/ClockSyncActivity.cpp
+++ b/src/activities/settings/ClockSyncActivity.cpp
@@ -11,6 +11,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/SubpageLayout.h"
@@ -24,6 +25,7 @@ void ClockSyncActivity::onEnter() {
   syncedTime[0] = '\0';
 
   if (WiFi.status() == WL_CONNECTED) {
+    NetworkStartup::prepare(renderer);
     requestUpdate();
     return;
   }

--- a/src/activities/settings/DictionaryDownloadActivity.cpp
+++ b/src/activities/settings/DictionaryDownloadActivity.cpp
@@ -66,13 +66,13 @@ void DictionaryDownloadActivity::onEnter() {
 }
 
 void DictionaryDownloadActivity::startWifiSelection() {
-  WiFi.mode(WIFI_STA);
   auto wifiSelection = makeUniqueNoThrow<WifiSelectionActivity>(renderer, mappedInput);
   if (!wifiSelection) {
     LOG_ERR("DICTDL", "OOM allocating WifiSelectionActivity (%zu bytes)", sizeof(WifiSelectionActivity));
     finish();
     return;
   }
+
   startActivityForResult(std::move(wifiSelection),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
 }

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -18,6 +18,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "SdCardFontSystem.h"
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
@@ -83,7 +84,6 @@ void FontDownloadActivity::onEnter() {
 }
 
 void FontDownloadActivity::startWifiSelection() {
-  WiFi.mode(WIFI_STA);
   // ActivityManager owns the Wi-Fi picker across frames, so it must live on the heap.
   auto wifiSelection = makeUniqueNoThrow<WifiSelectionActivity>(renderer, mappedInput);
   if (!wifiSelection) {
@@ -113,7 +113,6 @@ void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
 
   {
     RenderLock lock(*this);
-    sdFontSystem.releaseLoadedFont(renderer);
     state_ = LOADING_MANIFEST;
   }
   requestUpdateAndWait();
@@ -371,6 +370,7 @@ bool FontDownloadActivity::computeFileCrc32(const char* path, uint32_t& outCrc) 
 }
 
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(ManifestFamily& family) {
+  NetworkStartup::prepare(renderer);
   const bool wasInstalled = family.installed;
   auto discardIncompleteFamily = [this, &family, wasInstalled] {
     if (!wasInstalled) fontInstaller_.deleteFamily(family.name.c_str());

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -7,6 +7,7 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncClient.h"
 #include "MappedInputManager.h"
+#include "NetworkStartup.h"
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/SubpageLayout.h"
@@ -56,13 +57,18 @@ void KOReaderAuthActivity::onEnter() {
 
   // Check if already connected
   if (WiFi.status() == WL_CONNECTED) {
+    NetworkStartup::prepare(renderer);
     onWifiSelectionComplete(true);
     return;
   }
 
   // Launch WiFi selection
-  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
-                         [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
+  if (!startActivityForResultWith<WifiSelectionActivity>(
+          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); })) {
+    state = FAILED;
+    errorMessage = tr(STR_MEMORY_ERROR);
+    requestUpdate();
+  }
 }
 
 void KOReaderAuthActivity::onExit() {

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -116,9 +116,11 @@ void OtaUpdateActivity::beginWifiSelection() {
     return;
   }
 
-  state = WIFI_SELECTION;
-  LOG_DBG("OTA", "Turning on WiFi...");
-  WiFi.mode(WIFI_STA);
+  {
+    RenderLock lock(*this);
+    state = WIFI_SELECTION;
+    sdFontSystem.releaseLoadedFont(renderer);
+  }
 
   LOG_DBG("OTA", "Launching WifiSelectionActivity...");
   startActivityForResult(std::move(wifiSelection),
@@ -258,7 +260,6 @@ void OtaUpdateActivity::runUpdateInstall() {
   {
     RenderLock lock(*this);
     state = UPDATE_IN_PROGRESS;
-    sdFontSystem.releaseLoadedFont(renderer);
   }
   requestUpdateAndWait();
   const auto res = updater.installUpdate(

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -119,7 +119,6 @@ void OtaUpdateActivity::beginWifiSelection() {
   {
     RenderLock lock(*this);
     state = WIFI_SELECTION;
-    sdFontSystem.releaseLoadedFont(renderer);
   }
 
   LOG_DBG("OTA", "Launching WifiSelectionActivity...");

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -784,7 +784,7 @@ void SettingsActivity::toggleCurrentSetting() {
         startActivityForResult(std::make_unique<OpdsServerListActivity>(renderer, mappedInput), resultHandler);
         break;
       case SettingAction::Network:
-        startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput, false), resultHandler);
+        startActivityForResultWith<WifiSelectionActivity>(resultHandler, false);
         break;
       case SettingAction::DateTime:
         // ActivityManager owns child activities across frames, so stack/static lifetime is invalid.


### PR DESCRIPTION
## Summary

- Add a shared, allocation-free network startup boundary used by application STA/AP paths before Wi-Fi begins allocating.
- On ESP32-C3 or builds without usable PSRAM, release the loaded SD reading font and clear renderer font caches under `RenderLock`.
- On PSRAM-enabled builds, preserve the font and caches only when free PSRAM is at least 256 KB, free internal 8-bit SRAM is at least 64 KB, and the largest internal block is at least 32 KB; otherwise fall back to the full release path.
- Make the simulator take the memory-healthy path and cover the decision thresholds with compile-time assertions.
- Prepare memory before Wi-Fi selection, saved-credential connections, repeated font downloads, OTA, dictionary management, OPDS, Calibre, Web Server STA/AP, clock sync, Standby, AirPage, PixelSwitch, WeRead, and KOReader sync.
- Keep Wi-Fi selection activity allocation fallible and remove parent-page Wi-Fi startup and duplicate font releases.
- No public API, user setting, runtime allocation, configuration format, or persistent format changes.

## Validation

- [x] `pio run -e default`
- [x] `pio run -e gh_release_cn`
- [x] `pio run -e simulator`
- [x] GitHub CI: `Build default and simulators` and `Build sticky`
- [ ] `pio run -e sticky` locally: blocked by the existing S3 dependency-pruning setup removing `espressif__cbor` while Arduino still requires it; the PR Sticky CI passed for this revision.
- [x] `git diff --check`
- [x] `clang-format --dry-run --Werror src/NetworkStartup.cpp src/NetworkStartup.h`
- [x] Static audit: no application `WiFi.mode(WIFI_STA/WIFI_AP)` call bypasses `NetworkStartup`; `WIFI_OFF` teardown remains unchanged.
- [ ] On C3 Chinese firmware with CEFFontsCJK/NotoSansSC selected and substantial reading statistics, verify OTA, dictionary management, font downloads, OPDS, Calibre, Web Server STA/AP, clock sync, AirPage, PixelSwitch, Standby, WeRead, and KOReader sync.
- [ ] Confirm C3 networking releases the SD font and no longer produces `wifi.json: NoMemory`, `bad_alloc`, RX-buffer initialization shortage, panic, or unexpected restart.
- [ ] On S3/Sticky, confirm PSRAM initializes and healthy memory levels preserve the SD font across repeated networking and font preview operations.
- [ ] Force each S3 threshold below its limit and confirm networking falls back to releasing the font and renderer cache.
- [ ] After network exit, reopen EPUB/TXT and confirm the saved SD font is available; when networking is not started, confirm the font is not released.

## Notes

Hardware verification remains pending. Keep this PR as Draft until the C3/S3 device matrix and the new CI revision pass.
