### PR TITLE
fix: recover from EPUB layout OOM

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -613,11 +613,11 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
   return 0;
 }
 // Consumes data to minimize memory usage
-void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
+bool ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
                                        const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
-    return;
+    return true;
   }
 
   // Per-paragraph RTL auto-detection: only when CSS/HTML didn't explicitly set direction.
@@ -657,19 +657,29 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   const int pageWidth = viewportWidth;
   auto wordWidths = calculateWordWidths(renderer, fontId);
 
-  std::vector<size_t> lineBreakIndices;
+  std::vector<size_t> hyphenatedLineBreaks;
+  std::unique_ptr<LineBreakState[]> lineBreakWorkspace;
+  size_t lineBreakCount = 0;
   if (hyphenationEnabled) {
     // Use greedy layout that can split words mid-loop when a hyphenated prefix fits.
-    lineBreakIndices =
+    hyphenatedLineBreaks =
         computeHyphenatedLineBreaks(renderer, fontId, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore);
+    lineBreakCount = hyphenatedLineBreaks.size();
   } else {
-    lineBreakIndices = computeLineBreaks(renderer, fontId, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore);
+    if (!computeLineBreaks(renderer, fontId, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore,
+                           lineBreakWorkspace, lineBreakCount)) {
+      return false;
+    }
   }
-  const size_t lineCount = includeLastLine ? lineBreakIndices.size() : lineBreakIndices.size() - 1;
+  const size_t lineCount = includeLastLine ? lineBreakCount : (lineBreakCount > 0 ? lineBreakCount - 1 : 0);
+
+  const auto breakAt = [&](const size_t index) {
+    return hyphenationEnabled ? hyphenatedLineBreaks[index] : lineBreakWorkspace[index].breakIndex;
+  };
 
   for (size_t i = 0; i < lineCount; ++i) {
-    extractLine(i, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore, lineBreakIndices, processLine, renderer,
-                fontId);
+    extractLine(i, breakAt(i), i > 0 ? breakAt(i - 1) : 0, lineBreakCount, pageWidth, wordWidths, wordContinues,
+                wordNoSpaceBefore, processLine, renderer, fontId);
   }
 
   if (lineCount > 0) {
@@ -678,7 +688,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
 
   // Remove consumed words so size() reflects only remaining words
   if (lineCount > 0) {
-    const size_t consumed = lineBreakIndices[lineCount - 1];
+    const size_t consumed = breakAt(lineCount - 1);
     words.erase(words.begin(), words.begin() + consumed);
     wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
@@ -690,6 +700,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
       rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + rtConsumed);
     }
   }
