### PR TITLE
fix: keep EPUB auto-turn awake

### DIFF
--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -231,6 +231,7 @@ class EpubReaderActivity final : public Activity {
   // and while the build is heap-paused (no work is happening, so spinning at full
   // speed would only burn battery; the paused gate still retries every loop pass).
   bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
+  bool preventAutoSleep() override { return automaticPageTurnActive; }
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
     {


### PR DESCRIPTION
## Summary

- Prevent timeout-triggered deep sleep only while EPUB automatic page turn is active.
- Reuse the existing current-activity preventAutoSleep hook, so stopping auto turn or leaving the reader immediately restores normal timeout behavior.
- This is a standalone sleep-policy fix on current main and does not modify the custom-rate behavior introduced by #177.

## Scope

- EPUB reader only; TXT and XTC behavior is unchanged.
- CPU idle downclock and manual power-button sleep remain available.
- No persistent or global state, settings, dependencies, documentation changes, allocations, or new RAM/heap usage.

## Validation

- [x] git diff --check
- [x] ./bin/ci-check (format, cppcheck, default/sticky builds, 345 host tests)
- [x] pio run -e gh_release_cn
- [ ] Hardware: auto turn continues beyond the configured sleep timeout
- [ ] Hardware: stopping auto turn restarts the normal timeout behavior
- [ ] Hardware: leaving for Home and reopening a book leaves no sleep protection behind
- [ ] Hardware: manual power-button sleep remains functional

## AI Usage

YES