### PR TITLE
perf: speed up Inx tab switching

### DIFF
--- a/src/activities/apps/reading-stats/ReadingStatsActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsActivity.cpp
@@ -278,7 +278,7 @@ void ReadingStatsActivity::selectMainTabContentEdge(const MainTabContentEdge edg
 
 void ReadingStatsActivity::onEnter() {
   Activity::onEnter();
-  renderer.requestNextRefresh(HalDisplay::HALF_REFRESH);
+  if (!usesInxLayout()) renderer.requestNextRefresh(HalDisplay::HALF_REFRESH);
   selectedIndex = usesInxLayout() ? 0 : (READING_STATS.getBooks().empty() ? 0 : 1);
   waitForConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
   waitForBackRelease = false;
@@ -364,7 +364,7 @@ void ReadingStatsActivity::loop() {
     buttonNavigator.onPreviousRelease([moveSelection] { moveSelection(-1); });
     buttonNavigator.onNextContinuous([moveSelection] { moveSelection(1); });
     buttonNavigator.onPreviousContinuous([moveSelection] { moveSelection(-1); });
-    prepareVisibleCover();
+    if (showMainTabContentSelection()) prepareVisibleCover();
     return;
   }
 

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -196,10 +196,8 @@ void SettingsActivity::rebuildSettingsLists() {
   // reader activity ran — otherwise the font-family picker shows stale list.
   sdFontSystem.refreshIfDirty();
 
-  // Rescan /dictionaries on every rebuild: cheap (one directory listing) and
-  // picks up dictionaries copied to the SD card since the last visit.
   std::vector<DictionaryEntry> dictionaries;
-  DictionaryRegistry::discover(dictionaries);
+  if (dictionariesLoaded) DictionaryRegistry::discover(dictionaries);
 
   for (auto& setting : getSettingsList(&sdFontSystem.registry(), &dictionaries)) {
     if (setting.category == StrId::STR_NONE_OPT) continue;
@@ -294,6 +292,7 @@ void SettingsActivity::onEnter() {
       SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT;
   quickResumeTimeoutAutoEnabled = false;
   syncQuickResumeTimeoutForSleepScreen(/*sleepScreenChanged=*/true, /*quickResumeTimeoutChanged=*/false);
+  dictionariesLoaded = !usesAccordion();
 
   rebuildSettingsLists();
 
@@ -507,7 +506,13 @@ std::array<int, SettingsActivity::categoryCount> SettingsActivity::accordionSett
 
 void SettingsActivity::toggleAccordionCategory(const int categoryIndex) {
   if (categoryIndex < 0 || categoryIndex >= categoryCount) return;
-  expandedCategories ^= uint8_t{1} << categoryIndex;
+  constexpr int readerCategoryIndex = 1;
+  const uint8_t categoryMask = uint8_t{1} << categoryIndex;
+  if (categoryIndex == readerCategoryIndex && !dictionariesLoaded && (expandedCategories & categoryMask) == 0) {
+    dictionariesLoaded = true;
+    rebuildSettingsLists();
+  }
+  expandedCategories ^= categoryMask;
   accordionSelectedIndex =
       InxAccordionGeometry::categoryRow(accordionSettingCounts(), expandedCategories, categoryIndex);
   requestUpdate();

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -193,6 +193,7 @@ class SettingsActivity final : public Activity {
 
   bool preserveQuickResumeTimeoutOn = false;
   bool quickResumeTimeoutAutoEnabled = false;
+  bool dictionariesLoaded = false;
 
   OptionPopup optionPopup;
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Reduce the visible delay when switching main tabs with the Inx theme on X4 Chinese firmware.
* **What changes are included?**
  - Use fast refresh for the Inx statistics tab while preserving half refresh for other layouts.
  - Prepare statistics covers only while the content area is focused.
  - Defer dictionary discovery in the Inx settings accordion until the Reader category is first expanded; non-Inx layouts keep eager discovery.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well; X4 measurements showed the statistics transition was dominated by an avoidable half refresh.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Tested on X4 with `gh_release_cn`, Simplified Chinese, and the Inx theme.
* Statistics display time dropped from about 1816 ms to 506-507 ms.
* No extra refresh occurred while remaining on the statistics tab bar for 5.3 seconds.
* Dictionary selection was verified on device after lazy discovery.
* No material persistent RAM increase: the change adds one boolean state and no new heap-owned structure.
* Local validation passed for `simulator`, `simulator_x3`, formatting, cppcheck, `default`, `sticky`, all 358 host tests, and `gh_release_cn`.
* A network-enabled H2O `pr-ci` run passed. The subsequent disconnected run stopped before source compilation because the ESP-IDF component registry metadata was unavailable, so the final gate used the complete local CI run as agreed.

---

### AI Usage

Did you use AI tools to help write this code? **YES**