### PR TITLE
feat: add custom EPUB auto-turn rate

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -617,7 +617,8 @@ Available options include:
 - **Footnotes** – Navigate to the footnotes for the current section *(only shown in books that contain footnotes)*.
 - **Look Up** – Select a word on the current page and show its dictionary definition (see [docs/dictionary.md](docs/dictionary.md)). Requires a dictionary to be selected in **Settings → Reader → Dictionary**.
 - **Reading Orientation** – Cycle through screen orientations without leaving the reader.
-- **Auto Turn (Pages Per Minute)** – Cycle through automatic page turn speed options for hands-free reading.
+- **Auto Turn (Pages Per Minute)** – Choose Off, a preset speed (3, 6, or 12), or a custom speed from 1–30
+  pages per minute for hands-free reading. The custom speed is remembered only while the current book remains open.
 - **Go to %** – Jump to a specific position in the book by percentage.
 - **Take screenshot** – Save a screenshot of the current page to the `screenshots/` folder.
 - **Show page as QR** – Display a QR code encoding the current reading position.

--- a/src/activities/ActivityResult.h
+++ b/src/activities/ActivityResult.h
@@ -20,7 +20,7 @@ struct KeyboardResult {
 struct MenuResult {
   int action = -1;
   uint8_t orientation = 0;
-  uint8_t pageTurnOption = 0;
+  uint8_t pageTurnRate = 0;
 };
 
 struct ChapterResult {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -55,9 +55,7 @@
 #include "util/TimeUtils.h"
 
 namespace {
-// pagesPerRefresh now comes from SETTINGS.getRefreshFrequency()
-// pages per minute, first item is 1 to prevent division by zero if accessed
-constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
+constexpr uint8_t MAX_PAGE_TURN_RATE = 30;
 constexpr size_t initialBookmarkCacheCapacity = 16;
 constexpr float bookmarkProgressEpsilon = 0.0001f;
 
@@ -356,19 +354,20 @@ void EpubReaderActivity::openReaderMenu() {
     bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
   }
   const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
-  startActivityForResult(std::make_unique<EpubReaderMenuActivity>(
-                             renderer, mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent,
-                             SETTINGS.orientation, !currentPageFootnotes.empty(), !cachedBookmarks.empty()),
-                         [this](const ActivityResult& result) {
-                           READING_STATS.resumeSession();
-                           // Always apply orientation change even if the menu was cancelled
-                           const auto& menu = std::get<MenuResult>(result.data);
-                           applyOrientation(menu.orientation);
-                           toggleAutoPageTurn(menu.pageTurnOption);
-                           if (!result.isCancelled) {
-                             onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action));
-                           }
-                         });
+  startActivityForResult(
+      std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, epub->getTitle(), currentPage, totalPages,
+                                               bookProgressPercent, SETTINGS.orientation, pageTurnRate,
+                                               !currentPageFootnotes.empty(), !cachedBookmarks.empty()),
+      [this](const ActivityResult& result) {
+        READING_STATS.resumeSession();
+        // Always apply orientation change even if the menu was cancelled
+        const auto& menu = std::get<MenuResult>(result.data);
+        applyOrientation(menu.orientation);
+        toggleAutoPageTurn(menu.pageTurnRate);
+        if (!result.isCancelled) {
+          onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action));
+        }
+      });
 }
 
 bool EpubReaderActivity::buildTickHeapGate() {
@@ -1202,15 +1201,15 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
   }
 }
 
