### PR TITLE
feat: add OTA summaries to manual nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,23 @@ on:
   schedule:
     - cron: '0 23 * * *' # daily 07:00 Asia/Shanghai
   workflow_dispatch:
+    inputs:
+      summary_en_1:
+        description: 'English OTA summary line 1 (max 42 ASCII characters)'
+        required: true
+        type: string
+      summary_en_2:
+        description: 'English OTA summary line 2 (max 42 ASCII characters)'
+        required: true
+        type: string
+      summary_zh_1:
+        description: 'Chinese OTA summary line 1 (max 16 characters)'
+        required: true
+        type: string
+      summary_zh_2:
+        description: 'Chinese OTA summary line 2 (max 16 characters)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -22,6 +39,23 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+
+      - name: Validate manual OTA summary
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SUMMARY_EN_1: ${{ inputs.summary_en_1 }}
+          SUMMARY_EN_2: ${{ inputs.summary_en_2 }}
+          SUMMARY_ZH_1: ${{ inputs.summary_zh_1 }}
+          SUMMARY_ZH_2: ${{ inputs.summary_zh_2 }}
+        run: |
+          mkdir -p dist
+          python3 scripts/generate_ota_summary.py \
+            --en-line="$SUMMARY_EN_1" \
+            --en-line="$SUMMARY_EN_2" \
+            --zh-line="$SUMMARY_ZH_1" \
+            --zh-line="$SUMMARY_ZH_2" \
+            --output dist/ota-summary.md
+          test -s dist/ota-summary.md
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -80,6 +114,10 @@ jobs:
             printf '%s\n' '- `firmware.bin` — international'
             printf '%s\n' '- `firmware-cn.bin` — Chinese (中文)'
           } > nightly-body.md
+          if [ -s dist/ota-summary.md ]; then
+            printf '\n' >> nightly-body.md
+            cat dist/ota-summary.md >> nightly-body.md
+          fi
 
       # Roll the single `nightly` release/tag forward to the current commit.
       - name: Remove previous nightly release
@@ -94,7 +132,9 @@ jobs:
           name: CrossMux Nightly (${{ env.SHORT_SHA }})
           prerelease: true
           target_commitish: ${{ github.sha }}
-          files: dist/*
+          files: |
+            dist/firmware.bin
+            dist/firmware-cn.bin
           fail_on_unmatched_files: true
           body_path: nightly-body.md
 

--- a/scripts/generate_ota_summary.py
+++ b/scripts/generate_ota_summary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate an OTA summary supplied in an annotated release tag."""
+"""Validate and serialize OTA summary metadata."""
 
 from __future__ import annotations
 
@@ -101,6 +101,8 @@ def self_test() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--input")
+    parser.add_argument("--en-line", action="append")
+    parser.add_argument("--zh-line", action="append")
     parser.add_argument("--output", default="ota-summary.md")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -113,9 +115,12 @@ def main() -> int:
     output = Path(args.output)
     output.unlink(missing_ok=True)
     try:
-        if not args.input:
-            raise ValueError("input file is required")
-        summary = extract_summary(Path(args.input).read_text(encoding="utf-8"))
+        if args.input and (args.en_line or args.zh_line):
+            raise ValueError("use either --input or direct summary lines")
+        if args.input:
+            summary = extract_summary(Path(args.input).read_text(encoding="utf-8"))
+        else:
+            summary = validate_summary({"en": args.en_line, "zh": args.zh_line})
         output.write_text(marker(summary), encoding="utf-8")
     except Exception as error:
         print(f"::warning::OTA summary omitted: {error}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- require bilingual OTA summary inputs for manually dispatched Nightly builds
- validate summaries before installing PlatformIO or compiling firmware
- embed the validated summary in GitHub and Gitee release notes while leaving scheduled Nightly builds unchanged

## Tests

- python3 scripts/generate_ota_summary.py --self-test
- valid direct-input and annotated-tag compatibility checks
- missing, duplicate, unsafe, and oversized summary rejection checks
- nightly.yml YAML syntax check
- git diff --check