### PR TITLE
fix: align WeRead and KOReader progress sync

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -94,7 +94,7 @@ KOReaderSyncClient::Error KOReaderSyncClient::authenticate() {
   LOG_DBG("KOSync", "Auth response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200) return OK;
+  if (httpCode >= 200 && httpCode < 300) return OK;
   if (httpCode == 401) return AUTH_FAILED;
   return SERVER_ERROR;
 }
@@ -131,7 +131,7 @@ KOReaderSyncClient::Error KOReaderSyncClient::createUser() {
   LOG_DBG("KOSync", "Create user response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200 || httpCode == 201) return OK;
+  if (httpCode >= 200 && httpCode < 300) return OK;
   if (httpCode == 402) return USER_EXISTS;
   return SERVER_ERROR;
 }
@@ -165,7 +165,12 @@ KOReaderSyncClient::Error KOReaderSyncClient::getProgress(const std::string& doc
     return NETWORK_ERROR;
   }
 
-  if (httpCode == 200) {
+  if (httpCode == 204) {
+    http.end();
+    return NOT_FOUND;
+  }
+
+  if (httpCode >= 200 && httpCode < 300) {
     JsonDocument doc;
     const DeserializationError error = deserializeJson(doc, http.getString().c_str());
     http.end();
@@ -268,7 +273,7 @@ KOReaderSyncClient::Error KOReaderSyncClient::updateProgress(const KOReaderProgr
   LOG_DBG("KOSync", "Update progress response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200 || httpCode == 202) return OK;
+  if (httpCode >= 200 && httpCode < 300) return OK;
   if (httpCode == 401) return AUTH_FAILED;
   return SERVER_ERROR;
 }

--- a/lib/WeReadWebApi/src/WeReadClient.cpp
+++ b/lib/WeReadWebApi/src/WeReadClient.cpp
@@ -1298,7 +1298,7 @@ bool appendEncodedId(char* out, const size_t outSize, size_t& position, char* wo
 bool appendProgressQuery(char* out, const size_t outSize, char* work, const size_t workSize, const char* bookId,
                          const WeReadStore::TocRecord& chapter, const uint32_t chapterOffset, const uint32_t progress,
                          const uint32_t now, const char* psvts, const char* pclts, const char* token, const bool report,
-                         const uint32_t readingSeconds, const uint64_t timestampMs, const uint32_t randomNumber) {
+                         const uint64_t timestampMs, const uint32_t randomNumber) {
   size_t position = 0;
   out[0] = '\0';
   if (!makeWebAppId(work, workSize) || !appendText(out, outSize, position, "appId=") ||
@@ -1324,8 +1324,7 @@ bool appendProgressQuery(char* out, const size_t outSize, char* work, const size
   }
   if (report) {
     if (!appendText(out, outSize, position, "&rn=") || !appendUnsigned(out, outSize, position, randomNumber) ||
-        !WeReadProtocol::formatReadingTimeQuery(readingSeconds, work, workSize) ||
-        !appendText(out, outSize, position, work)) {
+        !appendText(out, outSize, position, "&sg=")) {
       return false;
     }
     const int sourceLength = snprintf(work, workSize, "%llu%u%s", static_cast<unsigned long long>(timestampMs),
@@ -1344,8 +1343,8 @@ bool appendProgressQuery(char* out, const size_t outSize, char* work, const size
 
 bool makeProgressBody(const char* bookId, const WeReadStore::TocRecord& chapter, const uint32_t chapterOffset,
                       const float localFraction, const char* psvts, const char* pclts, const char* readerToken,
-                      const bool report, const uint32_t readingSeconds, char* body, const size_t bodySize, char* work,
-                      const size_t workSize, size_t& written) {
+                      const bool report, char* body, const size_t bodySize, char* work, const size_t workSize,
+                      size_t& written) {
   static constexpr char kDefaultReaderToken[] = "3c5c8717f3daf09iop3423zafeqoi";
   const uint32_t now = TimeUtils::getCurrentValidTimestamp();
   if (now == 0 || !isSafeProtocolToken(bookId) || !isSafeProtocolToken(chapter.chapterUid) ||
@@ -1361,7 +1360,7 @@ bool makeProgressBody(const char* bookId, const WeReadStore::TocRecord& chapter,
       report ? static_cast<uint64_t>(now) * 1000ULL + static_cast<uint32_t>(random(0, 1000)) : 0;
 
   if (!appendProgressQuery(body, bodySize, work, workSize, bookId, chapter, chapterOffset, progress, now, psvts, pclts,
-                           token, report, readingSeconds, timestampMs, randomNumber)) {
+                           token, report, timestampMs, randomNumber)) {
     return false;
   }
   char signature[24];
@@ -1394,8 +1393,7 @@ bool makeProgressBody(const char* bookId, const WeReadStore::TocRecord& chapter,
   }
   if (!appendText(body, bodySize, position, "\"")) return false;
   if (report) {
-    if (!WeReadProtocol::formatReadingTimeJson(readingSeconds, work, workSize) ||
-        !appendText(body, bodySize, position, work) || !appendUnsigned(body, bodySize, position, timestampMs) ||
+    if (!appendText(body, bodySize, position, ",\"ts\":") || !appendUnsigned(body, bodySize, position, timestampMs) ||
         !appendText(body, bodySize, position, ",\"rn\":") || !appendUnsigned(body, bodySize, position, randomNumber)) {
       return false;
     }
@@ -2165,7 +2163,6 @@ void Operation::reset() {
   progressSyncInput_ = {};
   progressSyncMode_ = ProgressSyncMode::Compare;
   progressSyncResult_ = {};
-  progressReportOutcome_ = ProgressSyncOutcome::Pending;
   session_.clear();
   book_ = {};
   chapter_ = {};
@@ -3117,11 +3114,9 @@ Error Operation::decideProgress() {
           chapter_.chapterUid, static_cast<unsigned>(progressChapterOffset_),
           static_cast<unsigned long>(progressSyncInput_.localFraction * 1000000.0f + 0.5f));
   const bool samePosition = sameRemotePosition();
-  const bool hasReadingTime = progressSyncInput_.readingSeconds > 0;
-  const ProgressAction action = progressAction(progressSyncMode_, samePosition, hasReadingTime);
-  LOG_INF("WR", "progress decision: mode=%u same=%u action=%u readingSeconds=%u",
-          static_cast<unsigned>(progressSyncMode_), static_cast<unsigned>(samePosition), static_cast<unsigned>(action),
-          static_cast<unsigned>(progressSyncInput_.readingSeconds));
+  const ProgressAction action = progressAction(progressSyncMode_, samePosition);
+  LOG_INF("WR", "progress decision: mode=%u same=%u action=%u", static_cast<unsigned>(progressSyncMode_),
+          static_cast<unsigned>(samePosition), static_cast<unsigned>(action));
   switch (action) {
     case ProgressAction::AlreadySynced:
       progressSyncResult_.outcome = ProgressSyncOutcome::AlreadySynced;
@@ -3132,32 +3127,7 @@ Error Operation::decideProgress() {
     case ProgressAction::ApplyRemote:
       progressSyncResult_.outcome = ProgressSyncOutcome::ApplyRemote;
       return Error::Ok;
-    case ProgressAction::ReportSynced:
-      progressReportOutcome_ = ProgressSyncOutcome::AlreadySynced;
-      break;
-    case ProgressAction::ReportRemote: {
-      const auto& remote = progressSyncResult_.remote;
-      uint32_t tocIndex = 0;
-      float chapterFraction = 0.0f;
-      float bookFraction = 0.0f;
-      if (!remote.hasChapterOffset ||
-          !WeReadStore::mapChapterToPosition(tocPath_, remote.chapterUid, remote.chapterOffset, tocIndex,
-                                             chapterFraction, bookFraction)) {
-        return Error::Unavailable;
-      }
-      HalFile toc;
-      uint32_t count = 0;
-      if (!WeReadStore::openToc(tocPath_, toc, count) || tocIndex >= count ||
-          !WeReadStore::readTocRecord(toc, tocIndex, chapter_)) {
-        return Error::SdCard;
-      }
-      progressChapterOffset_ = remote.chapterOffset;
-      progressSyncInput_.localFraction = bookFraction;
-      progressReportOutcome_ = ProgressSyncOutcome::ApplyRemote;
-      break;
-    }
     case ProgressAction::UploadLocal:
-      progressReportOutcome_ = ProgressSyncOutcome::LocalUploaded;
       break;
   }
   if (!makeReaderReferer(book_.bookId, chapter_.chapterUid, referer_)) return Error::Unavailable;
@@ -3185,8 +3155,8 @@ Error Operation::fetchProgressReaderOnce() {
 Error Operation::sendProgressOnce(const bool report) {
   size_t bodySize = 0;
   if (!makeProgressBody(book_.bookId, chapter_, progressChapterOffset_, progressSyncInput_.localFraction, psvts_,
-                        imageHost_, previousVid_, report, progressSyncInput_.readingSeconds,
-                        reinterpret_cast<char*>(ioBuffer_), sizeof(ioBuffer_), url_, sizeof(url_), bodySize)) {
+                        imageHost_, previousVid_, report, reinterpret_cast<char*>(ioBuffer_), sizeof(ioBuffer_), url_,
+                        sizeof(url_), bodySize)) {
     return Error::Clock;
   }
   SimpleJsonContext context;
@@ -4004,17 +3974,11 @@ Operation::Event Operation::step(const WeReadStore::WorkCallback callback, void*
 
     case Phase::SendProgressReport: {
       const Error error = sendProgressOnce(true);
-      progressSyncInput_.readingSeconds = readingSecondsAfterReport(error, progressSyncInput_.readingSeconds);
       if (error == Error::SessionExpired) {
         requestAuthentication(Phase::FetchProgressReader);
         return phase_ == Phase::Failed ? fail(error_) : Event::None;
       }
-      if (error != Error::Ok) {
-        // A timed report may have reached WeRead even if its response was lost.
-        // Surface Retry instead of automatically sending the same seconds again.
-        if (ambiguousTimedReportFailure(error, progressSyncInput_.readingSeconds)) return fail(error);
-        return handleRequestError(error, Phase::SendProgressReport);
-      }
+      if (error != Error::Ok) return handleRequestError(error, Phase::SendProgressReport);
       requestSucceeded();
       progressVerifyAttempts_ = 0;
       nextActionAt_ = millis() + kNetworkRetryBaseMs;
@@ -4044,7 +4008,7 @@ Operation::Event Operation::step(const WeReadStore::WorkCallback callback, void*
       switch (outcome) {
         case ProgressSyncOutcome::LocalUploaded:
         case ProgressSyncOutcome::AlreadySynced:
-          progressSyncResult_.outcome = reportedProgressOutcome(outcome, progressReportOutcome_);
+          progressSyncResult_.outcome = outcome;
           break;
         case ProgressSyncOutcome::SelectionRequired:
           progressSyncResult_.outcome = outcome;

--- a/lib/WeReadWebApi/src/WeReadClient.h
+++ b/lib/WeReadWebApi/src/WeReadClient.h
@@ -13,11 +13,6 @@ namespace WeReadClient {
 
 struct OperationTestPeer;
 
-constexpr uint32_t readingSecondsForSession(const bool valid, const bool pathMatches, const bool bookMatches,
-                                            const uint32_t sessionMs) {
-  return valid && pathMatches && bookMatches ? sessionMs / 1000 : 0;
-}
-
 enum class Error {
   Ok,
   Cancelled,
@@ -46,13 +41,12 @@ struct DownloadOptions {
 struct ProgressSyncInput {
   float localFraction = 0.0f;
   uint32_t localTocIndex = 0;
-  uint32_t readingSeconds = 0;
   uint16_t localSpineIndex = 0;
   uint16_t localPageNumber = 0;
   uint16_t localPageCount = 0;
   bool hasLocalTocIndex = false;
 };
-static_assert(sizeof(ProgressSyncInput) == 20);
+static_assert(sizeof(ProgressSyncInput) == 16);
 
 enum class ProgressSyncMode : uint8_t {
   Compare,
@@ -112,7 +106,6 @@ class Operation {
   const char* qrUrl() const { return url_; }
   const char* finalPath() const { return outputPath_.c_str(); }
   const ProgressSyncResult& progressSyncResult() const { return progressSyncResult_; }
-  uint32_t pendingReadingSeconds() const { return progressSyncInput_.readingSeconds; }
   bool active() const;
 
  private:
@@ -123,8 +116,6 @@ class Operation {
     SelectDirection,
     ApplyRemote,
     UploadLocal,
-    ReportSynced,
-    ReportRemote,
   };
 
   enum class CoverCacheAction : uint8_t {
@@ -264,14 +255,13 @@ class Operation {
   static constexpr bool wholeChapterRange(const uint32_t first, const uint32_t last, const uint32_t count) {
     return validChapterRange(first, last, count) && first == 0 && last == count - 1;
   }
-  static constexpr ProgressAction progressAction(const ProgressSyncMode mode, const bool samePosition,
-                                                 const bool hasReadingTime) {
-    if (samePosition) return hasReadingTime ? ProgressAction::ReportSynced : ProgressAction::AlreadySynced;
+  static constexpr ProgressAction progressAction(const ProgressSyncMode mode, const bool samePosition) {
+    if (samePosition) return ProgressAction::AlreadySynced;
     switch (mode) {
       case ProgressSyncMode::Compare:
         return ProgressAction::SelectDirection;
       case ProgressSyncMode::ApplyRemote:
-        return hasReadingTime ? ProgressAction::ReportRemote : ProgressAction::ApplyRemote;
+        return ProgressAction::ApplyRemote;
       case ProgressSyncMode::UploadLocal:
         return ProgressAction::UploadLocal;
     }
@@ -289,16 +279,6 @@ class Operation {
       return ProgressSyncOutcome::SelectionRequired;
     }
     return ProgressSyncOutcome::Pending;
-  }
-  static constexpr ProgressSyncOutcome reportedProgressOutcome(const ProgressSyncOutcome verified,
-                                                               const ProgressSyncOutcome target) {
-    return target == ProgressSyncOutcome::Pending ? verified : target;
-  }
-  static constexpr bool ambiguousTimedReportFailure(const Error error, const uint32_t readingSeconds) {
-    return error == Error::Network && readingSeconds > 0;
-  }
-  static constexpr uint32_t readingSecondsAfterReport(const Error error, const uint32_t readingSeconds) {
-    return error == Error::Ok ? 0 : readingSeconds;
   }
   static constexpr uint32_t browseReviewRequestCount(const uint32_t cached) {
     const uint32_t remaining = cached < WeReadBrowse::kMaxCachedReviews ? WeReadBrowse::kMaxCachedReviews - cached : 0;
@@ -368,7 +348,6 @@ class Operation {
   ProgressSyncInput progressSyncInput_;
   ProgressSyncMode progressSyncMode_ = ProgressSyncMode::Compare;
   ProgressSyncResult progressSyncResult_;
-  ProgressSyncOutcome progressReportOutcome_ = ProgressSyncOutcome::Pending;
   WeReadStore::Session session_;
   WeReadStore::ShelfRecord book_;
   WeReadStore::TocRecord chapter_;

--- a/lib/WeReadWebApi/src/WeReadProtocol.cpp
+++ b/lib/WeReadWebApi/src/WeReadProtocol.cpp
@@ -132,18 +132,6 @@ uint32_t hashAppId(const char* value, const size_t len) {
 
 bool hasUsablePclts(const char* value) { return value && value[0] && strcmp(value, "0") != 0; }
 
-bool formatReadingTimeQuery(const uint32_t seconds, char* out, const size_t outSize) {
-  if (!out || outSize == 0) return false;
-  const int length = snprintf(out, outSize, "&rt=%u&sg=", static_cast<unsigned>(seconds));
-  return length > 0 && static_cast<size_t>(length) < outSize;
-}
-
-bool formatReadingTimeJson(const uint32_t seconds, char* out, const size_t outSize) {
-  if (!out || outSize == 0) return false;
-  const int length = snprintf(out, outSize, ",\"rt\":%u,\"ts\":", static_cast<unsigned>(seconds));
-  return length > 0 && static_cast<size_t>(length) < outSize;
-}
-
 RemoteProgressParser::RemoteProgressParser(const char* requestedBookId)
     : requestedBookId_(requestedBookId), parser_(callbacks(this)) {
   reset();

--- a/lib/WeReadWebApi/src/WeReadProtocol.h
+++ b/lib/WeReadWebApi/src/WeReadProtocol.h
@@ -25,8 +25,6 @@ ImageType normalizeImageUrl(const char* source, char* output, size_t outputSize)
 uint32_t parseUint32OrZero(const char* value, size_t len);
 uint32_t hashAppId(const char* value, size_t len);
 bool hasUsablePclts(const char* value);
-bool formatReadingTimeQuery(uint32_t seconds, char* out, size_t outSize);
-bool formatReadingTimeJson(uint32_t seconds, char* out, size_t outSize);
 
 struct RemoteProgress {
   char chapterUid[64] = {};

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
@@ -68,18 +68,6 @@ void WeReadProgressSyncActivity::onEnter() {
   Activity::onEnter();
   ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
 
-  const auto& snapshot = READING_STATS.getLastSessionSnapshot();
-  char mappedBookId[sizeof(bookId_)] = {};
-  const bool pathMatches = snapshot.path == epubPath_;
-  const bool bookMatches = pathMatches &&
-                           WeReadStore::findBookIdForPath(snapshot.path, mappedBookId, sizeof(mappedBookId)) &&
-                           strcmp(mappedBookId, bookId_) == 0;
-  input_.readingSeconds =
-      WeReadClient::readingSecondsForSession(snapshot.valid, pathMatches, bookMatches, snapshot.sessionMs);
-  LOG_INF("WRSync", "session report: valid=%u path=%u book=%u readingSeconds=%u", static_cast<unsigned>(snapshot.valid),
-          static_cast<unsigned>(pathMatches), static_cast<unsigned>(bookMatches),
-          static_cast<unsigned>(input_.readingSeconds));
-
   WeReadStore::Session session;
   const bool loggedIn = WeReadStore::loadSession(session) && session.valid();
   session.clear();
@@ -158,7 +146,6 @@ void WeReadProgressSyncActivity::advanceSync() {
   RenderLock renderBarrier(*this);
   if (auto* fontCache = renderer.getFontCacheManager()) fontCache->clearCache();
   const auto event = operation_.step();
-  input_.readingSeconds = operation_.pendingReadingSeconds();
   switch (event) {
     case WeReadClient::Operation::Event::None:
     case WeReadClient::Operation::Event::Authenticated:
@@ -180,8 +167,7 @@ void WeReadProgressSyncActivity::advanceSync() {
 
   const auto result = operation_.progressSyncResult();
   outcome_ = result.outcome;
-  LOG_INF("WRSync", "sync complete: outcome=%u readingSeconds=%u", static_cast<unsigned>(outcome_),
-          static_cast<unsigned>(input_.readingSeconds));
+  LOG_INF("WRSync", "sync complete: outcome=%u", static_cast<unsigned>(outcome_));
   operation_.reset();
   if (outcome_ == WeReadClient::ProgressSyncOutcome::SelectionRequired) {
     remoteFraction_ = result.remote.percent / 100.0f;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -850,6 +850,7 @@ bool EpubReaderActivity::jumpToFraction(float fraction) {
   // Reset state so render() reloads and repositions on the target spine.
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     currentSpineIndex = targetSpineIndex;
     nextPageNumber = 0;
     pendingPercentJump = true;
@@ -873,6 +874,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       // possibly-different settings.
       if (sync.hasVisibleTextOffset && sync.spineIndex >= 0 && sync.spineIndex < epub->getSpineItemsCount()) {
         RenderLock lock(*this);
+        clearDeferredReposition();
         if (section && currentSpineIndex == sync.spineIndex) {
           // Already in this chapter and laid out: resolve straight away, no reload.
           const auto page = section->getPageForVisibleTextOffset(sync.visibleTextOffset);
@@ -902,13 +904,13 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         targetPage = fallback.pageNumber;
       }
 
+      RenderLock lock(*this);
+      clearDeferredReposition();
       if (currentSpineIndex != targetSpineIndex) {
-        RenderLock lock(*this);
         currentSpineIndex = targetSpineIndex;
         nextPageNumber = targetPage;
         section.reset();
       } else if (section && section->currentPage != targetPage) {
-        RenderLock lock(*this);
         const int clampedTargetPage = std::max(0, targetPage);
         section->currentPage = clampedTargetPage;
       } else if (!section) {
@@ -929,6 +931,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
               const auto& chapterResult = std::get<ChapterResult>(result.data);
               RenderLock lock(*this);
 
+              clearDeferredReposition();
               currentSpineIndex = chapterResult.spineIndex;
 
               // If anchor is not empty, it will be used later to calculate the page number.
@@ -1227,6 +1230,10 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   READING_STATS.noteActivity();
+  {
+    RenderLock lock(*this);
+    clearDeferredReposition();
+  }
   if (isForwardTurn) {
     // Advance within the section while there are (or may still be) more pages: either a built
     // page ahead, or the section is still building (windowed), in which case more pages exist
@@ -1364,8 +1371,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // Otherwise fall back to the settings-change reposition: read after the cache-hit reset above,
     // a spec match means the saved page number still names the same content so there is nothing to
     // reposition, while a page jump or fragment anchor is a deliberate navigation that outranks it.
+    const bool explicitOffsetJump = pendingOffsetJump.has_value();
     const std::optional<uint32_t> offsetJump =
-        pendingOffsetJump.has_value() ? pendingOffsetJump
+        explicitOffsetJump ? pendingOffsetJump
         : (pendingPageJump.has_value() || !pendingAnchor.empty() || currentSpineIndex != cachedSpineIndex)
             ? std::nullopt
             : cachedVisibleTextOffset;
@@ -1523,8 +1531,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (offsetJump.has_value()) {
       if (const auto offsetPage = section->getPageForVisibleTextOffset(*offsetJump)) {
         section->currentPage = *offsetPage;
+        clearDeferredReposition();
       }
     }
+    if (explicitOffsetJump) clearDeferredReposition();
     pendingOffsetJump.reset();  // one-shot explicit jump: consumed on this render
 
     if (!pendingAnchor.empty()) {
@@ -1734,9 +1744,13 @@ bool EpubReaderActivity::applyDeferredReposition() {
       changed = true;
     }
   }
-  cachedChapterTotalPageCount = 0;  // consumed; don't read cached progress again
-  cachedVisibleTextOffset.reset();
+  clearDeferredReposition();
   return changed;
+}
+
+void EpubReaderActivity::clearDeferredReposition() {
+  cachedChapterTotalPageCount = 0;
+  cachedVisibleTextOffset.reset();
 }
 
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {
@@ -2185,6 +2199,7 @@ void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool s
 
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     pendingAnchor = std::move(anchor);
     currentSpineIndex = targetSpineIndex;
     nextPageNumber = 0;
@@ -2202,6 +2217,7 @@ void EpubReaderActivity::restoreSavedPosition() {
 
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     currentSpineIndex = pos.spineIndex;
     nextPageNumber = pos.pageNumber;
     section.reset();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -184,6 +184,8 @@ class EpubReaderActivity final : public Activity {
   // settings change re-paginates a chapter). Returns true if currentPage moved.
   // No-op while the section is still building or when the pagination is unchanged (plain resume).
   bool applyDeferredReposition();
+  // Discard the session-start resume anchor after explicit navigation supersedes it.
+  void clearDeferredReposition();
   void rememberCurrentContentOffset();
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   bool jumpToFraction(float fraction);

--- a/test/weread_webapi/WeReadProtocolTest.cpp
+++ b/test/weread_webapi/WeReadProtocolTest.cpp
@@ -55,25 +55,14 @@ struct OperationTestPeer {
     return Operation::wholeChapterRange(first, last, count);
   }
   using ProgressAction = Operation::ProgressAction;
-  static ProgressAction progressAction(const ProgressSyncMode mode, const bool samePosition,
-                                       const bool hasReadingTime) {
-    return Operation::progressAction(mode, samePosition, hasReadingTime);
+  static ProgressAction progressAction(const ProgressSyncMode mode, const bool samePosition) {
+    return Operation::progressAction(mode, samePosition);
   }
   static ProgressSyncOutcome progressVerification(const bool samePosition, const bool remoteHasAppId,
                                                   const bool sameAppId, const bool remoteHasUpdateTime,
                                                   const uint32_t remoteUpdateTime, const uint32_t uploadStartedAt) {
     return Operation::progressVerification(samePosition, remoteHasAppId, sameAppId, remoteHasUpdateTime,
                                            remoteUpdateTime, uploadStartedAt);
-  }
-  static ProgressSyncOutcome reportedProgressOutcome(const ProgressSyncOutcome verified,
-                                                     const ProgressSyncOutcome target) {
-    return Operation::reportedProgressOutcome(verified, target);
-  }
-  static bool ambiguousTimedReportFailure(const Error error, const uint32_t readingSeconds) {
-    return Operation::ambiguousTimedReportFailure(error, readingSeconds);
-  }
-  static uint32_t readingSecondsAfterReport(const Error error, const uint32_t readingSeconds) {
-    return Operation::readingSecondsAfterReport(error, readingSeconds);
   }
   static uint32_t browseReviewRequestCount(const uint32_t cached) {
     return Operation::browseReviewRequestCount(cached);
@@ -541,85 +530,12 @@ TEST(WeReadClientState, RequiresDirectionSelectionOnlyWhenComparedPositionsDiffe
   using Action = WeReadClient::OperationTestPeer::ProgressAction;
   const auto action = WeReadClient::OperationTestPeer::progressAction;
 
-  EXPECT_EQ(action(Mode::Compare, true, false), Action::AlreadySynced);
-  EXPECT_EQ(action(Mode::Compare, false, false), Action::SelectDirection);
-  EXPECT_EQ(action(Mode::ApplyRemote, true, false), Action::AlreadySynced);
-  EXPECT_EQ(action(Mode::ApplyRemote, false, false), Action::ApplyRemote);
-  EXPECT_EQ(action(Mode::UploadLocal, true, false), Action::AlreadySynced);
-  EXPECT_EQ(action(Mode::UploadLocal, false, false), Action::UploadLocal);
-}
-
-TEST(WeReadClientState, ReportsReadingTimeAtTheFinalProgressPosition) {
-  using Mode = WeReadClient::ProgressSyncMode;
-  using Action = WeReadClient::OperationTestPeer::ProgressAction;
-  const auto action = WeReadClient::OperationTestPeer::progressAction;
-
-  EXPECT_EQ(action(Mode::Compare, true, true), Action::ReportSynced);
-  EXPECT_EQ(action(Mode::Compare, false, true), Action::SelectDirection);
-  EXPECT_EQ(action(Mode::ApplyRemote, true, true), Action::ReportSynced);
-  EXPECT_EQ(action(Mode::ApplyRemote, false, true), Action::ReportRemote);
-  EXPECT_EQ(action(Mode::UploadLocal, true, true), Action::ReportSynced);
-  EXPECT_EQ(action(Mode::UploadLocal, false, true), Action::UploadLocal);
-}
-
-TEST(WeReadClientState, AcceptsOnlyTheJustEndedMatchingReadingSession) {
-  const auto seconds = WeReadClient::readingSecondsForSession;
-
-  EXPECT_EQ(seconds(true, true, true, 123999), 123U);
-  EXPECT_EQ(seconds(true, true, true, 999), 0U);
-  EXPECT_EQ(seconds(false, true, true, 123000), 0U);
-  EXPECT_EQ(seconds(true, false, true, 123000), 0U);
-  EXPECT_EQ(seconds(true, true, false, 123000), 0U);
-}
-
-TEST(WeReadClientState, PreservesTheChosenOutcomeAndDoesNotAutoRetryAmbiguousTimedReports) {
-  using Error = WeReadClient::Error;
-  using Outcome = WeReadClient::ProgressSyncOutcome;
-
-  EXPECT_EQ(WeReadClient::OperationTestPeer::reportedProgressOutcome(Outcome::LocalUploaded, Outcome::ApplyRemote),
-            Outcome::ApplyRemote);
-  EXPECT_EQ(WeReadClient::OperationTestPeer::reportedProgressOutcome(Outcome::AlreadySynced, Outcome::AlreadySynced),
-            Outcome::AlreadySynced);
-  EXPECT_EQ(WeReadClient::OperationTestPeer::reportedProgressOutcome(Outcome::LocalUploaded, Outcome::Pending),
-            Outcome::LocalUploaded);
-  EXPECT_TRUE(WeReadClient::OperationTestPeer::ambiguousTimedReportFailure(Error::Network, 123));
-  EXPECT_FALSE(WeReadClient::OperationTestPeer::ambiguousTimedReportFailure(Error::Network, 0));
-  EXPECT_FALSE(WeReadClient::OperationTestPeer::ambiguousTimedReportFailure(Error::Protocol, 123));
-}
-
-TEST(WeReadClientState, ConsumesReadingTimeOnlyAfterAnAcceptedReport) {
-  using Error = WeReadClient::Error;
-  const auto remaining = WeReadClient::OperationTestPeer::readingSecondsAfterReport;
-
-  EXPECT_EQ(remaining(Error::Ok, 123), 0U);
-  EXPECT_EQ(remaining(Error::Network, 123), 123U);
-  EXPECT_EQ(remaining(Error::Protocol, 123), 123U);
-  EXPECT_EQ(remaining(Error::Network, remaining(Error::Ok, 123)), 0U);
-}
-
-TEST(WeReadProtocol, IncludesReadingTimeInSignedQueryAndJsonBody) {
-  char field[32];
-  ASSERT_TRUE(WeReadProtocol::formatReadingTimeQuery(123, field, sizeof(field)));
-  EXPECT_STREQ(field, "&rt=123&sg=");
-
-  std::string query = "appId=wb123&b=book&c=chapter&rn=7";
-  query += field;
-  query += "abcdef&sm=title&ts=1700000000123";
-  char signature[24];
-  ASSERT_TRUE(WeReadProtocol::signQuery(query.c_str(), signature, sizeof(signature)));
-
-  ASSERT_TRUE(WeReadProtocol::formatReadingTimeQuery(124, field, sizeof(field)));
-  std::string changedQuery = "appId=wb123&b=book&c=chapter&rn=7";
-  changedQuery += field;
-  changedQuery += "abcdef&sm=title&ts=1700000000123";
-  char changedSignature[24];
-  ASSERT_TRUE(WeReadProtocol::signQuery(changedQuery.c_str(), changedSignature, sizeof(changedSignature)));
-  EXPECT_STRNE(signature, changedSignature);
-
-  ASSERT_TRUE(WeReadProtocol::formatReadingTimeJson(123, field, sizeof(field)));
-  EXPECT_STREQ(field, ",\"rt\":123,\"ts\":");
-  EXPECT_FALSE(WeReadProtocol::formatReadingTimeQuery(123, field, 4));
-  EXPECT_FALSE(WeReadProtocol::formatReadingTimeJson(123, field, 4));
+  EXPECT_EQ(action(Mode::Compare, true), Action::AlreadySynced);
+  EXPECT_EQ(action(Mode::Compare, false), Action::SelectDirection);
+  EXPECT_EQ(action(Mode::ApplyRemote, true), Action::AlreadySynced);
+  EXPECT_EQ(action(Mode::ApplyRemote, false), Action::ApplyRemote);
+  EXPECT_EQ(action(Mode::UploadLocal, true), Action::AlreadySynced);
+  EXPECT_EQ(action(Mode::UploadLocal, false), Action::UploadLocal);
 }
 
 TEST(WeReadClientState, RequiresAReadBackBeforeReportingProgressUpload) {


### PR DESCRIPTION
## Summary

- stop collecting and reporting reading duration during WeRead progress sync; report payloads retain rn, ts, sg, and read-back verification but omit rt
- accept any successful 2xx response from KOSync-compatible servers and treat a 204 progress lookup as no remote progress, matching upstream 0423276d
- clear deferred resume/reflow anchors after explicit navigation so background pagination cannot roll back a synced position, matching upstream 48e39eb0
- keep the existing content-based XPath, visible-text-offset, and percentage fallback calculations unchanged

## Verification

- 345/345 host tests passed
- WeReadProtocolTest: 38/38 passed
- clang-format 21 check passed
- git diff --check passed
- pio run -e gh_release_cn succeeded
- static DRAM: 118,967 bytes
- confirmed WeRead progress code contains no readingSeconds, reading-time formatter, or rt request field; wr_rt authentication cookie remains intact

## Upstream baseline

Compared against upstream/develop 4970ef1f. Only the two targeted sync fixes were ported; unrelated FUI/UI changes were intentionally excluded.