### PR TITLE
fix: preserve AirPage image while updating

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -578,6 +578,12 @@ void AirPageActivity::render(RenderLock&&) {
     return;
   }
 
+  if (screen_ == Screen::Image && (phase_ == Phase::FetchRequested || phase_ == Phase::Fetching)) {
+    renderer.setRenderMode(GfxRenderer::BW);
+    GUI.drawPopup(renderer, tr(STR_UPDATING));
+    return;
+  }
+
   if (screen_ == Screen::Image && phase_ == Phase::Idle) {
     const bool screenSizeChanged =
         displayedScreenWidth_ != fullScreen.width || displayedScreenHeight_ != fullScreen.height;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Keep the current AirPage image visible while a pushed update downloads.
* **What changes are included?** During `FetchRequested`/`Fetching` on the image screen, draw the existing localized `STR_UPDATING` popup over the retained framebuffer instead of showing the clearing `STR_AIRPAGE_LOADING` page.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not currently handle this update transition well; this fixes the existing AirPage behavior.
- [x] Not applicable: this PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Reuses the retained framebuffer and existing `STR_UPDATING` translation; no new public API, type, translation key, file format, or heap allocation.
* Verified with `git diff --check`, `./bin/ci-check` (formatting, cppcheck, default/sticky firmware builds, and 359 host tests), `pio run`, and `pio run -e gh_release_cn`.
* X3/X4 hardware verification for a flash-free overlay refresh is still pending.

---

### AI Usage

Did you use AI tools to help write this code? **YES**