-void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption) {
-  if (selectedPageTurnOption == 0 || selectedPageTurnOption >= std::size(PAGE_TURN_RATES)) {
+void EpubReaderActivity::toggleAutoPageTurn(const uint8_t requestedPageTurnRate) {
+  if (requestedPageTurnRate == 0 || requestedPageTurnRate > MAX_PAGE_TURN_RATE) {
     automaticPageTurnActive = false;
     return;
   }
 
+  pageTurnRate = requestedPageTurnRate;
   lastPageTurnTime = millis();
-  // calculates page turn duration by dividing by number of pages
-  pageTurnDuration = (1UL * 60 * 1000) / PAGE_TURN_RATES[selectedPageTurnOption];
+  pageTurnDuration = (1UL * 60 * 1000) / pageTurnRate;
   automaticPageTurnActive = true;
 
   const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
@@ -2138,7 +2137,7 @@ void EpubReaderActivity::renderStatusBar() const {
   const auto sb = SETTINGS.statusBarSpec();
 
   if (automaticPageTurnActive) {
-    title = tr(STR_AUTO_TURN_ENABLED) + std::to_string(60 * 1000 / pageTurnDuration);
+    title = tr(STR_AUTO_TURN_ENABLED) + std::to_string(pageTurnRate);
 
     // calculates textYOffset when rendering title in status bar
     const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -39,6 +39,7 @@ class EpubReaderActivity final : public Activity {
   std::optional<uint32_t> pendingOffsetJump;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
+  uint8_t pageTurnRate = 15;
   unsigned long openStartMs;
   bool firstPageLogged = false;
   // Signals that the next render should reposition within the newly loaded section
@@ -202,7 +203,7 @@ class EpubReaderActivity final : public Activity {
   bool launchWeReadSync();
 #endif
   void applyOrientation(uint8_t orientation);
-  void toggleAutoPageTurn(uint8_t selectedPageTurnOption);
+  void toggleAutoPageTurn(uint8_t requestedPageTurnRate);
   void pageTurn(bool isForwardTurn);
   void loadCachedBookmarks();
   void addBookmark();

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -3,18 +3,51 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
+#include <algorithm>
+#include <array>
+
 #include "MappedInputManager.h"
+#include "activities/util/IntervalSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+
+namespace {
+constexpr std::array<uint8_t, 4> PAGE_TURN_RATES = {0, 3, 6, 12};
+constexpr int CUSTOM_PAGE_TURN_OPTION = static_cast<int>(PAGE_TURN_RATES.size());
+constexpr uint8_t DEFAULT_CUSTOM_PAGE_TURN_RATE = 15;
+constexpr uint8_t MIN_CUSTOM_PAGE_TURN_RATE = 1;
+constexpr uint8_t MAX_CUSTOM_PAGE_TURN_RATE = 30;
+
+constexpr uint8_t clampCustomPageTurnRate(const int rate) {
+  if (rate == 0) return DEFAULT_CUSTOM_PAGE_TURN_RATE;
+  return static_cast<uint8_t>(
+      std::clamp(rate, static_cast<int>(MIN_CUSTOM_PAGE_TURN_RATE), static_cast<int>(MAX_CUSTOM_PAGE_TURN_RATE)));
+}
+
+constexpr uint8_t pageTurnRateForOption(const int option, const uint8_t customRate) {
+  if (option == CUSTOM_PAGE_TURN_OPTION) return clampCustomPageTurnRate(customRate);
+  if (option < 0 || option >= static_cast<int>(PAGE_TURN_RATES.size())) return 0;
+  return PAGE_TURN_RATES[option];
+}
+
+static_assert(pageTurnRateForOption(0, 6) == 0);
+static_assert(pageTurnRateForOption(2, 6) == 6);
+static_assert(pageTurnRateForOption(CUSTOM_PAGE_TURN_OPTION, 7) == 7);
+static_assert(pageTurnRateForOption(CUSTOM_PAGE_TURN_OPTION, 0) == DEFAULT_CUSTOM_PAGE_TURN_RATE);
+static_assert(pageTurnRateForOption(CUSTOM_PAGE_TURN_OPTION, 31) == MAX_CUSTOM_PAGE_TURN_RATE);
+static_assert(pageTurnRateForOption(99, 6) == 0);
+}  // namespace
 
 EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                                const std::string& title, const int currentPage, const int totalPages,
                                                const int bookProgressPercent, const uint8_t currentOrientation,
-                                               const bool hasFootnotes, const bool hasBookmarks)
+                                               const uint8_t initialPageTurnRate, const bool hasFootnotes,
+                                               const bool hasBookmarks)
     : Activity("EpubReaderMenu", renderer, mappedInput),
       menuItems(buildMenuItems(hasFootnotes, hasBookmarks)),
       title(title),
       pendingOrientation(currentOrientation),
+      customPageTurnRate(clampCustomPageTurnRate(initialPageTurnRate)),
       currentPage(currentPage),
       totalPages(totalPages),
       bookProgressPercent(bookProgressPercent) {}
@@ -54,7 +87,7 @@ void EpubReaderMenuActivity::onExit() { Activity::onExit(); }
 void EpubReaderMenuActivity::closeCancelled() {
   ActivityResult result;
   result.isCancelled = true;
-  result.data = MenuResult{-1, pendingOrientation, selectedPageTurnOption};
+  result.data = MenuResult{-1, pendingOrientation, pageTurnRateForOption(selectedPageTurnOption, customPageTurnRate)};
   setResult(std::move(result));
   finish();
 }
@@ -104,14 +137,33 @@ void EpubReaderMenuActivity::loop() {
     if (selectedAction == MenuAction::AUTO_PAGE_TURN) {
       optionPopup.show(I18N.get(StrId::STR_AUTO_TURN_PAGES_PER_MIN), pageTurnLabels.data(),
                        static_cast<int>(pageTurnLabels.size()), selectedPageTurnOption, [this](int idx) {
-                         selectedPageTurnOption = idx;
+                         if (idx != CUSTOM_PAGE_TURN_OPTION) {
+                           selectedPageTurnOption = idx;
+                           requestUpdate();
+                           return;
+                         }
+
+                         // ActivityManager owns the picker across frames; the shared helper keeps its allocation
+                         // fallible and logs OOM while leaving the previous option unchanged.
+                         startActivityForResultWith<IntervalSelectionActivity>(
+                             [this](const ActivityResult& result) {
+                               if (!result.isCancelled) {
+                                 customPageTurnRate =
+                                     clampCustomPageTurnRate(std::get<IntervalResult>(result.data).value);
+                                 selectedPageTurnOption = CUSTOM_PAGE_TURN_OPTION;
+                               }
+                               requestUpdate();
+                             },
+                             "AutoPageTurnRate", StrId::STR_AUTO_TURN_PAGES_PER_MIN, customPageTurnRate,
+                             MIN_CUSTOM_PAGE_TURN_RATE, MAX_CUSTOM_PAGE_TURN_RATE, 1, 5);
                          requestUpdate();
                        });
       requestUpdate();
       return;
     }
 
-    setResult(MenuResult{static_cast<int>(selectedAction), pendingOrientation, selectedPageTurnOption});
+    setResult(MenuResult{static_cast<int>(selectedAction), pendingOrientation,
+                         pageTurnRateForOption(selectedPageTurnOption, customPageTurnRate)});
     finish();
   };
 

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -2,6 +2,7 @@
 #include <Epub.h>
 #include <I18n.h>
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -31,7 +32,8 @@ class EpubReaderMenuActivity final : public Activity {
 
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title,
                                   const int currentPage, const int totalPages, const int bookProgressPercent,
-                                  const uint8_t currentOrientation, const bool hasFootnotes, bool hasBookmarks);
+                                  const uint8_t currentOrientation, const uint8_t initialPageTurnRate,
+                                  const bool hasFootnotes, bool hasBookmarks);
 
   void onEnter() override;
   void onExit() override;
@@ -61,9 +63,11 @@ class EpubReaderMenuActivity final : public Activity {
   std::string title = "Reader Menu";
   uint8_t pendingOrientation = 0;
   uint8_t selectedPageTurnOption = 0;
+  uint8_t customPageTurnRate = 15;
   const std::vector<StrId> orientationLabels = {StrId::STR_PORTRAIT, StrId::STR_LANDSCAPE_CW, StrId::STR_INVERTED,
                                                 StrId::STR_LANDSCAPE_CCW};
-  const std::vector<const char*> pageTurnLabels = {I18N.get(StrId::STR_STATE_OFF), "1", "3", "6", "12"};
+  const std::array<const char*, 5> pageTurnLabels = {I18N.get(StrId::STR_STATE_OFF), "3", "6", "12",
+                                                     I18N.get(StrId::STR_CUSTOM)};
   int currentPage = 0;
   int totalPages = 0;
   int bookProgressPercent = 0;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Add a session-scoped custom EPUB auto-page-turn rate.
* **What changes are included?**
  - Offers Off, 3, 6, 12, and Custom; Custom supports 1–30 pages/min and starts at 15.
  - Returns actual page rates instead of option indexes.
  - Reuses IntervalSelectionActivity and retains the last nonzero rate only for the current open-book session.
  - Documents the new behavior.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This extends an existing core reading feature without adding a new app or general-purpose surface.
- [x] No new dependency, persistent setting, cache format, or generated i18n file is introduced.
- [x] The change uses existing Activity, input, allocation, and localization mechanisms.

## Additional Context

* Runtime memory: one session-rate byte is added to reader state; the menu labels now use std::array instead of a heap-backed vector. The custom interval activity is allocated only while its picker is open and is released on exit.
* Validation completed:
  - [x] git diff --check
  - [x] ./bin/ci-check
  - [x] pio run -e gh_release_cn
* Device validation pending:
  - [ ] Custom slider bounds and button/touch increments
  - [ ] Cancel leaves the previous value unchanged
  - [ ] 7 pages/min status and approximately 8.57-second turn interval
  - [ ] Session reset after closing and reopening a book
  - [ ] Serial free-heap and largest-block recovery after opening and closing the picker

### AI Usage

Did you use AI tools to assist with this PR? **YES**