### PR TITLE
fix: keep synthetic bold font cache consistent

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -620,9 +620,16 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     return;
   }
 
+  const uint8_t activeSyntheticBoldPixels =
+      syntheticBoldPixels != 0 && (style & EpdFontFamily::BOLD) != 0 ? syntheticBoldPixels : 0;
+  const auto renderStyle =
+      activeSyntheticBoldPixels != 0
+          ? static_cast<EpdFontFamily::Style>(static_cast<uint8_t>(style) & ~static_cast<uint8_t>(EpdFontFamily::BOLD))
+          : style;
+
   // Route CJK-bearing strings to the fallback font when the requested font
   // lacks the glyphs (e.g. Chinese book titles drawn with a Latin UI font).
-  const int resolvedFontId = resolveTextFontId(fontId, text, style);
+  const int resolvedFontId = resolveTextFontId(fontId, text, renderStyle);
 
   std::string visual;
   const char* renderedText = resolveVisualText(text, visual, baseDir);
@@ -635,7 +642,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
-    fontCacheManager_->recordText(renderedText, resolvedFontId, style);
+    fontCacheManager_->recordText(renderedText, resolvedFontId, renderStyle);
     return;
   }
 
@@ -645,12 +652,6 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     return;
   }
   const auto& font = fontIt->second;
-  const uint8_t activeSyntheticBoldPixels =
-      syntheticBoldPixels != 0 && (style & EpdFontFamily::BOLD) != 0 ? syntheticBoldPixels : 0;
-  const auto renderStyle =
-      activeSyntheticBoldPixels != 0
-          ? static_cast<EpdFontFamily::Style>(static_cast<uint8_t>(style) & ~static_cast<uint8_t>(EpdFontFamily::BOLD))
-          : style;
 
   const char* textCursor = renderedText;
   uint32_t cp;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1832,7 +1832,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     if (includeBackground && SETTINGS.readingBackgroundEnabled && !readingBackground::load(renderer)) {
       renderer.clearScreen();
     }
-    page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop);
+    renderPage();
     if (!SETTINGS.readingGuideLineEnabled) return;
 
     const int x1 = orientedMarginLeft;


### PR DESCRIPTION
## Summary

- route every EPUB page redraw through the existing synthetic-bold scope
- resolve the effective render style before fallback font selection and font-cache scanning
- keep scan, prewarm, and rendering on the same Regular or Italic font face while preserving layout metrics

## Validation

- [x] clang-format check
- [x] 345/345 unit tests
- [x] default firmware build
- [x] gh_release_cn firmware build
- [x] device matrix: built-in and SD fonts; off, standard, and bold; antialiasing on and off
- [x] SD font with Regular and Bold faces prewarms and renders Regular or Italic when synthetic bold is enabled

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Additional Context

- Follow-up to #186.
- No new allocation, public API, cache-format, pixel-dilation, layout-metric, or UI behavior changes.
- Memory and flash impact: no intentional change; this only reorders existing style selection and reuses the existing page-render entry point.

---

### AI Usage

Did you use AI tools to help write this code? **YES**