### PR TITLE
fix: stabilize resumable font downloads

### DIFF
--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -12,7 +12,7 @@ gates every CN-only resource:
 |---|---|
 | i18n string table (`gen_i18n.py`) | Pre-script auto-detects the flag via `env.subst("$BUILD_FLAGS")` and emits **only EN + ZH_CN** into `I18nStrings.cpp` (saves ~144 KB vs the full 23-language table). Detection logs `[gen_i18n] ENABLE_CHINESE_VERSION detected …` during the build. |
 | Built-in fonts ([lib/EpdFont/builtinFonts/all.h](../../lib/EpdFont/builtinFonts/all.h)) | Latin headers are skipped. The reader UI exposes one built-in **Noto Sans** because the legacy Serif/Sans IDs both reference the same six per-size CJK headers (`notosans_cjk_{8,10,12,14,16,18}.h`). The old IDs remain valid for settings compatibility. The headers use raw 2-bit bitmaps. **Character coverage is tiered by point size**: 8/10/12pt carry all 3500 chars from `chars_3500_common.txt` plus every CJK glyph found in `chinese.yaml` and feature-specific require-from files (3517 CJK glyphs total); 14/16/18pt carry only the require-from set (747 CJK glyphs). Every size also includes the standard ASCII, Latin-1, and CJK punctuation ranges. The 14/16/18pt sizes rely on a complete SD-card font for broad Chinese EPUB coverage while still rendering every built-in Chinese UI string. |
-| Downloadable fonts | The Chinese build uses the same manifest-v1 font manager as global builds; only its catalog URL points to an externally maintained Gitee release. Its embedded 8/10/12pt fonts already cover the Simplified-Chinese UI, so it keeps only the selected reader-size SD font resident and does not load the global build's three size-matched UI fallbacks. This preserves contiguous heap for EPUB image decoding and glyph prewarm. |
+| Downloadable fonts | The Chinese build uses the same manifest-v1 font manager as global builds. Current firmware reads the catalog through the CrossMux API and downloads immutable files from `assets.crossmux.cn`; old firmware reads the Gitee manifest, which points to the same asset domain. Its embedded 8/10/12pt fonts already cover the Simplified-Chinese UI, so it keeps only the selected reader-size SD font resident and does not load the global build's three size-matched UI fallbacks. This preserves contiguous heap for EPUB image decoding and glyph prewarm. |
 | `src/main.cpp` font globals | Each Latin `EpdFont`/`EpdFontFamily` global is aliased to the matching-size CJK header. Bold/italic variants all point at the Regular OTF (no style data in the subset). SD-card fonts still provide style variants when the user loads them. |
 | EPUB layout ([lib/Epub/Epub/ParsedText.cpp](../../lib/Epub/Epub/ParsedText.cpp)) | All firmware flavors use the same Unicode-aware CJK splitting, punctuation, line-breaking, and source-space rules. The CN build changes the bundled font data and metrics, not tokenization or inter-word spacing behavior. |
 | Activities (`src/activities/apps/chinese-chess/`) | Compiled in (also gated by `build_src_filter +<activities/apps/chinese-chess/>`). |
@@ -229,18 +229,25 @@ measured rather than inferred from the source character count.
 
 ## Complete Chinese SD fonts
 
-The Chinese build downloads its catalog from:
+Current Chinese firmware downloads its catalog from:
 
 ```text
-https://gitee.com/x1abin/crossmux-fonts/releases/download/sd-fonts-m<manifest>-b<binary>/fonts.json
+https://crossmux.cn/api/assets/fonts/m<manifest>-b<binary>/fonts.json
 ```
 
+The API returns the canonical COS manifest, whose `baseUrl` uses an immutable
+Git SHA under `https://assets.crossmux.cn/fonts/m1-b4/releases/`. Older Chinese
+firmware continues to read the Gitee release manifest; releases are kept in
+sync with the canonical manifest, so those devices also download font files
+from `assets.crossmux.cn`. The CrossMux per-file API keeps its fixed Gitee
+proxy behavior only as a compatibility and rollback path. Global firmware
+continues to use the corresponding GitHub manifest and files.
+
 The version numbers come from the firmware's manifest and cpfont constants.
-The external Gitee service must keep manifest v1 and all referenced cpfont v4
-assets under that tag. `baseUrl`, family/file names, non-zero file sizes, and
-CRC32 values must be valid; the external catalog maintainer is responsible for
-complete Chinese coverage. Global firmware continues to use the corresponding
-GitHub service.
+All catalogs must keep manifest v1 and referenced cpfont v4 assets consistent.
+`baseUrl`, family/file names, non-zero file sizes, and CRC32 values must be
+valid; the external catalog maintainer is responsible for complete Chinese
+coverage.
 
 The firmware offers the guided downloader when a built-in font is changed to
 14/16/18pt, or when an EPUB scan sees a missing U+4E00–U+9FFF or

