### PR TITLE
feat: connect Wi-Fi when entering AirPage

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -114,12 +114,14 @@ void AirPageActivity::onEnter() {
   legacyDownloadUrl_ += deviceId;
   legacyDownloadUrl_ += "/latest.bmp";
 
-  applyConnectionEvent(connection_.begin(airpage::loadRealtimeMode()));
+  const auto connectionEvent = connection_.begin(airpage::loadRealtimeMode());
+  applyConnectionEvent(connectionEvent);
   LOG_DBG("AIRP", "onEnter activity=%u free=%u largest=%u id=%s cached=%d realtime=%d",
           static_cast<unsigned>(sizeof(*this)), static_cast<unsigned>(ESP.getFreeHeap()),
           static_cast<unsigned>(ESP.getMaxAllocHeap()), deviceId.c_str(), imageStore_.hasImage() ? 1 : 0,
           connection_.realtime() ? 1 : 0);
   requestUpdate();
+  if (connectionEvent == airpage::AirPageConnection::Event::WifiRequired) openWifiSelection(false);
 }
 
 void AirPageActivity::onExit() {


### PR DESCRIPTION
## Summary

* Make AirPage proactively start the existing Wi-Fi connection flow when entered offline.
* Reuse WifiSelectionActivity auto-connect behavior; already-connected sessions are unchanged.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This only corrects entry behavior for the existing AirPage activity; it adds no new app or network surface.
- [x] This PR does not touch freeink-sdk, lib/hal, the bootloader, OTA, or recovery code.

## Verification

- [x] ./bin/ci-check
  - clang-format check passed
  - cppcheck passed with no defects
  - default ESP32-C3 firmware build passed
  - sticky ESP32-S3 firmware build passed
  - 358 host tests passed

## Additional Context

* No new setting, dependency, persistent state, or heap allocation.
* The existing fallible WifiSelectionActivity allocation and result/release-barrier path are reused.
* Static DRAM usage reported by the default build is unchanged.

---

### AI Usage

Did you use AI tools to help write this code? **YES**