### PR TITLE
docs: set default pull request target

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -42,7 +42,7 @@ full reasoning, examples, and edge cases.
 9. **Free in `onExit()` what you alloc in `onEnter()`.** `vTaskDelete()` tasks before activity destruction; activities are heap-allocated and deleted on exit. → [architecture-and-patterns.md](docs/engineering/architecture-and-patterns.md)
 10. **Bump the cache format version BEFORE changing a binary layout** (`book.bin`, `section.bin`); document it in `docs/file-formats.md`. → [cache-management.md](docs/engineering/cache-management.md)
 11. **Edit sources, not generated files** (`*.generated.h`, `I18n*` generated headers). → [generated-files.md](docs/engineering/generated-files.md)
-12. **Verify repo context before any git op; ask before committing**; never stage `.gitignore`d files. → [git-workflow.md](docs/engineering/git-workflow.md)
+12. **Verify repo context before any git op; ask before committing.** Unqualified PR requests target `0x1abin/crossmux:main` via `origin` without asking; an explicit user target overrides this default. Never stage `.gitignore`d files. → [git-workflow.md](docs/engineering/git-workflow.md)
 13. **One physical button gesture causes one action.** Normal Activities read the shared input snapshot; across popups and Activities, gate inherited held buttons and consume the triggering release. → [ui-and-input.md](docs/engineering/ui-and-input.md)
 
 ## Quick Reference

--- a/docs/engineering/git-workflow.md
+++ b/docs/engineering/git-workflow.md
@@ -41,10 +41,12 @@ upstream    https://github.com/crosspoint-reader/crosspoint-reader.git (fetch/pu
    # Good: git push origin $(git branch --show-current)
    ```
 
-2. **Never assume remote names or write permissions**:
-   - **Forked repos**: Push to `origin` (your fork), submit PR to `upstream`
-   - **Direct contributors**: May push feature branches to `upstream`
-   - **Always ask**: "Should I push to origin or create a PR?"
+2. **Use this project's default PR target**:
+   - For an unqualified PR request, push the feature branch to `origin` and open the PR against
+     `0x1abin/crossmux:main` without asking for the target again.
+   - An explicit user-supplied repository or base branch overrides this default.
+   - Still verify that `origin` resolves to `0x1abin/crossmux` and that the current credentials can push; ask only
+     when the configured repository differs or required access is unavailable.
 
 3. **Check for upstream changes before starting work**:
    ```bash


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Persist the repository-specific default that unqualified PR requests target `0x1abin/crossmux:main`.
* **What changes are included?** Update the agent entrypoint and Git workflow documentation so the target is not repeatedly requested, while preserving explicit user overrides and repository/access checks.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no firmware behavior changes are included.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Documentation-only change; no firmware build is required.
* Verified with `git diff --check` and confirmed `AGENTS.md` and `CLAUDE.md` still resolve to `.skills/SKILL.md`.
* Memory / flash impact: none.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