--- a/docs/sd-card-fonts.md
+++ b/docs/sd-card-fonts.md
@@ -124,16 +124,20 @@ What this means in practice:
 The current list of pre-built fonts is maintained in the
 [crosspoint-fonts repository](https://github.com/crosspoint-reader/crosspoint-fonts).
 
-Chinese firmware builds use an externally maintained Gitee catalog; global
-builds keep using the GitHub catalog. Both use the release tag
-`sd-fonts-m<manifest>-b<binary>`, matching the manifest and cpfont versions
-compiled into the firmware.
+Current Chinese firmware loads its manifest through the CrossMux API, and the
+manifest points immutable font files at `assets.crossmux.cn`. Older Chinese
+firmware still loads the Gitee release manifest; that manifest points to the
+same assets domain, so those devices do not follow Gitee redirects for each
+font file. Global builds continue to use the GitHub manifest and assets.
 
-The external Chinese catalog must publish manifest v1 with a valid `baseUrl`,
-family/file names, non-zero file sizes, and CRC32 values. Every referenced
-asset must be cpfont v4 and provide the complete Chinese coverage promised by
-the catalog maintainer. Font sources and catalog-generation configuration are
-not kept in this repository.
+The CrossMux `/api/assets/fonts/m1-b4/<file>.cpfont` Gitee proxy remains a
+compatibility and rollback path. It is not the canonical file source.
+
+The Chinese and global catalogs both publish manifest v1 with a valid
+`baseUrl`, family/file names, non-zero file sizes, and CRC32 values. Every
+referenced asset must be cpfont v4 and provide the coverage promised by its
+catalog maintainer. Font sources and catalog-generation configuration are not
+kept in this repository.
 
 The incomplete-font prompt opens the same font manager described above. A
 successful single or batch download selects a default and opens the font

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -369,6 +369,82 @@ bool FontDownloadActivity::computeFileCrc32(const char* path, uint32_t& outCrc) 
   return true;
 }
 
+FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const ManifestFamily& family,
+                                                                        const ManifestFile& file) {
+  {
+    RenderLock lock(*this);
+    fileProgress_ = 0;
+    fileTotal_ = file.size;
+  }
+  requestUpdateAndWait();
+
+  char destPath[128];
+  FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));
+  char downloadPath[136];
+  snprintf(downloadPath, sizeof(downloadPath), "%s.part", destPath);
+
+  uint32_t lastProgressRefreshAt = millis();
+  const auto result = HttpDownloader::downloadToFile(
+      baseUrl_ + file.name, downloadPath,
+      [this, &lastProgressRefreshAt](size_t downloaded, size_t total) {
+        fileProgress_ = downloaded;
+        fileTotal_ = total;
+        mappedInput.update();
+        if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
+            mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+          cancelRequested_ = true;
+        }
+        const uint32_t now = millis();
+        if (now - lastProgressRefreshAt >= kProgressRefreshIntervalMs) {
+          lastProgressRefreshAt = now;
+          requestUpdate(true);
+        }
+      },
+      &cancelRequested_);
+  if (result == HttpDownloader::ABORTED) return DownloadResult::Cancelled;
+  if (result != HttpDownloader::OK) {
+    LOG_ERR("FONT", "Download failed: %s (%d)", file.name.c_str(), result);
+    errorMessage_ = "Download failed: " + file.name;
+    return DownloadResult::Failed;
+  }
+
+  uint32_t actualCrc = 0;
+  if (!computeFileCrc32(downloadPath, actualCrc)) {
+    LOG_ERR("FONT", "Failed to open file for CRC check: %s", downloadPath);
+    Storage.remove(downloadPath);
+    errorMessage_ = "Failed to compute checksum: " + file.name;
+    return DownloadResult::Failed;
+  }
+  if (actualCrc != file.crc32) {
+    LOG_ERR("FONT", "CRC32 mismatch for %s: got %08x expected %08x", file.name.c_str(), actualCrc, file.crc32);
+    Storage.remove(downloadPath);
+    errorMessage_ = "Checksum mismatch: " + file.name;
+    return DownloadResult::Failed;
+  }
+  LOG_DBG("FONT", "Downloaded %s (size=%zu crc32=%08x)", file.name.c_str(), file.size, actualCrc);
+
+  if (!fontInstaller_.validateCpfontFile(downloadPath)) {
+    LOG_ERR("FONT", "Invalid .cpfont: %s", downloadPath);
+    Storage.remove(downloadPath);
+    errorMessage_ = "Invalid font file: " + file.name;
+    return DownloadResult::Failed;
+  }
+
+  char backupPath[136];
+  snprintf(backupPath, sizeof(backupPath), "%s.bak", destPath);
+  Storage.remove(backupPath);
+  const bool hadPrevious = Storage.exists(destPath);
+  if ((hadPrevious && !Storage.rename(destPath, backupPath)) || !Storage.rename(downloadPath, destPath)) {
+    if (hadPrevious && !Storage.exists(destPath)) Storage.rename(backupPath, destPath);
+    Storage.remove(downloadPath);
+    errorMessage_ = "Failed to install font file: " + file.name;
+    return DownloadResult::Failed;
+  }
+  if (hadPrevious) Storage.remove(backupPath);
+  currentFileIndex_++;
+  return DownloadResult::Success;
+}
+
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(ManifestFamily& family) {
   NetworkStartup::prepare(renderer);
   const bool wasInstalled = family.installed;
@@ -394,107 +470,15 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(Manife
     return DownloadResult::Failed;
   }
 
-  for (size_t i = 0; i < family.files.size(); i++) {
-    const auto& file = family.files[i];
+  for (const auto& file : family.files) {
+    const auto result = downloadFile(family, file);
+    if (result == DownloadResult::Success) continue;
 
-    {
-      RenderLock lock(*this);
-      fileProgress_ = 0;
-      fileTotal_ = file.size;
-    }
-    requestUpdateAndWait();
-
-    char destPath[128];
-    FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));
-    char downloadPath[136];
-    snprintf(downloadPath, sizeof(downloadPath), "%s.part", destPath);
-
-    std::string url = baseUrl_ + file.name;
-    uint32_t lastProgressRefreshAt = millis();
-
-    auto result = HttpDownloader::downloadToFile(
-        url, downloadPath,
-        [this, &lastProgressRefreshAt](size_t downloaded, size_t total) {
-          fileProgress_ = downloaded;
-          fileTotal_ = total;
-          mappedInput.update();
-          if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-              mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-            cancelRequested_ = true;
-          }
-          const uint32_t now = millis();
-          if (now - lastProgressRefreshAt >= kProgressRefreshIntervalMs) {
-            lastProgressRefreshAt = now;
-            requestUpdate(true);
-          }
-        },
-        &cancelRequested_);
-
-    if (result == HttpDownloader::ABORTED) {
-      discardIncompleteFamily();
-      {
-        RenderLock lock(*this);
-        state_ = FAMILY_LIST;
-      }
-      operation_ = DownloadOperation::None;
-      return DownloadResult::Cancelled;
-    }
-
-    if (result != HttpDownloader::OK) {
-      LOG_ERR("FONT", "Download failed: %s (%d)", file.name.c_str(), result);
-      discardIncompleteFamily();
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Download failed: " + file.name;
-      return DownloadResult::Failed;
-    }
-
-    uint32_t actualCrc = 0;
-    if (!computeFileCrc32(downloadPath, actualCrc)) {
-      LOG_ERR("FONT", "Failed to open file for CRC check: %s", downloadPath);
-      Storage.remove(downloadPath);
-      discardIncompleteFamily();
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Failed to compute checksum: " + file.name;
-      return DownloadResult::Failed;
-    }
-    if (actualCrc != file.crc32) {
-      LOG_ERR("FONT", "CRC32 mismatch for %s: got %08x expected %08x", file.name.c_str(), actualCrc, file.crc32);
-      Storage.remove(downloadPath);
-      discardIncompleteFamily();
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Checksum mismatch: " + file.name;
-      return DownloadResult::Failed;
-    }
-    LOG_DBG("FONT", "Downloaded %s (size=%zu crc32=%08x)", file.name.c_str(), file.size, actualCrc);
-
-    if (!fontInstaller_.validateCpfontFile(downloadPath)) {
-      LOG_ERR("FONT", "Invalid .cpfont: %s", downloadPath);
-      Storage.remove(downloadPath);
-      discardIncompleteFamily();
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Invalid font file: " + file.name;
-      return DownloadResult::Failed;
-    }
-
-    char backupPath[136];
-    snprintf(backupPath, sizeof(backupPath), "%s.bak", destPath);
-    Storage.remove(backupPath);
-    const bool hadPrevious = Storage.exists(destPath);
-    if ((hadPrevious && !Storage.rename(destPath, backupPath)) || !Storage.rename(downloadPath, destPath)) {
-      if (hadPrevious && !Storage.exists(destPath)) Storage.rename(backupPath, destPath);
-      Storage.remove(downloadPath);
-      discardIncompleteFamily();
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Failed to install font file: " + file.name;
-      return DownloadResult::Failed;
-    }
-    if (hadPrevious) Storage.remove(backupPath);
-    currentFileIndex_++;
+    discardIncompleteFamily();
+    if (result == DownloadResult::Cancelled) operation_ = DownloadOperation::None;
+    RenderLock lock(*this);
+    state_ = result == DownloadResult::Cancelled ? FAMILY_LIST : ERROR;
+    return result;
   }
 
   fontInstaller_.refreshRegistry();

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -416,10 +416,18 @@ bool FontDownloadActivity::computeFileCrc32(const char* path, uint32_t& outCrc) 
   return true;
 }
 