+  return true;
 }
 
 static inline bool isCjkIdeograph(uint32_t cp) {
@@ -872,11 +883,13 @@ std::vector<uint16_t> ParsedText::calculateWordWidths(const GfxRenderer& rendere
   return wordWidths;
 }
 
-std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, const int fontId, const int pageWidth,
-                                                  std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
-                                                  std::vector<bool>& noSpaceBeforeVec) {
+bool ParsedText::computeLineBreaks(const GfxRenderer& renderer, const int fontId, const int pageWidth,
+                                   std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
+                                   std::vector<bool>& noSpaceBeforeVec, std::unique_ptr<LineBreakState[]>& workspace,
+                                   size_t& lineBreakCount) {
   if (words.empty()) {
-    return {};
+    lineBreakCount = 0;
+    return true;
   }
 
   const int firstLineIndent = resolveFirstLineIndent(true, renderer, fontId);
@@ -894,18 +907,25 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
 
   const size_t totalWordCount = words.size();
 
-  // DP table to store the minimum badness (cost) of lines starting at index i
-  std::vector<int> dp(totalWordCount);
-  // 'ans[i]' stores the index 'j' of the *last word* in the optimal line starting at 'i'
-  std::vector<size_t> ans(totalWordCount);
+  // One fallible allocation holds both the DP cost and chosen break for every
+  // word. At the parser's 750-word soft limit this is 6 KB on ESP32, too large
+  // for the render-task stack and short-lived enough to release after layout.
+  workspace = makeUniqueNoThrow<LineBreakState[]>(totalWordCount);
+  if (!workspace) {
+    LOG_ERR("PTX", "OOM: line-break workspace (%u words, %u bytes, free=%u, maxAlloc=%u)",
+            static_cast<unsigned>(totalWordCount), static_cast<unsigned>(totalWordCount * sizeof(LineBreakState)),
+            static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    lineBreakCount = 0;
+    return false;
+  }
 
   // Base Case
-  dp[totalWordCount - 1] = 0;
-  ans[totalWordCount - 1] = totalWordCount - 1;
+  workspace[totalWordCount - 1].cost = 0;
+  workspace[totalWordCount - 1].breakIndex = totalWordCount - 1;
 
   for (int i = totalWordCount - 2; i >= 0; --i) {
     int currlen = 0;
-    dp[i] = MAX_COST;
+    workspace[i].cost = MAX_COST;
 
     // First line has reduced width due to text-indent
     const int effectivePageWidth = i == 0 ? pageWidth - firstLineIndent : pageWidth;
@@ -949,7 +969,7 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
       } else {
         const int remainingSpace = effectivePageWidth - currlen;
         // Use long long for the square to prevent overflow
-        const long long cost_ll = static_cast<long long>(remainingSpace) * remainingSpace + dp[j + 1];
+        const long long cost_ll = static_cast<long long>(remainingSpace) * remainingSpace + workspace[j + 1].cost;
 
         if (cost_ll > MAX_COST) {
           cost = MAX_COST;
@@ -960,31 +980,32 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
 
       // Favor longer lines when line-breaking costs are equal, to avoid unnecessary short lines in Chinese and Japanese
       // text.
-      if (cost <= dp[i]) {
-        dp[i] = cost;
-        ans[i] = j;  // j is the index of the last word in this optimal line
+      if (cost <= workspace[i].cost) {
+        workspace[i].cost = cost;
+        workspace[i].breakIndex = j;  // j is the index of the last word in this optimal line
       }
     }
 
     // Handle oversized word: if no valid configuration found, force single-word line
     // This prevents cascade failure where one oversized word breaks all preceding words
-    if (dp[i] == MAX_COST) {
-      ans[i] = i;  // Just this word on its own line
+    if (workspace[i].cost == MAX_COST) {
+      workspace[i].breakIndex = i;  // Just this word on its own line
       // Inherit cost from next word to allow subsequent words to find valid configurations
       if (i + 1 < static_cast<int>(totalWordCount)) {
-        dp[i] = dp[i + 1];
+        workspace[i].cost = workspace[i + 1].cost;
       } else {
-        dp[i] = 0;
+        workspace[i].cost = 0;
       }
     }
   }
 
-  // Stores the index of the word that starts the next line (last_word_index + 1)
-  std::vector<size_t> lineBreakIndices;
+  // Compact the chosen breaks into the front of the same workspace. The write
+  // index never overtakes currentWordIndex, so no unread DP entry is replaced.
+  lineBreakCount = 0;
   size_t currentWordIndex = 0;
 
   while (currentWordIndex < totalWordCount) {
-    size_t nextBreakIndex = ans[currentWordIndex] + 1;
+    size_t nextBreakIndex = workspace[currentWordIndex].breakIndex + 1;
 
     // Safety check: prevent infinite loop if nextBreakIndex doesn't advance
     if (nextBreakIndex <= currentWordIndex) {
@@ -992,11 +1013,11 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
       nextBreakIndex = currentWordIndex + 1;
     }
 
-    lineBreakIndices.push_back(nextBreakIndex);
+    workspace[lineBreakCount++].breakIndex = nextBreakIndex;
     currentWordIndex = nextBreakIndex;
   }
 
-  return lineBreakIndices;
+  return true;
 }
 
 // Builds break indices while opportunistically splitting the word that would overflow the current line.
@@ -1177,17 +1198,15 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   return true;
 }
 
-void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
+void ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, const size_t lastBreakAt,
+                             const size_t lineCount, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
-                             const std::vector<size_t>& lineBreakIndices,
                              const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
-  const size_t lineBreak = lineBreakIndices[breakIndex];
-  const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
   const uint32_t lineVisibleOffset = visibleOffsetAt(lastBreakAt);
 
-  const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0, renderer, fontId);
+  const int firstLineIndent = resolveFirstLineIndent(lineIndex == 0, renderer, fontId);
 
   std::vector<std::string> lineRubyTexts(lineWordCount);
   if (!rubyTexts.empty() && lastBreakAt < rubyTexts.size()) {
@@ -1243,7 +1262,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   // Calculate spacing (account for indent reducing effective page width on first line)
   const int effectivePageWidth = pageWidth - firstLineIndent;
-  const bool isLastLine = breakIndex == lineBreakIndices.size() - 1;
+  const bool isLastLine = lineIndex == lineCount - 1;
 
   // For RTL, implicit/default Left alignment becomes Right alignment.
   // Explicit text-align:left must remain left for CSS correctness.

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -14,6 +14,11 @@
 class GfxRenderer;
 
 class ParsedText {
+  struct LineBreakState {
+    int cost;
+    size_t breakIndex;
+  };
+
   // Long CJK paragraphs can exceed 512 short tokens. A vector<string> growth
   // from 512 to 1024 needs one 24 KB contiguous block while retaining the old
   // 12 KB block; deque keeps the same indexed interface without that peak.
@@ -58,17 +63,17 @@ class ParsedText {
   int calculateRubyExtraEndOffset(size_t lineStartIdx, size_t lineBreakIdx, const GfxRenderer& renderer,
                                   int fontId) const;
   int resolveFirstLineIndent(bool isFirstLine, const GfxRenderer& renderer, int fontId) const;
-  std::vector<size_t> computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
-                                        std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
-                                        std::vector<bool>& noSpaceBeforeVec);
+  bool computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth, std::vector<uint16_t>& wordWidths,
+                         std::vector<bool>& continuesVec, std::vector<bool>& noSpaceBeforeVec,
+                         std::unique_ptr<LineBreakState[]>& workspace, size_t& lineBreakCount);
   std::vector<size_t> computeHyphenatedLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
                                                   std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
                                                   std::vector<bool>& noSpaceBeforeVec);
   bool hyphenateWordAtIndex(size_t wordIndex, int availableWidth, const GfxRenderer& renderer, int fontId,
                             std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks);
-  void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
-                   const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
-                   const std::vector<size_t>& lineBreakIndices,
+  void extractLine(size_t lineIndex, size_t lineBreak, size_t lastBreakAt, size_t lineCount, int pageWidth,
+                   const std::vector<uint16_t>& wordWidths, const std::vector<bool>& continuesVec,
+                   const std::vector<bool>& noSpaceBeforeVec,
                    const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                    const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
@@ -98,7 +103,7 @@ class ParsedText {
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
-  void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
+  bool layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
                              const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -610,7 +610,11 @@ bool Section::commitBuildFile(const uint8_t version, const uint32_t bytesConsume
 
 bool Section::finalizeBuild() {
   // Flush the trailing page (emits the last page via the completePageFn into the LUT).
-  build_->parser->finishParse();
+  if (!build_->parser->finishParse()) {
+    LOG_ERR("SCT", "Failed to finish section parse");
+    abandonBuild();
+    return false;
+  }
 
   if (!build_->reusedHtml) {
     // Parse succeeded: promote the freshly unzipped HTML to the persistent cache so future

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1315,12 +1315,14 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
                                         ? static_cast<uint16_t>(self->viewportWidth - horizontalInset)
                                         : self->viewportWidth;
-    self->currentTextBlock->layoutAndExtractLines(
-        self->renderer, self->fontId, effectiveWidth,
-        [self](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
-          self->addLineToPage(std::move(textBlock), offset);
-        },
-        false);
+    if (!self->currentTextBlock->layoutAndExtractLines(
+            self->renderer, self->fontId, effectiveWidth,
+            [self](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
+              self->addLineToPage(std::move(textBlock), offset);
+            },
+            false)) {
+      self->allocationFailed_ = true;
+    }
   }
 }
 
@@ -1716,10 +1718,13 @@ void ChapterHtmlSlimParser::makePages() {
   const uint16_t effectiveWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
 
-  currentTextBlock->layoutAndExtractLines(renderer, fontId, effectiveWidth,
-                                          [this](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
-                                            addLineToPage(std::move(textBlock), offset);
-                                          });
+  if (!currentTextBlock->layoutAndExtractLines(renderer, fontId, effectiveWidth,
+                                               [this](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
+                                                 addLineToPage(std::move(textBlock), offset);
+                                               })) {
+    allocationFailed_ = true;
+    return;
+  }
   if (allocationFailed_) return;
 
   // Fallback: transfer any remaining pending footnotes to current page.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -523,8 +523,9 @@ void EpubReaderActivity::loop() {
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
         LOG_ERR("ERS", "Background section build failed");
-        section.reset();
-        requestUpdate();
+        automaticPageTurnActive = false;
+        renderer.clearScreen();
+        GUI.drawPopup(renderer, tr(STR_INDEX_FAILED));
       } else if (section->isBuildComplete() && applyDeferredReposition()) {
         // The chapter re-paginated since the saved progress (settings changed): we now know the
         // real page count, so re-render at the remapped page. No-op for an unchanged resume.
@@ -1323,6 +1324,12 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
   const auto buildSomeMoreWithScratch = [this](const int maxPages) {
+    if (!buildTickHeapGate()) {
+      LOG_ERR("ERS", "Insufficient heap for synchronous section build (free=%u, maxAlloc=%u)",
+              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+      section->abandonBuild();
+      return false;
+    }
     GfxRenderer::FrameBufferLoan loan(renderer);
     return section->buildSomeMore(maxPages);
   };

--- a/src/activities/settings/TextSettingsPreview.cpp
+++ b/src/activities/settings/TextSettingsPreview.cpp
@@ -61,10 +61,12 @@ void relayout(PreviewLayout& layout, const GfxRenderer& renderer, int fontId, in
     }
   }
 
-  parsed.layoutAndExtractLines(renderer, fontId, static_cast<uint16_t>(textWidth),
-                               [&layout, maxLines](std::unique_ptr<TextBlock> line, uint32_t) {
-                                 if (layout.lines.size() < maxLines) layout.lines.push_back(std::move(line));
-                               });
+  if (!parsed.layoutAndExtractLines(renderer, fontId, static_cast<uint16_t>(textWidth),
+                                    [&layout, maxLines](std::unique_ptr<TextBlock> line, uint32_t) {
+                                      if (layout.lines.size() < maxLines) layout.lines.push_back(std::move(line));
+                                    })) {
+    layout.lines.clear();
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- replace the ordinary EPUB line-breaking DP vectors with one bounded, fallible workspace
- propagate layout allocation failure through chapter parsing and section finalization so incomplete pagination is abandoned
- reuse the existing heap gate for synchronous chapter builds and show the existing index-failed UI instead of retrying or aborting

## Memory behavior
At the parser's 750-word soft limit, the line-break workspace uses about 6 KB on ESP32. It is allocated with `makeUniqueNoThrow`, logged with free/max-alloc heap values on failure, and released after layout. This removes the confirmed throwing `std::vector<int>` allocation path without adding persistent state, dependencies, or cache-format changes.

## Validation
- `./bin/clang-format-fix -g --check`
- `git diff --cached --check`
- native test build and 358/358 tests passed
- `pio run`
- `pio run -e gh_release_cn`

Hardware low-memory stress testing remains to be performed with the original EPUB.