### PR TITLE
fix: avoid reading stats crash on low heap

### DIFF
--- a/src/AchievementsStore.cpp
+++ b/src/AchievementsStore.cpp
@@ -451,7 +451,6 @@ void AchievementsStore::recordSessionEnded(const ReadingSessionSnapshot& snapsho
 
   markDirty();
   evaluateProgress(true);
-  saveToFile();
 }
 
 void AchievementsStore::recordBookmarkAdded() {

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -3,7 +3,9 @@
 #include <ArduinoJson.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 
+#include <cstring>
 #include <string>
 #include <utility>
 
@@ -17,23 +19,35 @@ namespace {
 // target so a power loss mid-write never corrupts the existing file. Streaming
 // keeps peak heap bounded for large analytics documents.
 bool saveJsonDocumentToFile(const char* moduleName, const char* path, const JsonDocument& doc) {
-  const std::string targetPath = path ? path : "";
-  const std::string tempPath = targetPath + ".tmp";
-
-  if (targetPath.empty()) {
+  if (!path || *path == '\0') {
     LOG_ERR(moduleName, "Missing JSON path for write");
     return false;
   }
+  if (doc.overflowed()) {
+    LOG_ERR(moduleName, "Insufficient heap for JSON document");
+    return false;
+  }
 
-  if (Storage.exists(tempPath.c_str())) {
-    Storage.remove(tempPath.c_str());
+  const size_t pathLength = strlen(path);
+  const size_t tempPathSize = pathLength + sizeof(".tmp");
+  // Export paths are variable-length, so use one fallible exact-size buffer instead of fixed stack storage.
+  auto tempPath = makeUniqueNoThrow<char[]>(tempPathSize);
+  if (!tempPath) {
+    LOG_ERR(moduleName, "OOM allocating JSON temp path (%zu bytes)", tempPathSize);
+    return false;
+  }
+  memcpy(tempPath.get(), path, pathLength);
+  memcpy(tempPath.get() + pathLength, ".tmp", sizeof(".tmp"));
+
+  if (Storage.exists(tempPath.get())) {
+    Storage.remove(tempPath.get());
   }
 
   size_t written = 0;
   {
     HalFile file;
-    if (!Storage.openFileForWrite(moduleName, tempPath.c_str(), file)) {
-      LOG_ERR(moduleName, "Could not open JSON file for write: %s", tempPath.c_str());
+    if (!Storage.openFileForWrite(moduleName, tempPath.get(), file)) {
+      LOG_ERR(moduleName, "Could not open JSON file for write: %s", tempPath.get());
       return false;
     }
 
@@ -41,20 +55,20 @@ bool saveJsonDocumentToFile(const char* moduleName, const char* path, const Json
     file.flush();
   }
   if (written == 0) {
-    Storage.remove(tempPath.c_str());
-    LOG_ERR(moduleName, "serializeJson wrote 0 bytes for %s", targetPath.c_str());
+    Storage.remove(tempPath.get());
+    LOG_ERR(moduleName, "serializeJson wrote 0 bytes for %s", path);
     return false;
   }
 
-  if (Storage.exists(targetPath.c_str()) && !Storage.remove(targetPath.c_str())) {
-    Storage.remove(tempPath.c_str());
-    LOG_ERR(moduleName, "Could not remove JSON file before replace: %s", targetPath.c_str());
+  if (Storage.exists(path) && !Storage.remove(path)) {
+    Storage.remove(tempPath.get());
+    LOG_ERR(moduleName, "Could not remove JSON file before replace: %s", path);
     return false;
   }
 
-  if (!Storage.rename(tempPath.c_str(), targetPath.c_str())) {
-    Storage.remove(tempPath.c_str());
-    LOG_ERR(moduleName, "Could not rename JSON temp file to final path: %s", targetPath.c_str());
+  if (!Storage.rename(tempPath.get(), path)) {
+    Storage.remove(tempPath.get());
+    LOG_ERR(moduleName, "Could not rename JSON temp file to final path: %s", path);
     return false;
   }
 

--- a/src/ReadingStatsStore.cpp
+++ b/src/ReadingStatsStore.cpp
@@ -19,7 +19,8 @@ namespace {
 constexpr char READING_STATS_FILE_JSON[] = "/.crosspoint/reading_stats.json";
 constexpr unsigned long MAX_READING_GAP_MS = 30UL * 60UL * 1000UL;
 constexpr unsigned long SESSION_HEARTBEAT_MS = 60UL * 1000UL;
-constexpr unsigned long DEFERRED_SAVE_INTERVAL_MS = 30UL * 1000UL;
+constexpr unsigned long CHECKPOINT_INTERVAL_MS = 10UL * 60UL * 1000UL;
+constexpr unsigned long CHECKPOINT_RETRY_INTERVAL_MS = 30UL * 1000UL;
 constexpr uint64_t MIN_SESSION_READING_MS = 3ULL * 60ULL * 1000ULL;
 constexpr size_t MAX_SESSION_LOG_ENTRIES = 256;
 
@@ -551,26 +552,29 @@ bool ReadingStatsStore::removeIgnoredBooks() {
 void ReadingStatsStore::invalidateSummaryCache() { summaryCache.valid = false; }
 
 void ReadingStatsStore::markDirty() {
+  if (!dirty) {
+    dirtySinceMs = millis();
+  }
   dirty = true;
   invalidateSummaryCache();
 }
 
-bool ReadingStatsStore::shouldSaveDeferred() const {
-  if (!dirty) {
+bool ReadingStatsStore::shouldSaveCheckpoint() const {
+  if (!dirty || !activeSession.active) {
     return false;
   }
-  if (!activeSession.active) {
-    return true;
-  }
-  return lastSaveMs == 0 || (millis() - lastSaveMs) >= DEFERRED_SAVE_INTERVAL_MS;
+  const unsigned long nowMs = millis();
+  return (nowMs - dirtySinceMs) >= CHECKPOINT_INTERVAL_MS &&
+         (lastSaveAttemptMs == 0 || (nowMs - lastSaveAttemptMs) >= CHECKPOINT_RETRY_INTERVAL_MS);
 }
 
 bool ReadingStatsStore::persistToFile(const char* path) const {
   Storage.mkdir("/.crosspoint");
+  lastSaveAttemptMs = millis();
   const bool saved = JsonSettingsIO::saveReadingStats(*this, path);
   if (saved) {
     dirty = false;
-    lastSaveMs = millis();
+    dirtySinceMs = 0;
   }
   return saved;
 }
@@ -702,9 +706,6 @@ void ReadingStatsStore::noteActivity() {
   }
 
   activeSession.lastInteractionMs = nowMs;
-  if (shouldSaveDeferred()) {
-    saveToFile();
-  }
 }
 
 void ReadingStatsStore::tickActiveSession() {
@@ -758,9 +759,6 @@ void ReadingStatsStore::updateProgress(const uint8_t progressPercent, const bool
   }
 
   markDirty();
-  if (shouldSaveDeferred()) {
-    saveToFile();
-  }
 }
 
 bool ReadingStatsStore::updateBookMetadata(const std::string& path, const std::string& title, const std::string& author,
@@ -791,7 +789,7 @@ bool ReadingStatsStore::updateBookMetadata(const std::string& path, const std::s
 
   if (changed) {
     markDirty();
-    if (shouldSaveDeferred()) {
+    if (!activeSession.active) {
       saveToFile();
     }
   }
@@ -927,7 +925,6 @@ void ReadingStatsStore::endSession() {
   lastSessionSnapshot.endProgressPercent = book.lastProgressPercent;
 
   activeSession = {};
-  saveToFile();
 }
 
 bool ReadingStatsStore::adjustBookReadingTime(const std::string& path, const uint32_t dayOrdinal,
@@ -1103,9 +1100,6 @@ bool ReadingStatsStore::saveToFile() const {
   if (!dirty && Storage.exists(READING_STATS_FILE_JSON)) {
     return true;
   }
-  if (activeSession.active && !shouldSaveDeferred()) {
-    return true;
-  }
   return persistToFile(READING_STATS_FILE_JSON);
 }
 
@@ -1145,7 +1139,8 @@ bool ReadingStatsStore::loadFromFile() {
       saveToFile();
     } else {
       dirty = false;
-      lastSaveMs = millis();
+      dirtySinceMs = 0;
+      lastSaveAttemptMs = millis();
     }
   }
   return loaded;
@@ -1178,7 +1173,8 @@ bool ReadingStatsStore::releaseMemoryForNetwork() {
   sessionSerialCounter = 0;
   invalidateSummaryCache();
   dirty = false;
-  lastSaveMs = millis();
+  dirtySinceMs = 0;
+  lastSaveAttemptMs = millis();
 
   LOG_DBG("RST", "After network release: free=%u largest=%u", ESP.getFreeHeap(),
           heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT));

--- a/src/ReadingStatsStore.h
+++ b/src/ReadingStatsStore.h
@@ -91,7 +91,8 @@ class ReadingStatsStore {
   uint32_t sessionSerialCounter = 0;
   mutable SummaryCache summaryCache;
   mutable bool dirty = false;
-  mutable unsigned long lastSaveMs = 0;
+  mutable unsigned long dirtySinceMs = 0;
+  mutable unsigned long lastSaveAttemptMs = 0;
 
   friend bool JsonSettingsIO::saveReadingStats(const ReadingStatsStore&, const char*);
   friend bool JsonSettingsIO::loadReadingStats(ReadingStatsStore&, const char*);
@@ -122,7 +123,6 @@ class ReadingStatsStore {
   bool removeIgnoredBooks();
   void invalidateSummaryCache();
   void rebuildSummaryCache() const;
-  bool shouldSaveDeferred() const;
   void markDirty();
   bool persistToFile(const char* path) const;
   static bool isClockValid(uint32_t epochSeconds);
@@ -172,6 +172,7 @@ class ReadingStatsStore {
   void reset();
   bool exportToFile(const std::string& path) const;
   bool importFromFile(const std::string& path);
+  bool shouldSaveCheckpoint() const;
   bool saveToFile() const;
   bool loadFromFile();
   bool releaseMemoryForNetwork();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@ FontDecompressor fontDecompressor;
 SdCardFontSystem sdFontSystem;
 FontCacheManager fontCacheManager(renderer.getFontMap(), renderer.getSdCardFonts());
 static unsigned long allowSleepAt = 0;
+constexpr unsigned long READING_STATS_CHECKPOINT_IDLE_MS = 15UL * 1000UL;
 
 // Fonts
 #ifdef ENABLE_CHINESE_VERSION
@@ -328,6 +329,13 @@ void enterDeepSleep(bool fromTimeout = false) {
   // a WiFi activity would otherwise silentRestart() here and reboot instead.
   deepSleepInProgress = true;
   activityManager.goToSleep(fromTimeout);
+
+  if (!READING_STATS.saveToFile()) {
+    LOG_ERR("RST", "Failed to save reading stats before deep sleep");
+  }
+  if (!ACHIEVEMENTS.saveToFile()) {
+    LOG_ERR("ACH", "Failed to save achievements before deep sleep");
+  }
 
   if (isQuickResumeSleep) {
     saveSleepFrameBuffer();
@@ -710,8 +718,26 @@ void loop() {
   }
 
   const unsigned long activityStartTime = millis();
+  const bool readerWasActive = activityManager.isReaderActivity();
   activityManager.loop();
+  const bool readerIsActive = activityManager.isReaderActivity();
   const unsigned long activityDuration = millis() - activityStartTime;
+
+  if (readerWasActive && !readerIsActive) {
+    if (!READING_STATS.saveToFile()) {
+      LOG_ERR("RST", "Failed to save reading stats after reader exit");
+    }
+    if (!ACHIEVEMENTS.saveToFile()) {
+      LOG_ERR("ACH", "Failed to save achievements after reader exit");
+    }
+  } else if (readerIsActive && (millis() - lastActivityTime) >= READING_STATS_CHECKPOINT_IDLE_MS &&
+             !activityManager.skipLoopDelay() && !activityManager.preventAutoSleep() &&
+             READING_STATS.shouldSaveCheckpoint()) {
+    RenderLock lock;
+    if (!READING_STATS.saveToFile()) {
+      LOG_ERR("RST", "Failed to save idle reading checkpoint");
+    }
+  }
 
   const unsigned long loopDuration = millis() - loopStartTime;
   if (loopDuration > maxLoopDuration) {


### PR DESCRIPTION
## Summary

- Reject missing paths and overflowed JSON documents before touching the existing reading-stats or achievements file.
- Replace throwing temporary-path string construction with one exact-size makeUniqueNoThrow buffer.
- Keep reader updates in memory and replace 30-second page-turn saves with a 10-minute checkpoint that waits for 15 seconds of physical-input idle, no background build, no automatic page turns, and exclusive RenderLock ownership.
- Finalize sessions and achievements in memory, then save both JSON files after the reader activity stack is destroyed or immediately before deep sleep.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not handle this low-contiguous-heap failure safely.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Verification

- git diff --check
- clang-format check
- 345/345 host unit tests
- PlatformIO cppcheck: no defects found
- default and gh_release_cn firmware builds
- Hardware replay remains for maintainer verification with the reported EPUB, SD font, and low-contiguous-heap setup. Verify no stats write before ten dirty minutes, checkpoint only after the safe idle window, and final stats plus achievements writes after reader exit or before sleep.

## Additional Context

The matching ELF backtrace ended in std::bad_alloc from temporary path construction after the statistics JsonDocument overflowed. Reader checkpoints now avoid concurrent renderer allocation and failed attempts remain dirty with a 30-second retry floor. The policy adds no heap allocation, task, setting, public data format, or cache format change; one fixed timestamp increases static DRAM by 8 bytes including alignment. EPUB image, CSS, ZIP/JPEG, and SD-font allocation fallbacks from the same log remain out of scope.

---

### AI Usage

Did you use AI tools to help write this code? **YES**