+bool FontDownloadActivity::isVerifiedFontFile(const char* path, const ManifestFile& file) {
+  {
+    HalFile existing;
+    if (!Storage.openFileForRead("FONT", path, existing) || existing.size() != file.size) return false;
+  }
+
+  uint32_t actualCrc = 0;
+  return fontInstaller_.validateCpfontFile(path) && computeFileCrc32(path, actualCrc) && actualCrc == file.crc32;
+}
+
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const ManifestFamily& family,
                                                                         const ManifestFile& file) {
-  requestUpdateAndWait();
-
   char fileName[128];
   const int fileNameLength =
       snprintf(fileName, sizeof(fileName), "%s_%u.cpfont", family.name.c_str(), static_cast<unsigned>(file.pointSize));
@@ -431,6 +439,15 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
   FontInstaller::buildFontPath(family.name.c_str(), fileName, destPath, sizeof(destPath));
   char downloadPath[136];
   snprintf(downloadPath, sizeof(downloadPath), "%s.part", destPath);
+
+  if (isVerifiedFontFile(destPath, file)) {
+    Storage.remove(downloadPath);
+    LOG_INF("FONT", "Skipping verified file: %s", fileName);
+    currentFileIndex_++;
+    return DownloadResult::Success;
+  }
+
+  requestUpdateAndWait();
 
   std::string url = baseUrl_ + fileName;
   std::string destination = downloadPath;
@@ -490,10 +507,10 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
 
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(ManifestFamily& family) {
   const bool wasInstalled = family.installed;
-  auto discardIncompleteFamily = [this, &family, wasInstalled] {
-    if (!wasInstalled) fontInstaller_.deleteFamily(family.name.c_str());
+  const bool hadUpdate = family.hasUpdate;
+  auto restoreFamilyState = [&family, wasInstalled, hadUpdate] {
     family.installed = wasInstalled;
-    family.hasUpdate = wasInstalled;
+    family.hasUpdate = hadUpdate;
   };
   {
     RenderLock lock(*this);
@@ -513,7 +530,7 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(Manife
     const auto result = downloadFile(family, files_[family.fileOffset + i]);
     if (result == DownloadResult::Success) continue;
 
-    discardIncompleteFamily();
+    restoreFamilyState();
     if (result == DownloadResult::Cancelled) operation_ = DownloadOperation::None;
     RenderLock lock(*this);
     state_ = result == DownloadResult::Cancelled ? FAMILY_LIST : ERROR;

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -32,7 +32,6 @@
 
 namespace {
 
-constexpr uint32_t kProgressRefreshIntervalMs = 2000;
 constexpr size_t kMaxManifestBytes = 64 * 1024;
 constexpr size_t kMaxManifestFamilies = 32;
 constexpr size_t kMaxManifestFiles = 128;
@@ -146,6 +145,7 @@ void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
     state_ = LOADING_MANIFEST;
   }
   requestUpdateAndWait();
+  NetworkStartup::prepare(renderer);
 
   if (!fetchAndParseManifest()) {
     {
@@ -418,11 +418,6 @@ bool FontDownloadActivity::computeFileCrc32(const char* path, uint32_t& outCrc) 
 
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const ManifestFamily& family,
                                                                         const ManifestFile& file) {
-  {
-    RenderLock lock(*this);
-    fileProgress_ = 0;
-    fileTotal_ = file.size;
-  }
   requestUpdateAndWait();
 
   char fileName[128];
@@ -437,24 +432,18 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
   char downloadPath[136];
   snprintf(downloadPath, sizeof(downloadPath), "%s.part", destPath);
 
-  uint32_t lastProgressRefreshAt = millis();
-  const auto result = HttpDownloader::downloadToFile(
-      baseUrl_ + fileName, downloadPath,
-      [this, &lastProgressRefreshAt](size_t downloaded, size_t total) {
-        fileProgress_ = downloaded;
-        fileTotal_ = total;
-        mappedInput.update();
-        if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-            mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-          cancelRequested_ = true;
-        }
-        const uint32_t now = millis();
-        if (now - lastProgressRefreshAt >= kProgressRefreshIntervalMs) {
-          lastProgressRefreshAt = now;
-          requestUpdate(true);
-        }
-      },
-      &cancelRequested_);
+  std::string url = baseUrl_ + fileName;
+  std::string destination = downloadPath;
+  HttpDownloader::ProgressCallback progress = [this](size_t, size_t) {
+    mappedInput.update();
+    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
+        mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      cancelRequested_ = true;
+    }
+  };
+
+  NetworkStartup::prepare(renderer);
+  const auto result = HttpDownloader::downloadToFile(url, destination, std::move(progress), &cancelRequested_);
   if (result == HttpDownloader::ABORTED) return DownloadResult::Cancelled;
   if (result != HttpDownloader::OK) {
     LOG_ERR("FONT", "Download failed: %s (%d)", fileName, result);
@@ -500,7 +489,6 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
 }
 
 FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(ManifestFamily& family) {
-  NetworkStartup::prepare(renderer);
   const bool wasInstalled = family.installed;
   auto discardIncompleteFamily = [this, &family, wasInstalled] {
     if (!wasInstalled) fontInstaller_.deleteFamily(family.name.c_str());
@@ -511,11 +499,8 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(Manife
     RenderLock lock(*this);
     state_ = DOWNLOADING;
     downloadingFamilyIndex_ = static_cast<int>(&family - families_.data());
-    fileProgress_ = 0;
-    fileTotal_ = 0;
     cancelRequested_ = false;
   }
-  requestUpdateAndWait();
 
   if (!fontInstaller_.ensureFamilyDir(family.name.c_str())) {
     RenderLock lock(*this);
@@ -881,10 +866,8 @@ void FontDownloadActivity::render(RenderLock&&) {
 
     std::string statusText = std::string(tr(STR_DOWNLOADING)) + " " + family.name + " (" +
                              std::to_string(currentFileIndex_ + 1) + "/" + std::to_string(currentFileTotal_) + ")";
-    float progress = 0;
-    if (fileTotal_ > 0) {
-      progress = static_cast<float>(fileProgress_) / static_cast<float>(fileTotal_);
-    }
+    const float progress =
+        currentFileTotal_ == 0 ? 0 : static_cast<float>(currentFileIndex_) / static_cast<float>(currentFileTotal_);
 
     const int statusLines = renderer.getTextWidth(UI_10_FONT_ID, statusText.c_str()) <= textBounds.width ? 1 : 2;
     const int statusHeight = lineHeight * statusLines;

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -14,6 +14,7 @@
 #include <esp_rom_crc.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 
 #include "CrossPointSettings.h"
@@ -32,6 +33,35 @@
 namespace {
 
 constexpr uint32_t kProgressRefreshIntervalMs = 2000;
+constexpr size_t kMaxManifestBytes = 64 * 1024;
+constexpr size_t kMaxManifestFamilies = 32;
+constexpr size_t kMaxManifestFiles = 128;
+constexpr size_t kMaxFilesPerFamily = 16;
+constexpr size_t kMaxFamilyNameBytes = 64;
+constexpr size_t kMaxDescriptionBytes = 160;
+constexpr size_t kMaxBaseUrlBytes = 256;
+constexpr size_t kMaxFontFileBytes = 25 * 1024 * 1024;
+
+bool parseManifestPointSize(const char* familyName, const char* fileName, uint8_t& pointSize) {
+  const size_t familyLength = strlen(familyName);
+  const size_t fileNameLength = strlen(fileName);
+  if (fileNameLength <= familyLength + 1) return false;
+  if (strncmp(fileName, familyName, familyLength) != 0 || fileName[familyLength] != '_') return false;
+
+  const char* cursor = fileName + familyLength + 1;
+  if (*cursor < '1' || *cursor > '9') return false;
+
+  uint16_t value = 0;
+  while (std::isdigit(static_cast<unsigned char>(*cursor))) {
+    value = static_cast<uint16_t>(value * 10 + (*cursor - '0'));
+    if (value > UINT8_MAX) return false;
+    ++cursor;
+  }
+  if (strcmp(cursor, ".cpfont") != 0) return false;
+
+  pointSize = static_cast<uint8_t>(value);
+  return true;
+}
 
 #ifdef ENABLE_CHINESE_VERSION
 std::atomic<bool> chineseFontPromptShownThisBoot{false};
@@ -139,6 +169,8 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   // TLS buffers and the full JSON string in RAM simultaneously.
   static constexpr const char* MANIFEST_TMP = "/fonts_manifest.tmp";
   families_.clear();
+  files_.clear();
+  baseUrl_.clear();
   downloadingFamilyIndex_ = -1;
 
   auto result = HttpDownloader::downloadToFile(FONT_MANIFEST_URL, MANIFEST_TMP, nullptr);
@@ -149,21 +181,23 @@ bool FontDownloadActivity::fetchAndParseManifest() {
     return false;
   }
 
-  // HTTP client is now closed — TLS buffers freed. Parse JSON from file.
-  HalFile manifestFile;
-  if (!Storage.openFileForRead("FONT", MANIFEST_TMP, manifestFile)) {
-    LOG_ERR("FONT", "Failed to open temp manifest");
-    Storage.remove(MANIFEST_TMP);
-    errorMessage_ = "Failed to read font list";
-    return false;
-  }
-
   JsonDocument doc;
-  DeserializationError err = deserializeJson(doc, manifestFile);
-  manifestFile.close();
+  DeserializationError err;
+  bool manifestTooLarge = false;
+  {
+    HalFile manifestFile;
+    if (!Storage.openFileForRead("FONT", MANIFEST_TMP, manifestFile)) {
+      LOG_ERR("FONT", "Failed to open temp manifest");
+      Storage.remove(MANIFEST_TMP);
+      errorMessage_ = "Failed to read font list";
+      return false;
+    }
+    manifestTooLarge = manifestFile.fileSize() > kMaxManifestBytes;
+    if (!manifestTooLarge) err = deserializeJson(doc, manifestFile);
+  }
   Storage.remove(MANIFEST_TMP);
 
-  if (err) {
+  if (manifestTooLarge || err) {
     LOG_ERR("FONT", "Manifest parse error: %s", err.c_str());
     errorMessage_ = "Invalid font manifest";
     return false;
@@ -177,80 +211,93 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   }
 
   baseUrl_ = doc["baseUrl"] | "";
-  if (baseUrl_.empty()) {
-    LOG_ERR("FONT", "Manifest has no baseUrl");
+  if (baseUrl_.empty() || baseUrl_.size() > kMaxBaseUrlBytes || baseUrl_.rfind("https://", 0) != 0 ||
+      baseUrl_.back() != '/') {
+    LOG_ERR("FONT", "Manifest has invalid baseUrl");
     errorMessage_ = "Invalid font manifest";
     return false;
   }
   fontInstaller_.refreshRegistry();
 
   JsonArray familiesArr = doc["families"].as<JsonArray>();
+  if (familiesArr.isNull() || familiesArr.size() == 0 || familiesArr.size() > kMaxManifestFamilies) {
+    LOG_ERR("FONT", "Manifest has invalid family count: %zu", familiesArr.size());
+    errorMessage_ = "Invalid font manifest";
+    return false;
+  }
+
+  size_t fileCount = 0;
+  for (JsonObject familyObject : familiesArr) {
+    const JsonArray familyFiles = familyObject["files"].as<JsonArray>();
+    if (familyFiles.isNull() || familyFiles.size() == 0 || familyFiles.size() > kMaxFilesPerFamily ||
+        familyFiles.size() > kMaxManifestFiles - fileCount) {
+      LOG_ERR("FONT", "Manifest has invalid file count");
+      errorMessage_ = "Invalid font manifest";
+      return false;
+    }
+    fileCount += familyFiles.size();
+  }
+
   families_.reserve(familiesArr.size());
+  files_.reserve(fileCount);
 
   for (JsonObject fObj : familiesArr) {
     ManifestFamily family;
     family.name = fObj["name"] | "";
     family.description = fObj["description"] | "";
-    if (!FontInstaller::isValidFamilyName(family.name.c_str())) {
+    const bool duplicateFamily = std::any_of(families_.begin(), families_.end(),
+                                             [&family](const auto& existing) { return existing.name == family.name; });
+    if (!FontInstaller::isValidFamilyName(family.name.c_str()) || family.name.size() > kMaxFamilyNameBytes ||
+        family.description.empty() || family.description.size() > kMaxDescriptionBytes || duplicateFamily) {
       LOG_ERR("FONT", "Malformed manifest family name: %s", family.name.c_str());
       families_.clear();
+      files_.clear();
       errorMessage_ = "Invalid font manifest";
       return false;
     }
 
-    const JsonArray stylesArr = fObj["styles"].as<JsonArray>();
-    family.styles.reserve(stylesArr.size());
-    for (JsonVariant s : stylesArr) {
-      family.styles.push_back(s.as<std::string>());
-    }
-
-    family.totalSize = 0;
     const JsonArray filesArr = fObj["files"].as<JsonArray>();
-    if (filesArr.isNull() || filesArr.size() == 0) {
-      LOG_ERR("FONT", "Manifest family has no files: %s", family.name.c_str());
-      families_.clear();
-      errorMessage_ = "Invalid font manifest";
-      return false;
-    }
-    family.files.reserve(filesArr.size());
+    family.fileOffset = files_.size();
+    family.fileCount = filesArr.size();
+    family.installed = fontInstaller_.isFamilyInstalled(family.name.c_str());
     for (JsonObject fileObj : filesArr) {
       ManifestFile file;
-      file.name = fileObj["name"] | "";
+      const char* fileName = fileObj["name"] | "";
       file.size = fileObj["size"] | 0;
 
-      if (!FontInstaller::isValidCpfontFilename(file.name.c_str()) || file.size == 0 ||
-          !fileObj["crc32"].is<uint32_t>()) {
-        LOG_ERR("FONT", "Malformed manifest file entry: %s", file.name.c_str());
+      if (!FontInstaller::isValidCpfontFilename(fileName) ||
+          !parseManifestPointSize(family.name.c_str(), fileName, file.pointSize) || file.size == 0 ||
+          file.size >= kMaxFontFileBytes || !fileObj["crc32"].is<uint32_t>()) {
+        LOG_ERR("FONT", "Malformed manifest file entry: %s", fileName);
         families_.clear();
+        files_.clear();
+        errorMessage_ = "Invalid font manifest";
+        return false;
+      }
+      const bool duplicatePointSize =
+          std::any_of(files_.begin() + static_cast<ptrdiff_t>(family.fileOffset), files_.end(),
+                      [&file](const auto& existing) { return existing.pointSize == file.pointSize; });
+      if (duplicatePointSize) {
+        LOG_ERR("FONT", "Duplicate manifest point size: %s", fileName);
+        families_.clear();
+        files_.clear();
         errorMessage_ = "Invalid font manifest";
         return false;
       }
       file.crc32 = fileObj["crc32"].as<uint32_t>();
 
       family.totalSize += file.size;
-      family.files.push_back(std::move(file));
-    }
+      files_.push_back(file);
 
-    family.installed = fontInstaller_.isFamilyInstalled(family.name.c_str());
-
-    // Detect updates by comparing manifest file sizes with files on disk.
-    // Not a checksum, but a size mismatch reliably indicates a rebuild in practice.
-    if (family.installed) {
-      for (const auto& file : family.files) {
+      // Detect updates by comparing manifest file sizes with files on disk.
+      if (family.installed && !family.hasUpdate) {
         char path[128];
-        FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), path, sizeof(path));
+        FontInstaller::buildFontPath(family.name.c_str(), fileName, path, sizeof(path));
         HalFile f;
         if (Storage.openFileForRead("FONT", path, f)) {
-          size_t actual = f.fileSize();
-          f.close();
-          if (actual != file.size) {
-            family.hasUpdate = true;
-            break;
-          }
+          if (f.fileSize() != file.size) family.hasUpdate = true;
         } else {
-          // File missing on disk but family dir exists — treat as update
           family.hasUpdate = true;
-          break;
         }
       }
     }
@@ -378,14 +425,21 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
   }
   requestUpdateAndWait();
 
+  char fileName[128];
+  const int fileNameLength =
+      snprintf(fileName, sizeof(fileName), "%s_%u.cpfont", family.name.c_str(), static_cast<unsigned>(file.pointSize));
+  if (fileNameLength < 0 || static_cast<size_t>(fileNameLength) >= sizeof(fileName)) {
+    errorMessage_ = "Invalid font filename";
+    return DownloadResult::Failed;
+  }
   char destPath[128];
-  FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));
+  FontInstaller::buildFontPath(family.name.c_str(), fileName, destPath, sizeof(destPath));
   char downloadPath[136];
   snprintf(downloadPath, sizeof(downloadPath), "%s.part", destPath);
 
   uint32_t lastProgressRefreshAt = millis();
   const auto result = HttpDownloader::downloadToFile(
-      baseUrl_ + file.name, downloadPath,
+      baseUrl_ + fileName, downloadPath,
       [this, &lastProgressRefreshAt](size_t downloaded, size_t total) {
         fileProgress_ = downloaded;
         fileTotal_ = total;
@@ -403,8 +457,8 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
       &cancelRequested_);
   if (result == HttpDownloader::ABORTED) return DownloadResult::Cancelled;
   if (result != HttpDownloader::OK) {
-    LOG_ERR("FONT", "Download failed: %s (%d)", file.name.c_str(), result);
-    errorMessage_ = "Download failed: " + file.name;
+    LOG_ERR("FONT", "Download failed: %s (%d)", fileName, result);
+    errorMessage_ = std::string("Download failed: ") + fileName;
     return DownloadResult::Failed;
   }
 
@@ -412,21 +466,21 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
   if (!computeFileCrc32(downloadPath, actualCrc)) {
     LOG_ERR("FONT", "Failed to open file for CRC check: %s", downloadPath);
     Storage.remove(downloadPath);
-    errorMessage_ = "Failed to compute checksum: " + file.name;
+    errorMessage_ = std::string("Failed to compute checksum: ") + fileName;
     return DownloadResult::Failed;
   }
   if (actualCrc != file.crc32) {
-    LOG_ERR("FONT", "CRC32 mismatch for %s: got %08x expected %08x", file.name.c_str(), actualCrc, file.crc32);
+    LOG_ERR("FONT", "CRC32 mismatch for %s: got %08x expected %08x", fileName, actualCrc, file.crc32);
     Storage.remove(downloadPath);
-    errorMessage_ = "Checksum mismatch: " + file.name;
+    errorMessage_ = std::string("Checksum mismatch: ") + fileName;
     return DownloadResult::Failed;
   }
-  LOG_DBG("FONT", "Downloaded %s (size=%zu crc32=%08x)", file.name.c_str(), file.size, actualCrc);
+  LOG_DBG("FONT", "Downloaded %s (size=%zu crc32=%08x)", fileName, file.size, actualCrc);
 
   if (!fontInstaller_.validateCpfontFile(downloadPath)) {
     LOG_ERR("FONT", "Invalid .cpfont: %s", downloadPath);
     Storage.remove(downloadPath);
-    errorMessage_ = "Invalid font file: " + file.name;
+    errorMessage_ = std::string("Invalid font file: ") + fileName;
     return DownloadResult::Failed;
   }
 
@@ -437,7 +491,7 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
   if ((hadPrevious && !Storage.rename(destPath, backupPath)) || !Storage.rename(downloadPath, destPath)) {
     if (hadPrevious && !Storage.exists(destPath)) Storage.rename(backupPath, destPath);
     Storage.remove(downloadPath);
-    errorMessage_ = "Failed to install font file: " + file.name;
+    errorMessage_ = std::string("Failed to install font file: ") + fileName;
     return DownloadResult::Failed;
   }
   if (hadPrevious) Storage.remove(backupPath);
@@ -470,8 +524,8 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFamily(Manife
     return DownloadResult::Failed;
   }
 
-  for (const auto& file : family.files) {
-    const auto result = downloadFile(family, file);
+  for (size_t i = 0; i < family.fileCount; ++i) {
+    const auto result = downloadFile(family, files_[family.fileOffset + i]);
     if (result == DownloadResult::Success) continue;
 
     discardIncompleteFamily();
@@ -529,19 +583,19 @@ void FontDownloadActivity::retryDownloadOperation() {
   switch (operation_) {
     case DownloadOperation::Single:
       if (downloadingFamilyIndex_ >= 0 && downloadingFamilyIndex_ < static_cast<int>(families_.size())) {
-        currentFileTotal_ = families_[downloadingFamilyIndex_].files.size();
+        currentFileTotal_ = families_[downloadingFamilyIndex_].fileCount;
       }
       downloadSingle(downloadingFamilyIndex_);
       return;
     case DownloadOperation::DownloadAll:
       for (const auto& family : families_) {
-        if (!family.installed) currentFileTotal_ += family.files.size();
+        if (!family.installed) currentFileTotal_ += family.fileCount;
       }
       downloadAll();
       return;
     case DownloadOperation::UpdateAll:
       for (const auto& family : families_) {
-        if (family.hasUpdate) currentFileTotal_ += family.files.size();
+        if (family.hasUpdate) currentFileTotal_ += family.fileCount;
       }
       updateAll();
       return;
@@ -620,7 +674,7 @@ void FontDownloadActivity::loop() {
         currentFileIndex_ = 0;
         currentFileTotal_ = 0;
         for (const auto& f : families_) {
-          if (!f.installed) currentFileTotal_ += f.files.size();
+          if (!f.installed) currentFileTotal_ += f.fileCount;
         }
         downloadAll();
       } else if (isUpdateAllRow(selectedIndex_)) {
@@ -630,7 +684,7 @@ void FontDownloadActivity::loop() {
         currentFileIndex_ = 0;
         currentFileTotal_ = 0;
         for (const auto& f : families_) {
-          if (f.hasUpdate) currentFileTotal_ += f.files.size();
+          if (f.hasUpdate) currentFileTotal_ += f.fileCount;
         }
         updateAll();
       } else {
@@ -640,7 +694,7 @@ void FontDownloadActivity::loop() {
           selectionUpdated_ = false;
           accelerationCompleted_ = false;
           currentFileIndex_ = 0;
-          currentFileTotal_ = family.files.size();
+          currentFileTotal_ = family.fileCount;
           downloadSingle(familyIndexFromList(selectedIndex_));
         } else {
           promptDeleteSelectedFamily();

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -70,16 +70,16 @@ class FontDownloadActivity : public Activity {
   enum class DownloadResult : uint8_t { Success, Cancelled, Failed };
 
   struct ManifestFile {
-    std::string name;
     size_t size = 0;
     uint32_t crc32 = 0;
+    uint8_t pointSize = 0;
   };
 
   struct ManifestFamily {
     std::string name;
     std::string description;
-    std::vector<std::string> styles;
-    std::vector<ManifestFile> files;
+    size_t fileOffset = 0;
+    size_t fileCount = 0;
     size_t totalSize = 0;
     bool installed = false;
     bool hasUpdate = false;
@@ -93,6 +93,7 @@ class FontDownloadActivity : public Activity {
   // Manifest data
   std::string baseUrl_;
   std::vector<ManifestFamily> families_;
+  std::vector<ManifestFile> files_;
   int selectedIndex_ = 0;
 
   // Download progress

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -111,6 +111,7 @@ class FontDownloadActivity : public Activity {
   void startWifiSelection();
   void onWifiSelectionComplete(bool success);
   bool fetchAndParseManifest();
+  DownloadResult downloadFile(const ManifestFamily& family, const ManifestFile& file);
   DownloadResult downloadFamily(ManifestFamily& family);
   void downloadSingle(int familyIndex);
   void downloadAll();

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -15,14 +15,13 @@
 #define FONTS_MANIFEST_VERSION 1
 
 #ifndef FONT_MANIFEST_URL
-// Global assets are published by .github/workflows/release-fonts.yml; Chinese
-// assets use the separately managed Gitee service. Both use the
-// "sd-fonts-m<META>-b<BIN>" tag derived from cpfont_version.py.
+// Global assets are published by .github/workflows/release-fonts.yml. Chinese
+// assets use the CrossMux API so the device avoids Gitee's redirect chain.
 #define FONT_MANIFEST_URL_STRINGIFY_INNER(x) #x
 #define FONT_MANIFEST_URL_STRINGIFY(x) FONT_MANIFEST_URL_STRINGIFY_INNER(x)
 #ifdef ENABLE_CHINESE_VERSION
-#define FONT_MANIFEST_URL                                                                             \
-  "https://gitee.com/x1abin/crossmux-fonts/releases/download/sd-fonts-m" FONT_MANIFEST_URL_STRINGIFY( \
+#define FONT_MANIFEST_URL                                                     \
+  "https://" CROSSMUX_HOST "/api/assets/fonts/m" FONT_MANIFEST_URL_STRINGIFY( \
       FONTS_MANIFEST_VERSION) "-b" FONT_MANIFEST_URL_STRINGIFY(CPFONT_VERSION) "/fonts.json"
 #else
 #define FONT_MANIFEST_URL                                                                                           \
@@ -99,8 +98,6 @@ class FontDownloadActivity : public Activity {
   // Download progress
   size_t currentFileIndex_ = 0;
   size_t currentFileTotal_ = 0;
-  size_t fileProgress_ = 0;
-  size_t fileTotal_ = 0;
   int downloadingFamilyIndex_ = -1;
   std::string errorMessage_;
   bool cancelRequested_ = false;

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -117,6 +117,7 @@ class FontDownloadActivity : public Activity {
   void retryDownloadOperation();
   void selectDownloadedFontAndPreview(const char* familyName);
   static bool computeFileCrc32(const char* path, uint32_t& outCrc);
+  bool isVerifiedFontFile(const char* path, const ManifestFile& file);
   bool showDownloadAllRow() const;
   bool showUpdateAllRow() const;
   int specialRowCount() const;


### PR DESCRIPTION
## Summary

- isolate single-file font transfer, validation, and atomic replacement
- bound manifest heap usage with fixed family/file limits and a flat POD file table
- render before network cleanup and keep TLS callbacks free of display work
- resume a family download by skipping files that pass size, cpfont magic, and CRC32 checks
- document Chinese COS delivery and the legacy Gitee compatibility path

## Validation

- `./bin/clang-format-fix`
- `git diff --check`
- `pio check`
- `pio run -e default -e gh_release_cn`

No production assets are changed or published by this PR.
