### PR TITLE
fix: restore PR200 UI regressions

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -625,7 +625,7 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
 
   if (!preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
@@ -646,13 +646,13 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
     renderer.copyGrayscaleLsbBuffers();
 
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, preserveBackground);
     renderer.copyGrayscaleMsbBuffers();
 
     renderer.displayGrayBuffer();
@@ -673,8 +673,6 @@ bool SleepActivity::renderSleepOverlayFile(HalFile& file, const char* pathForLog
   }
 
   LOG_DBG("SLP", "Rendering regular BMP sleep overlay: %s (%dx%d)", pathForLog, bitmap.getWidth(), bitmap.getHeight());
-  // drawBitmap leaves white pixels untouched; skipping the initial clear makes
-  // them transparent while retaining the existing grayscale pipeline.
   renderBitmapSleepScreen(bitmap, true);
   return true;
 }
@@ -732,6 +730,17 @@ bool SleepActivity::renderSleepOverlayPath(const std::string& path) const {
 }
 
 void SleepActivity::renderTransparentCustomSleepScreen() const {
+  {
+    HalFile legacyFile;
+    if (Storage.openFileForRead("SLP", "/sleep.bmp", legacyFile)) {
+      Bitmap legacyBitmap(legacyFile);
+      if (legacyBitmap.parseHeaders() == BmpReaderError::Ok && legacyBitmap.hasTransparency()) {
+        renderBitmapSleepScreen(legacyBitmap, true);
+        return;
+      }
+    }
+  }
+
   if (renderSleepOverlayPath(TRANSPARENT_SLEEP_ROOT_BMP)) return;
   if (renderSleepOverlayPath(TRANSPARENT_SLEEP_ROOT_PNG)) return;
 

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -835,11 +835,11 @@ void WifiSelectionActivity::render(RenderLock&&) {
   char countStr[64];
   snprintf(countStr, sizeof(countStr), tr(STR_NETWORKS_FOUND), realNetworkCount);
   GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
-                 tr(STR_WIFI_NETWORKS), countStr);
+                 tr(STR_WIFI_NETWORKS));
   GUI.drawSubHeader(
       renderer,
       Rect{screen.x, screen.y + metrics.topPadding + metrics.headerHeight, screen.width, metrics.tabBarHeight},
-      cachedMacAddress.c_str());
+      cachedMacAddress.c_str(), countStr);
 
   switch (state) {
     case WifiSelectionState::AUTO_CONNECTING:

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -30,7 +30,6 @@ enum ReadyRow {
 };
 
 constexpr uint8_t RELEASE_NOTE_MAX_LINES = 4;
-constexpr uint8_t RELEASE_NOTES_PER_PAGE_MAX = 3;
 
 fui::TextStyle releaseNoteStyle() {
   fui::TextStyle style;
@@ -229,7 +228,6 @@ void OtaUpdateActivity::rebuildReleaseNotePages(const Rect& safeArea) {
     int usedHeight = 0;
     const uint8_t pageStart = noteIndex;
     while (noteIndex < notes.size()) {
-      if (noteIndex - pageStart >= RELEASE_NOTES_PER_PAGE_MAX) break;
       const int noteHeight = fui::measureWrappedText(target, notes[noteIndex].data(), style, textWidth).height;
       const int itemHeight = noteHeight + (noteIndex == pageStart ? 0 : relatedGap);
       if (noteIndex != pageStart && usedHeight + itemHeight > availableHeight) break;


### PR DESCRIPTION
## Summary

- restore the WiFi scan title/subheader layout so the network count is no longer clipped
- restore transparent sleep covers while keeping opaque white pixels white
- paginate OTA release notes by measured rendered height instead of a three-entry cap

## Review cleanup

- parse the legacy marked `/sleep.bmp` once and render that same `Bitmap` directly
- retain `/sleep-overlay.bmp`, `/sleep-overlay.png`, and overlay-directory fallback behavior
- add no public API, configuration, cache-format, translation, dependency, or allocation changes

## Validation

- `git diff --check`
- `./bin/clang-format-fix --check`
- CTest: 372/372 passed
- PlatformIO: `default`, `simulator`, `simulator_x3`, and `gh_release_cn` passed
- simulator: WiFi count checked across themes; four short OTA notes stay on one page and long notes paginate by height
- simulator end-to-end: ImageViewer converted a PNG containing transparent, opaque white, black, and two gray levels into marked `/sleep.bmp`; SleepActivity preserved the underlying screen only through transparent pixels, while opaque white covered background content
- compatibility: ordinary `/sleep.bmp` does not enter the transparent compatibility path; marked legacy BMP and existing overlay paths remain supported

## Hardware acceptance

- [ ] X4: verify WiFi header, transparent sleep overlay, and OTA notes
- [ ] X3: verify WiFi header, transparent sleep overlay, and OTA notes

Build and simulator results do not replace true-device acceptance.