### PR TITLE
fix: preserve opaque white in transparent sleep screens

### DIFF
--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -90,7 +90,9 @@ BmpReaderError Bitmap::parseHeaders() {
   const uint16_t bfType = readLE16(file);
   if (bfType != 0x4D42) return BmpReaderError::NotBMP;
 
-  file.seekCur(8);
+  file.seekCur(4);  // bfSize
+  const uint16_t reserved1 = readLE16(file);
+  const uint16_t reserved2 = readLE16(file);
   bfOffBits = readLE32(file);
 
   // --- DIB HEADER ---
@@ -118,6 +120,9 @@ BmpReaderError Bitmap::parseHeaders() {
   if (colorsUsed == 0 && bpp <= 8) colorsUsed = 1u << bpp;
   if (colorsUsed > 256u) return BmpReaderError::PaletteTooLarge;
   file.seekCur(4);  // biClrImportant
+
+  transparentOverlay = reserved1 == TRANSPARENT_OVERLAY_MARKER && reserved2 == TRANSPARENT_OVERLAY_VERSION &&
+                       bpp == 4 && colorsUsed == TRANSPARENT_PALETTE_INDEX + 1;
 
   if (width <= 0 || height <= 0) return BmpReaderError::BadDimensions;
 
@@ -180,7 +185,7 @@ BmpReaderError Bitmap::parseHeaders() {
 }
 
 // packed 2bpp output, 0 = black, 1 = dark gray, 2 = light gray, 3 = white
-BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
+BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer, uint8_t* opacityRow) const {
   // Note: rowBuffer should be pre-allocated by the caller to size 'rowBytes'
   if (file.read(rowBuffer, rowBytes) != rowBytes) return BmpReaderError::ShortReadRow;
 
@@ -192,7 +197,7 @@ BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
   int currentX = 0;
 
   // Helper lambda to pack 2bpp color into the output stream
-  auto packPixel = [&](const uint8_t lum) {
+  auto packPixel = [&](const uint8_t lum, const bool opaque = true) {
     uint8_t color;
     if (atkinsonDitherer) {
       color = atkinsonDitherer->processPixel(adjustPixel(lum), currentX);
@@ -207,6 +212,7 @@ BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
         color = quantize(adjustPixel(lum), currentX, prevRowY);
       }
     }
+    if (opacityRow) opacityRow[currentX] = opaque;
     currentOutByte |= (color << bitShift);
     if (bitShift == 0) {
       *outPtr++ = currentOutByte;
@@ -248,7 +254,8 @@ BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
     case 4: {
       for (int x = 0; x < width; x++) {
         const uint8_t nibble = (x & 1) ? (rowBuffer[x >> 1] & 0x0F) : (rowBuffer[x >> 1] >> 4);
-        packPixel(paletteLum[nibble]);
+        const bool opaque = !transparentOverlay || nibble != TRANSPARENT_PALETTE_INDEX;
+        packPixel(opaque ? paletteLum[nibble] : 255, opaque);
       }
       break;
     }

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -62,12 +62,16 @@ enum class BmpReaderError : uint8_t {
 
 class Bitmap {
  public:
+  static constexpr uint16_t TRANSPARENT_OVERLAY_MARKER = 0x5843;
+  static constexpr uint16_t TRANSPARENT_OVERLAY_VERSION = 1;
+  static constexpr uint8_t TRANSPARENT_PALETTE_INDEX = 4;
+
   static const char* errorToString(BmpReaderError err);
 
   explicit Bitmap(HalFile& file, bool dithering = false) : file(file), dithering(dithering) {}
   ~Bitmap();
   BmpReaderError parseHeaders();
-  BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer) const;
+  BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer, uint8_t* opacityRow = nullptr) const;
   BmpReaderError rewindToData() const;
   int getWidth() const { return width; }
   int getHeight() const { return height; }
@@ -76,6 +80,7 @@ class Bitmap {
   int getRowBytes() const { return rowBytes; }
   bool is1Bit() const { return bpp == 1; }
   uint16_t getBpp() const { return bpp; }
+  bool hasTransparency() const { return transparentOverlay; }
 
  private:
   static uint16_t readLE16(HalFile& f);
@@ -89,6 +94,7 @@ class Bitmap {
   uint32_t bfOffBits = 0;
   uint16_t bpp = 0;
   uint32_t colorsUsed = 0;
+  bool transparentOverlay = false;
   bool nativePalette = false;  // true if all palette entries map to native gray levels
   int rowBytes = 0;
   uint8_t paletteLum[256] = {};

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1421,7 +1421,7 @@ bool GfxRenderer::drawBitmapCropToFill(const Bitmap& bitmap, const int x, const 
 }
 
 void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, const int maxWidth, const int maxHeight,
-                             const float cropX, const float cropY) const {
+                             const float cropX, const float cropY, const bool preserveTransparency) const {
   if (fontCacheManager_ && fontCacheManager_->isScanning()) return;
   // For 1-bit bitmaps, use optimized 1-bit rendering path (no crop support for 1-bit)
   if (bitmap.is1Bit() && cropX == 0.0f && cropY == 0.0f) {
@@ -1463,8 +1463,11 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
   auto* outputRow = static_cast<uint8_t*>(malloc(outputRowSize));
   auto* rowBytes = static_cast<uint8_t*>(malloc(bitmap.getRowBytes()));
+  const bool useTransparency = preserveTransparency && bitmap.hasTransparency();
+  // Up to 2048 bytes, too large for the task stack; allocate once for this draw pass.
+  auto opacityRow = useTransparency ? makeUniqueNoThrow<uint8_t[]>(bitmap.getWidth()) : nullptr;
 
-  if (!outputRow || !rowBytes) {
+  if (!outputRow || !rowBytes || (useTransparency && !opacityRow)) {
     LOG_ERR("GFX", "!! Failed to allocate BMP row buffers");
     free(outputRow);
     free(rowBytes);
@@ -1483,7 +1486,7 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
       break;
     }
 
-    if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
+    if (bitmap.readNextRow(outputRow, rowBytes, opacityRow.get()) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from bitmap", bmpY);
       free(outputRow);
       free(rowBytes);
@@ -1514,8 +1517,11 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
 
       const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
 
-      if (renderMode == BW && val < 3) {
-        drawPixel(screenX, screenY);
+      if (useTransparency && !opacityRow[bmpX]) {
+        continue;
+      }
+      if (renderMode == BW && (useTransparency || val < 3)) {
+        drawPixel(screenX, screenY, val < 3);
       } else if (renderMode == GRAYSCALE_MSB && (val == 1 || val == 2)) {
         drawPixel(screenX, screenY, false);
       } else if (renderMode == GRAYSCALE_LSB && val == 1) {

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -282,8 +282,8 @@ class GfxRenderer {
   void drawImage(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawIcon(const uint8_t bitmap[], int x, int y, int size) const;
   void drawIconInverted(const uint8_t bitmap[], int x, int y, int size) const;
-  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
-                  float cropY = 0) const;
+  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0, float cropY = 0,
+                  bool preserveTransparency = false) const;
   bool drawBitmapCropToFill(const Bitmap& bitmap, int x, int y, int width, int height) const;
   void drawBitmap1Bit(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight) const;
   void fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state = true) const;

--- a/lib/PngToBmpConverter/PngHelpers.h
+++ b/lib/PngToBmpConverter/PngHelpers.h
@@ -8,6 +8,10 @@ constexpr uint8_t blendWithWhite(const uint8_t gray, const uint8_t alpha) {
   return static_cast<uint8_t>((static_cast<uint16_t>(gray) * alpha + 255u * (255u - alpha) + 127u) / 255u);
 }
 
+constexpr uint8_t overlayPaletteIndex(const uint8_t grayLevel, const bool opaque) { return opaque ? grayLevel : 4; }
+
+constexpr bool isOverlayPixelOpaque(const uint16_t alpha) { return alpha != 0; }
+
 constexpr bool isSupportedFormat(const uint8_t colorType, const uint8_t bitDepth) {
   switch (colorType) {
     case 0:  // Grayscale

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "Bitmap.h"
 #include "BitmapHelpers.h"
 #include "PngHelpers.h"
 
@@ -189,6 +190,36 @@ void writeBmpHeader2bit(Print& bmpOut, const int width, const int height) {
   for (const uint8_t i : palette) {
     bmpOut.write(i);
   }
+}
+
+void writeTransparentBmpHeader4bit(Print& bmpOut, const int width, const int height) {
+  const int bytesPerRow = (width + 7) / 8 * 4;
+  const int imageSize = bytesPerRow * height;
+  constexpr uint32_t paletteSize = 5 * 4;
+  const uint32_t pixelOffset = 14 + 40 + paletteSize;
+
+  bmpOut.write('B');
+  bmpOut.write('M');
+  write32(bmpOut, pixelOffset + imageSize);
+  write16(bmpOut, Bitmap::TRANSPARENT_OVERLAY_MARKER);
+  write16(bmpOut, Bitmap::TRANSPARENT_OVERLAY_VERSION);
+  write32(bmpOut, pixelOffset);
+
+  write32(bmpOut, 40);
+  write32Signed(bmpOut, width);
+  write32Signed(bmpOut, -height);
+  write16(bmpOut, 1);
+  write16(bmpOut, 4);
+  write32(bmpOut, 0);
+  write32(bmpOut, imageSize);
+  write32(bmpOut, 2835);
+  write32(bmpOut, 2835);
+  write32(bmpOut, Bitmap::TRANSPARENT_PALETTE_INDEX + 1);
+  write32(bmpOut, Bitmap::TRANSPARENT_PALETTE_INDEX + 1);
+
+  constexpr uint8_t palette[] = {0x00, 0x00, 0x00, 0x00, 0x55, 0x55, 0x55, 0x00, 0xAA, 0xAA,
+                                 0xAA, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF, 0x00};
+  bmpOut.write(palette, sizeof(palette));
 }
 }  // namespace
 
@@ -445,9 +476,94 @@ static void convertScanlineToGray(const PngDecodeContext& ctx, uint8_t* grayRow)
   }
 }
 
+static void convertScanlineToOpacity(const PngDecodeContext& ctx, uint8_t* opacityRow) {
+  const uint8_t* src = ctx.currentRow;
+  const uint32_t w = ctx.width;
+
+  switch (ctx.colorType) {
+    case PNG_COLOR_GRAYSCALE:
+      if (!ctx.hasTransparentGray) {
+        memset(opacityRow, 1, w);
+      } else if (ctx.bitDepth == 8) {
+        for (uint32_t x = 0; x < w; x++) opacityRow[x] = src[x] != ctx.transparentGray;
+      } else if (ctx.bitDepth == 16) {
+        for (uint32_t x = 0; x < w; x++) {
+          const uint16_t sample = static_cast<uint16_t>(src[x * 2]) << 8 | src[x * 2 + 1];
+          opacityRow[x] = sample != ctx.transparentGray;
+        }
+      } else {
+        const int ppb = 8 / ctx.bitDepth;
+        const uint8_t mask = (1 << ctx.bitDepth) - 1;
+        for (uint32_t x = 0; x < w; x++) {
+          const int shift = (ppb - 1 - (x % ppb)) * ctx.bitDepth;
+          opacityRow[x] = ((src[x / ppb] >> shift) & mask) != ctx.transparentGray;
+        }
+      }
+      break;
+
+    case PNG_COLOR_RGB:
+      if (!ctx.hasTransparentRgb) {
+        memset(opacityRow, 1, w);
+      } else if (ctx.bitDepth == 8) {
+        for (uint32_t x = 0; x < w; x++) {
+          const uint8_t* p = src + x * 3;
+          opacityRow[x] = p[0] != ctx.transparentRed || p[1] != ctx.transparentGreen || p[2] != ctx.transparentBlue;
+        }
+      } else {
+        for (uint32_t x = 0; x < w; x++) {
+          const uint8_t* p = src + x * 6;
+          const uint16_t red = static_cast<uint16_t>(p[0]) << 8 | p[1];
+          const uint16_t green = static_cast<uint16_t>(p[2]) << 8 | p[3];
+          const uint16_t blue = static_cast<uint16_t>(p[4]) << 8 | p[5];
+          opacityRow[x] = red != ctx.transparentRed || green != ctx.transparentGreen || blue != ctx.transparentBlue;
+        }
+      }
+      break;
+
+    case PNG_COLOR_PALETTE: {
+      const int ppb = 8 / ctx.bitDepth;
+      const uint8_t mask = (1 << ctx.bitDepth) - 1;
+      for (uint32_t x = 0; x < w; x++) {
+        const int shift = (ppb - 1 - (x % ppb)) * ctx.bitDepth;
+        uint8_t idx = (src[x / ppb] >> shift) & mask;
+        if (idx >= ctx.paletteSize) idx = 0;
+        opacityRow[x] = ctx.paletteAlpha[idx] != 0;
+      }
+      break;
+    }
+
+    case PNG_COLOR_GRAYSCALE_ALPHA:
+      if (ctx.bitDepth == 8) {
+        for (uint32_t x = 0; x < w; x++) opacityRow[x] = pngHelpers::isOverlayPixelOpaque(src[x * 2 + 1]);
+      } else {
+        for (uint32_t x = 0; x < w; x++) {
+          const uint16_t alpha = static_cast<uint16_t>(src[x * 4 + 2]) << 8 | src[x * 4 + 3];
+          opacityRow[x] = pngHelpers::isOverlayPixelOpaque(alpha);
+        }
+      }
+      break;
+
+    case PNG_COLOR_RGBA:
+      if (ctx.bitDepth == 8) {
+        for (uint32_t x = 0; x < w; x++) opacityRow[x] = pngHelpers::isOverlayPixelOpaque(src[x * 4 + 3]);
+      } else {
+        for (uint32_t x = 0; x < w; x++) {
+          const uint16_t alpha = static_cast<uint16_t>(src[x * 8 + 6]) << 8 | src[x * 8 + 7];
+          opacityRow[x] = pngHelpers::isOverlayPixelOpaque(alpha);
+        }
+      }
+      break;
+
+    default:
+      memset(opacityRow, 1, w);
+      break;
+  }
+}
+
 bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                                   bool oneBit, bool crop) {
-  LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
+                                                   bool oneBit, bool crop, bool preserveTransparency) {
+  LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)",
+          preserveTransparency ? "transparent 4-bit" : (oneBit ? "1-bit" : "2-bit"), targetWidth, targetHeight);
 
   // Verify PNG signature
   uint8_t sig[8];
@@ -696,7 +812,10 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
 
   // Write BMP header
   int bytesPerRow;
-  if (USE_8BIT_OUTPUT && !oneBit) {
+  if (preserveTransparency) {
+    writeTransparentBmpHeader4bit(bmpOut, outWidth, outHeight);
+    bytesPerRow = (outWidth + 7) / 8 * 4;
+  } else if (USE_8BIT_OUTPUT && !oneBit) {
     writeBmpHeader8bit(bmpOut, outWidth, outHeight);
     bytesPerRow = (outWidth + 3) / 4 * 4;
   } else if (oneBit) {
@@ -735,21 +854,25 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   // Scaling accumulators
   std::unique_ptr<uint32_t[]> rowAccum;
   std::unique_ptr<uint16_t[]> rowCount;
+  std::unique_ptr<uint32_t[]> rowOpaqueCount;
   int currentOutY = 0;
   uint32_t nextOutY_srcStart = 0;
 
   if (needsScaling) {
     rowAccum = makeUniqueNoThrow<uint32_t[]>(outWidth);
     rowCount = makeUniqueNoThrow<uint16_t[]>(outWidth);
-    if (!rowAccum || !rowCount) return false;
+    if (preserveTransparency) rowOpaqueCount = makeUniqueNoThrow<uint32_t[]>(outWidth);
+    if (!rowAccum || !rowCount || (preserveTransparency && !rowOpaqueCount)) return false;
     nextOutY_srcStart = scaleY_fp;
   }
 
   // Allocate grayscale row buffer - batch-convert each scanline to avoid
   // per-pixel getPixelGray() switch overhead in the hot loops
   auto grayRow = makeUniqueNoThrow<uint8_t[]>(width);
-  if (!grayRow) {
-    LOG_ERR("PNG", "Failed to allocate grayscale row buffer");
+  // Source rows can be 2048 pixels wide, so the optional opacity row cannot live on the task stack.
+  auto opacityRow = preserveTransparency ? makeUniqueNoThrow<uint8_t[]>(width) : nullptr;
+  if (!grayRow || (preserveTransparency && !opacityRow)) {
+    LOG_ERR("PNG", "Failed to allocate grayscale/opacity row buffers");
     return false;
   }
 
@@ -767,12 +890,13 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
 
     // Batch-convert entire scanline to grayscale (one branch, tight loop)
     convertScanlineToGray(ctx, grayRow.get());
+    if (preserveTransparency) convertScanlineToOpacity(ctx, opacityRow.get());
 
     if (!needsScaling) {
       // Direct output (no scaling)
       memset(rowBuffer.get(), 0, bytesPerRow);
 
-      if (USE_8BIT_OUTPUT && !oneBit) {
+      if (!preserveTransparency && USE_8BIT_OUTPUT && !oneBit) {
         for (int x = 0; x < outWidth; x++) {
           rowBuffer[x] = adjustPixel(grayRow[x]);
         }
@@ -787,18 +911,27 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
         if (atkinson1BitDitherer) atkinson1BitDitherer->nextRow();
       } else {
         for (int x = 0; x < outWidth; x++) {
+          const bool opaque = !preserveTransparency || opacityRow[x] != 0;
           const uint8_t gray = adjustPixel(grayRow[x]);
           uint8_t twoBit;
-          if (atkinsonDitherer) {
+          if (!opaque) {
+            twoBit = Bitmap::TRANSPARENT_PALETTE_INDEX;
+          } else if (atkinsonDitherer) {
             twoBit = atkinsonDitherer->processPixel(gray, x);
           } else if (fsDitherer) {
             twoBit = fsDitherer->processPixel(gray, x);
           } else {
             twoBit = quantize(gray, x, y);
           }
-          const int byteIndex = (x * 2) / 8;
-          const int bitOffset = 6 - ((x * 2) % 8);
-          rowBuffer[byteIndex] |= (twoBit << bitOffset);
+          if (preserveTransparency) {
+            const int byteIndex = x / 2;
+            const int bitOffset = (x & 1) ? 0 : 4;
+            rowBuffer[byteIndex] |= pngHelpers::overlayPaletteIndex(twoBit, opaque) << bitOffset;
+          } else {
+            const int byteIndex = (x * 2) / 8;
+            const int bitOffset = 6 - ((x * 2) % 8);
+            rowBuffer[byteIndex] |= twoBit << bitOffset;
+          }
         }
         if (atkinsonDitherer)
           atkinsonDitherer->nextRow();
@@ -815,18 +948,22 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
 
         int sum = 0;
         int count = 0;
+        uint32_t opaqueCount = 0;
         for (int srcX = srcXStart; srcX < srcXEnd && srcX < static_cast<int>(width); srcX++) {
           sum += grayRow[srcX];
           count++;
+          if (preserveTransparency) opaqueCount += opacityRow[srcX] != 0;
         }
 
         if (count == 0 && srcXStart < static_cast<int>(width)) {
           sum = grayRow[srcXStart];
           count = 1;
+          if (preserveTransparency) opaqueCount = opacityRow[srcXStart] != 0;
         }
 
         rowAccum[outX] += sum;
         rowCount[outX] += count;
+        if (preserveTransparency) rowOpaqueCount[outX] += opaqueCount;
       }
 
       // Check if we've crossed into the next output row(s)
@@ -837,7 +974,7 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
       while (srcY_fp >= nextOutY_srcStart && currentOutY < outHeight) {
         memset(rowBuffer.get(), 0, bytesPerRow);
 
-        if (USE_8BIT_OUTPUT && !oneBit) {
+        if (!preserveTransparency && USE_8BIT_OUTPUT && !oneBit) {
           for (int x = 0; x < outWidth; x++) {
             const uint8_t gray = (rowCount[x] > 0) ? (rowAccum[x] / rowCount[x]) : 0;
             rowBuffer[x] = adjustPixel(gray);
@@ -854,18 +991,27 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
           if (atkinson1BitDitherer) atkinson1BitDitherer->nextRow();
         } else {
           for (int x = 0; x < outWidth; x++) {
+            const bool opaque = !preserveTransparency || rowOpaqueCount[x] != 0;
             const uint8_t gray = adjustPixel((rowCount[x] > 0) ? (rowAccum[x] / rowCount[x]) : 0);
             uint8_t twoBit;
-            if (atkinsonDitherer) {
+            if (!opaque) {
+              twoBit = Bitmap::TRANSPARENT_PALETTE_INDEX;
+            } else if (atkinsonDitherer) {
               twoBit = atkinsonDitherer->processPixel(gray, x);
             } else if (fsDitherer) {
               twoBit = fsDitherer->processPixel(gray, x);
             } else {
               twoBit = quantize(gray, x, currentOutY);
             }
-            const int byteIndex = (x * 2) / 8;
-            const int bitOffset = 6 - ((x * 2) % 8);
-            rowBuffer[byteIndex] |= (twoBit << bitOffset);
+            if (preserveTransparency) {
+              const int byteIndex = x / 2;
+              const int bitOffset = (x & 1) ? 0 : 4;
+              rowBuffer[byteIndex] |= pngHelpers::overlayPaletteIndex(twoBit, opaque) << bitOffset;
+            } else {
+              const int byteIndex = (x * 2) / 8;
+              const int bitOffset = 6 - ((x * 2) % 8);
+              rowBuffer[byteIndex] |= twoBit << bitOffset;
+            }
           }
           if (atkinsonDitherer)
             atkinsonDitherer->nextRow();
@@ -888,6 +1034,7 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
         // Moving to next source row - reset accumulators
         memset(rowAccum.get(), 0, outWidth * sizeof(uint32_t));
         memset(rowCount.get(), 0, outWidth * sizeof(uint16_t));
+        if (preserveTransparency) memset(rowOpaqueCount.get(), 0, outWidth * sizeof(uint32_t));
       }
     }
 
@@ -910,7 +1057,8 @@ bool PngToBmpConverter::pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool
   return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop);
 }
 
-bool PngToBmpConverter::pngFileToBmpFile(const char* pngPath, const char* bmpPath, const bool crop) {
+bool PngToBmpConverter::pngFileToBmpFileInternal(const char* pngPath, const char* bmpPath, const bool crop,
+                                                 const bool preserveTransparency) {
   if (!pngPath || !bmpPath) return false;
   if (Storage.exists(bmpPath)) Storage.remove(bmpPath);
 
@@ -919,11 +1067,20 @@ bool PngToBmpConverter::pngFileToBmpFile(const char* pngPath, const char* bmpPat
     HalFile input;
     HalFile output;
     converted = Storage.openFileForRead("PNG", pngPath, input) && Storage.openFileForWrite("PNG", bmpPath, output) &&
-                pngFileToBmpStream(input, output, crop);
+                pngFileToBmpStreamInternal(input, output, display.getDisplayHeight(), display.getDisplayWidth(), false,
+                                           crop, preserveTransparency);
     if (converted) output.flush();
   }
   if (!converted && Storage.exists(bmpPath)) Storage.remove(bmpPath);
   return converted;
+}
+
+bool PngToBmpConverter::pngFileToBmpFile(const char* pngPath, const char* bmpPath, const bool crop) {
+  return pngFileToBmpFileInternal(pngPath, bmpPath, crop, false);
+}
+
+bool PngToBmpConverter::pngFileToTransparentBmpFile(const char* pngPath, const char* bmpPath, const bool crop) {
+  return pngFileToBmpFileInternal(pngPath, bmpPath, crop, true);
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth,

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -6,10 +6,12 @@ class Print;
 
 class PngToBmpConverter {
   static bool pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                         bool oneBit, bool crop = true);
+                                         bool oneBit, bool crop = true, bool preserveTransparency = false);
+  static bool pngFileToBmpFileInternal(const char* pngPath, const char* bmpPath, bool crop, bool preserveTransparency);
 
  public:
   static bool pngFileToBmpFile(const char* pngPath, const char* bmpPath, bool crop = true);
+  static bool pngFileToTransparentBmpFile(const char* pngPath, const char* bmpPath, bool crop = true);
   static bool pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop = true);
   static bool pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   static bool pngFileTo1BitBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -224,7 +224,7 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
 
   if (!preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
@@ -245,13 +245,13 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
     renderer.copyGrayscaleLsbBuffers();
 
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
     renderer.copyGrayscaleMsbBuffers();
 
     renderer.displayGrayBuffer();
@@ -271,6 +271,11 @@ void SleepActivity::renderTransparentSleepScreen() const {
   const auto error = bitmap.parseHeaders();
   if (error != BmpReaderError::Ok) {
     LOG_ERR("SLP", "Invalid transparent sleep image: %s", Bitmap::errorToString(error));
+    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+    return;
+  }
+  if (!bitmap.hasTransparency()) {
+    LOG_ERR("SLP", "Transparent sleep image has no alpha data; select the PNG again");
     renderer.displayBuffer(HalDisplay::HALF_REFRESH);
     return;
   }

--- a/src/activities/util/ImageViewerActivity.cpp
+++ b/src/activities/util/ImageViewerActivity.cpp
@@ -15,7 +15,11 @@
 
 namespace {
 constexpr const char* PNG_PREVIEW_PATH = "/.crosspoint/image_preview.bmp";
-}
+constexpr const char* TRANSPARENT_PREVIEW_PATH = "/.crosspoint/image_preview.transparent.bmp";
+constexpr const char* SLEEP_IMAGE_PATH = "/sleep.bmp";
+constexpr const char* SLEEP_IMAGE_PART_PATH = "/sleep.bmp.part";
+constexpr const char* SLEEP_IMAGE_BACKUP_PATH = "/sleep.bmp.bak";
+}  // namespace
 
 ImageViewerActivity::ImageViewerActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string path)
     : Activity("ImageViewer", renderer, mappedInput), filePath(std::move(path)) {}
@@ -153,6 +157,7 @@ void ImageViewerActivity::onEnter() {
 void ImageViewerActivity::onExit() {
   Activity::onExit();
   if (Storage.exists(PNG_PREVIEW_PATH)) Storage.remove(PNG_PREVIEW_PATH);
+  if (Storage.exists(TRANSPARENT_PREVIEW_PATH)) Storage.remove(TRANSPARENT_PREVIEW_PATH);
   renderer.clearScreen();
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
@@ -160,41 +165,80 @@ void ImageViewerActivity::onExit() {
 void ImageViewerActivity::doSetSleepCover(const char* sourcePath, const bool transparent) {
   GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
 
-  bool success = false;
-  {
+  const char* preparedPath = sourcePath;
+  bool success = true;
+  if (transparent) {
+    GfxRenderer::FrameBufferLoan loan(renderer);
+    success = PngToBmpConverter::pngFileToTransparentBmpFile(sourcePath, TRANSPARENT_PREVIEW_PATH, true);
+    if (success) preparedPath = TRANSPARENT_PREVIEW_PATH;
+  }
+
+  Storage.remove(SLEEP_IMAGE_PART_PATH);
+  if (success) {
     HalFile inFile, outFile;
-    if (Storage.openFileForRead("IMAGE", sourcePath, inFile) &&
-        Storage.openFileForWrite("IMAGE", "/sleep.bmp", outFile)) {
-      char buffer[2048];
+    if (Storage.openFileForRead("IMAGE", preparedPath, inFile) &&
+        Storage.openFileForWrite("IMAGE", SLEEP_IMAGE_PART_PATH, outFile)) {
+      const uint64_t expected = inFile.fileSize64();
+      uint64_t copied = 0;
+      char buffer[128];
       int bytesRead;
-      success = true;
       while ((bytesRead = inFile.read(buffer, sizeof(buffer))) > 0) {
         if (outFile.write(buffer, bytesRead) != bytesRead) {
           success = false;
           break;
         }
+        copied += bytesRead;
       }
       outFile.flush();
+      success = success && copied == expected;
+    } else {
+      success = false;
     }
   }
 
   if (success) {
-    SETTINGS.sleepScreen = transparent ? CrossPointSettings::SLEEP_SCREEN_MODE::TRANSPARENT
-                                       : CrossPointSettings::SLEEP_SCREEN_MODE::CUSTOM;
-    SETTINGS.saveToFile();
-    GUI.drawPopup(renderer, tr(STR_DONE));
-  } else {
-    GUI.drawPopup(renderer, tr(STR_FAILED_LOWER));
+    Storage.remove(SLEEP_IMAGE_BACKUP_PATH);
+    const bool hadPrevious = Storage.exists(SLEEP_IMAGE_PATH);
+    if ((hadPrevious && !Storage.rename(SLEEP_IMAGE_PATH, SLEEP_IMAGE_BACKUP_PATH)) ||
+        !Storage.rename(SLEEP_IMAGE_PART_PATH, SLEEP_IMAGE_PATH)) {
+      if (hadPrevious && !Storage.exists(SLEEP_IMAGE_PATH)) {
+        Storage.rename(SLEEP_IMAGE_BACKUP_PATH, SLEEP_IMAGE_PATH);
+      }
+      success = false;
+    }
   }
 
+  if (success) {
+    const uint8_t previousMode = SETTINGS.sleepScreen;
+    SETTINGS.sleepScreen = transparent ? CrossPointSettings::SLEEP_SCREEN_MODE::TRANSPARENT
+                                       : CrossPointSettings::SLEEP_SCREEN_MODE::CUSTOM;
+    if (!SETTINGS.saveToFile()) {
+      SETTINGS.sleepScreen = previousMode;
+      (void)SETTINGS.saveToFile();
+      Storage.remove(SLEEP_IMAGE_PATH);
+      if (Storage.exists(SLEEP_IMAGE_BACKUP_PATH)) {
+        Storage.rename(SLEEP_IMAGE_BACKUP_PATH, SLEEP_IMAGE_PATH);
+      }
+      success = false;
+    }
+  }
+
+  Storage.remove(SLEEP_IMAGE_PART_PATH);
+  if (success) Storage.remove(SLEEP_IMAGE_BACKUP_PATH);
+  GUI.drawPopup(renderer, success ? tr(STR_DONE) : tr(STR_FAILED_LOWER));
   delay(1000);
 }
 
 void ImageViewerActivity::showSleepCoverOptions() {
+  if (!isPng()) {
+    doSetSleepCover(filePath.c_str(), false);
+    return;
+  }
+
   static constexpr StrId options[] = {StrId::STR_NORMAL, StrId::STR_TRANSPARENT};
   static constexpr int optionCount = sizeof(options) / sizeof(options[0]);
   sleepCoverPopup.show(StrId::STR_SET_SLEEP_COVER, options, optionCount, 0, [this](const int index) {
-    doSetSleepCover(isPng() ? PNG_PREVIEW_PATH : filePath.c_str(), index == 1);
+    doSetSleepCover(index == 1 ? filePath.c_str() : PNG_PREVIEW_PATH, index == 1);
   });
   requestUpdate();
 }

--- a/test/png_conversion/PngConversionTest.cpp
+++ b/test/png_conversion/PngConversionTest.cpp
@@ -10,6 +10,22 @@ TEST(PngConversion, CompositesAlphaAgainstWhite) {
   EXPECT_EQ(pngHelpers::blendWithWhite(100, 128), 177);
 }
 
+TEST(PngConversion, KeepsOpaqueWhiteDistinctFromTransparency) {
+  EXPECT_FALSE(pngHelpers::isOverlayPixelOpaque(0));
+  EXPECT_TRUE(pngHelpers::isOverlayPixelOpaque(1));
+  EXPECT_TRUE(pngHelpers::isOverlayPixelOpaque(128));
+  EXPECT_TRUE(pngHelpers::isOverlayPixelOpaque(255));
+  EXPECT_TRUE(pngHelpers::isOverlayPixelOpaque(65535));
+
+  EXPECT_EQ(pngHelpers::overlayPaletteIndex(0, true), 0);
+  EXPECT_EQ(pngHelpers::overlayPaletteIndex(3, true), 3);
+  EXPECT_EQ(pngHelpers::overlayPaletteIndex(0, false), 4);
+  EXPECT_EQ(pngHelpers::overlayPaletteIndex(3, false), 4);
+
+  const uint8_t semiTransparentWhite = pngHelpers::blendWithWhite(255, 128);
+  EXPECT_EQ(pngHelpers::overlayPaletteIndex(semiTransparentWhite >> 6, true), 3);
+}
+
 TEST(PngConversion, AcceptsOnlyLegalColorTypeAndDepthCombinations) {
   for (const uint8_t depth : {1, 2, 4, 8, 16}) EXPECT_TRUE(pngHelpers::isSupportedFormat(0, depth));
   for (const uint8_t depth : {8, 16}) {


### PR DESCRIPTION
## Summary

- Fixes the transparent sleep-screen regression introduced by #181: opaque white and fully transparent pixels were both reduced to 2-bit white, so both exposed the previous screen.
- Generates a marked, versioned 4-bit internal BMP for transparent overlays. Palette indices 0-3 are opaque grayscale (including opaque white); index 4 is reserved for `alpha == 0`.
- Keeps every non-zero alpha pixel visible after compositing against white, while preserving ordinary BMP rendering behavior.
- Regenerates transparent sleep images from the original PNG and installs `/sleep.bmp` transactionally. Missing, corrupt, or legacy unmarked overlays leave the last screen intact and ask the user to select the PNG again.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a corrective follow-up to the already merged #181 and does not broaden its feature surface.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Validation

- 350/350 host tests passed.
- PlatformIO builds passed: `default`, `gh_release_cn`, `simulator`, and `simulator_x3`.
- Static DRAM remains within the existing budget; the new transparency data uses row-level buffers only, with no second framebuffer or persistent sidecar cache.

## Pending hardware validation

- X3/X4 four-level grayscale output and semi-transparent edges.
- Fit/Crop in all four orientations.
- Largest available heap block during PNG conversion and three-pass grayscale rendering.

Users upgrading from a test build of #181 must select the original PNG again because legacy `/sleep.bmp` files do not contain alpha information or the new format marker.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
