### PR TITLE
fix: improve WeRead progress sync

### DIFF
--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -105,19 +105,24 @@ EPUBs continue to use KOReader. WeRead public-account books (`MP_WXS_`), moved
 files, and renamed files are intentionally treated as ordinary EPUBs. The
 existing long-press KOReader shortcut is unchanged.
 
-Manual WeRead sync renews the saved Cookie, fetches the remote position, and
-maps it through the `WRT2` chapter word counts. Positions within two percentage
-points are left unchanged. Otherwise the farther position wins automatically:
-a remote position is applied locally, or the local position is sent with an
-enter/report pair. For an exact WeRead EPUB, the report also includes the whole
-seconds recorded by the local reading session that ended when manual sync was
-opened. Equal positions report against the local position; when the remote
-position is selected, its exact chapter and offset are reported before being
-applied locally, so reporting time cannot move cloud progress backwards. A
-timed report is not automatically repeated after an ambiguous network failure;
-the current sync screen retains it for an explicit Retry, but no pending time is
-persisted after leaving the screen. An expired session directs the user back to
-**Apps → WeRead** to sign in; it does not open a QR flow from the reader.
+Manual WeRead sync starts with the saved Cookie and renews it only after an
+authentication failure. Newly generated WeRead chapters retain invisible
+raw-XHTML UTF-16 source anchors. These map the local page's visible-text offset
+to WeRead's native `chapterUid + chapterOffset` coordinate without clamping the
+offset to the `WRT2` word count; the inverse mapping restores a remote offset
+through the reader's existing pagination LUT. Older generated books without
+anchors retain the visible-offset approximation, and other EPUBs fall back to
+the whole-book percentage derived from `WRT2` word counts. Different canonical
+positions show the direction selector. A local upload uses an enter/report pair
+and includes the whole seconds recorded by the local reading session that ended
+when manual sync was opened. When the remote position is selected, its exact
+chapter and offset are reported before being applied locally, so reporting time
+cannot move cloud progress backwards. Upload is accepted only after a read-back
+verifies the chapter and offset. A timed report is not automatically repeated
+after an ambiguous network failure; the current sync screen retains it for an
+explicit Retry, but no pending time is persisted after leaving the screen. An
+expired session directs the user back to **Apps → WeRead** to sign in; it does
+not open a QR flow from the reader.
 
 For a new standard-book cache, the downloader fetches cloud progress after the
 `WRT2` catalog and before any chapter or image. This request is best effort:

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -590,7 +590,15 @@ automatically; cache a book again to embed its available cover and selected
 chapter images.
 
 `WRT2` rejects `WRT1` TOC indexes because TOC records now include
-`wordCount`, used to map local whole-book progress to WeRead chapter offsets.
+`wordCount`, used for fallback whole-book progress mapping. It is not the unit
+of WeRead's native `chapterOffset`.
+
+Newly generated chapter XHTML embeds `<!--wr-co:N-->` comments at source-text,
+entity, image, and final boundaries. `N` is the zero-based UTF-16 code-unit
+offset in the decoded raw chapter source after removing a UTF-8 BOM. The reader
+ignores these comments; manual sync streams the loose generated chapter to map
+between its visible-text offsets and WeRead's native offsets. Old chapters have
+no marker and remain compatible through the approximate fallback.
 Manual progress sync refreshes only an old or invalid TOC; an existing
 `/WeRead/*.epub` is retained.
 

--- a/lib/WeReadWebApi/src/WeReadClient.cpp
+++ b/lib/WeReadWebApi/src/WeReadClient.cpp
@@ -23,9 +23,13 @@
 #include "../../../src/util/BookCacheUtils.h"
 #include "../../../src/util/TimeUtils.h"
 #include "WeReadProtocol.h"
+#include "WeReadXhtmlCodec.h"
 
 namespace WeReadClient {
 namespace {
+
+using WeReadXhtmlCodec::writeLiteral;
+using WeReadXhtmlCodec::writeXmlText;
 
 constexpr const char* kHost = "https://weread.qq.com";
 constexpr const char* kOrigin = "https://weread.qq.com";
@@ -1570,307 +1574,6 @@ bool combineAndDecode(const std::string* shards, const size_t shardCount, const 
   return true;
 }
 
-bool writeXmlText(HalFile& output, const char* text) {
-  if (!text) return true;
-  for (const auto* p = reinterpret_cast<const uint8_t*>(text); *p; ++p) {
-    const char* escaped = nullptr;
-    switch (*p) {
-      case '&':
-        escaped = "&amp;";
-        break;
-      case '<':
-        escaped = "&lt;";
-        break;
-      case '>':
-        escaped = "&gt;";
-        break;
-      case '"':
-        escaped = "&quot;";
-        break;
-      case '\'':
-        escaped = "&apos;";
-        break;
-      default:
-        if (output.write(*p) != 1) return false;
-        continue;
-    }
-    if (output.write(reinterpret_cast<const uint8_t*>(escaped), strlen(escaped)) != strlen(escaped)) return false;
-  }
-  return true;
-}
-
-bool writeLiteral(HalFile& output, const char* text) {
-  return output.write(reinterpret_cast<const uint8_t*>(text), strlen(text)) == strlen(text);
-}
-
-void decodeBasicHtmlEntities(char* text) {
-  if (!text) return;
-  char* read = text;
-  char* write = text;
-  while (*read) {
-    struct Entity {
-      const char* encoded;
-      char decoded;
-    };
-    static constexpr Entity kEntities[] = {
-        {"&amp;", '&'}, {"&lt;", '<'}, {"&gt;", '>'}, {"&quot;", '"'}, {"&apos;", '\''}};
-    bool replaced = false;
-    for (const auto& entity : kEntities) {
-      const size_t length = strlen(entity.encoded);
-      if (strncmp(read, entity.encoded, length) != 0) continue;
-      *write++ = entity.decoded;
-      read += length;
-      replaced = true;
-      break;
-    }
-    if (!replaced) *write++ = *read++;
-  }
-  *write = '\0';
-}
-
-struct XhtmlSanitizer {
-  HalFile* output = nullptr;
-  WeReadStore::IndexWriter* imageWriter = nullptr;
-  char* tag = nullptr;
-  size_t tagCapacity = 0;
-  uint32_t chapterIndex = 0;
-  bool plainText = false;
-  bool inTag = false;
-  bool inEntity = false;
-  bool skip = false;
-  bool skipHead = false;
-  bool tagOverflow = false;
-  size_t tagLen = 0;
-  char entity[24] = {};
-  size_t entityLen = 0;
-};
-
-bool emitEntity(XhtmlSanitizer& sanitizer) {
-  sanitizer.entity[sanitizer.entityLen] = '\0';
-  const char* replacement = nullptr;
-  if (strcmp(sanitizer.entity, "amp") == 0) replacement = "&amp;";
-  if (strcmp(sanitizer.entity, "lt") == 0) replacement = "&lt;";
-  if (strcmp(sanitizer.entity, "gt") == 0) replacement = "&gt;";
-  if (strcmp(sanitizer.entity, "quot") == 0) replacement = "&quot;";
-  if (strcmp(sanitizer.entity, "apos") == 0) replacement = "&apos;";
-  if (strcmp(sanitizer.entity, "nbsp") == 0) replacement = "&#160;";
-  bool numericEntity = sanitizer.entity[0] == '#' && sanitizer.entity[1] != '\0';
-  const bool hexEntity = sanitizer.entity[1] == 'x' || sanitizer.entity[1] == 'X';
-  if (hexEntity && sanitizer.entity[2] == '\0') numericEntity = false;
-  for (size_t i = hexEntity ? 2 : 1; numericEntity && sanitizer.entity[i]; ++i) {
-    numericEntity = hexEntity ? std::isxdigit(static_cast<unsigned char>(sanitizer.entity[i]))
-                              : std::isdigit(static_cast<unsigned char>(sanitizer.entity[i]));
-  }
-  if (numericEntity) {
-    char numeric[32];
-    const int written = snprintf(numeric, sizeof(numeric), "&%s;", sanitizer.entity);
-    if (written <= 0 || static_cast<size_t>(written) >= sizeof(numeric)) return false;
-    replacement = numeric;
-    const bool ok = writeLiteral(*sanitizer.output, replacement);
-    sanitizer.entityLen = 0;
-    sanitizer.inEntity = false;
-    return ok;
-  }
-  bool ok = true;
-  if (replacement) {
-    ok = writeLiteral(*sanitizer.output, replacement);
-  } else {
-    ok = writeLiteral(*sanitizer.output, "&amp;") && writeLiteral(*sanitizer.output, sanitizer.entity) &&
-         writeLiteral(*sanitizer.output, ";");
-  }
-  sanitizer.entityLen = 0;
-  sanitizer.inEntity = false;
-  return ok;
-}
-
-bool emitSanitizedTextByte(XhtmlSanitizer& sanitizer, const uint8_t value) {
-  if (sanitizer.skip || sanitizer.skipHead) return true;
-  if (sanitizer.plainText) {
-    if (value == '\r') return true;
-    if (value == '\n') return writeLiteral(*sanitizer.output, "<br/>");
-  }
-  if (sanitizer.inEntity) {
-    if (value == ';') return emitEntity(sanitizer);
-    if (sanitizer.entityLen + 1 >= sizeof(sanitizer.entity) || value == '<' || value == '&' || std::isspace(value)) {
-      if (!writeLiteral(*sanitizer.output, "&amp;") ||
-          sanitizer.output->write(reinterpret_cast<const uint8_t*>(sanitizer.entity), sanitizer.entityLen) !=
-              sanitizer.entityLen) {
-        return false;
-      }
-      sanitizer.entityLen = 0;
-      sanitizer.inEntity = false;
-    } else {
-      sanitizer.entity[sanitizer.entityLen++] = static_cast<char>(value);
-      return true;
-    }
-  }
-  if (value == '&') {
-    sanitizer.inEntity = true;
-    sanitizer.entityLen = 0;
-    return true;
-  }
-  if (value < 0x20 && value != '\t' && value != '\n') return true;
-  if (value == '<') return writeLiteral(*sanitizer.output, "&lt;");
-  if (value == '>') return writeLiteral(*sanitizer.output, "&gt;");
-  return sanitizer.output->write(value) == 1;
-}
-
-bool processTag(XhtmlSanitizer& sanitizer) {
-  if (sanitizer.tagOverflow || !sanitizer.tag || sanitizer.tagCapacity == 0) {
-    sanitizer.tagLen = 0;
-    sanitizer.inTag = false;
-    sanitizer.tagOverflow = false;
-    return true;
-  }
-  sanitizer.tag[sanitizer.tagLen] = '\0';
-  const char* tagEnd = sanitizer.tag + sanitizer.tagLen;
-  while (tagEnd > sanitizer.tag && std::isspace(static_cast<unsigned char>(tagEnd[-1]))) --tagEnd;
-  const bool selfClosing = tagEnd > sanitizer.tag && tagEnd[-1] == '/';
-  const char* cursor = sanitizer.tag;
-  while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) ++cursor;
-  bool closing = false;
-  if (*cursor == '/') {
-    closing = true;
-    ++cursor;
-  }
-  char name[24] = {};
-  size_t len = 0;
-  while (*cursor && !std::isspace(static_cast<unsigned char>(*cursor)) && *cursor != '/' && *cursor != '>' &&
-         len + 1 < sizeof(name)) {
-    name[len++] = static_cast<char>(std::tolower(static_cast<unsigned char>(*cursor++)));
-  }
-  name[len] = '\0';
-  sanitizer.tagLen = 0;
-  sanitizer.inTag = false;
-  if (!name[0] || name[0] == '!' || name[0] == '?') return true;
-
-  if (strcmp(name, "head") == 0) {
-    sanitizer.skipHead = !closing && !selfClosing;
-    return true;
-  }
-  if (strcmp(name, "script") == 0 || strcmp(name, "style") == 0) {
-    sanitizer.skip = !closing && !selfClosing;
-    return true;
-  }
-  if (!closing && strcmp(name, "img") == 0 && !sanitizer.skip && !sanitizer.skipHead) {
-    WeReadStore::ImageRecord record;
-    char alt[256] = {};
-    const bool extracted =
-        WeReadProtocol::extractImageAttributes(sanitizer.tag, record.url, sizeof(record.url), alt, sizeof(alt));
-    const WeReadProtocol::ImageType type =
-        extracted ? WeReadProtocol::normalizeImageUrl(record.url, sanitizer.tag, sizeof(record.url))
-                  : WeReadProtocol::ImageType::None;
-    decodeBasicHtmlEntities(alt);
-    if (type != WeReadProtocol::ImageType::None) {
-      memcpy(record.url, sanitizer.tag, strlen(sanitizer.tag) + 1);
-      const char* extension = type == WeReadProtocol::ImageType::Jpeg ? "jpg" : "png";
-      const int hrefLen = snprintf(record.href, sizeof(record.href), "images/ch%06u-%u.%s",
-                                   static_cast<unsigned>(sanitizer.chapterIndex),
-                                   static_cast<unsigned>(sanitizer.imageWriter->count()), extension);
-      if (hrefLen <= 0 || static_cast<size_t>(hrefLen) >= sizeof(record.href) ||
-          !sanitizer.imageWriter->append(&record) || !writeLiteral(*sanitizer.output, "<img src=\"") ||
-          !writeLiteral(*sanitizer.output, record.href)) {
-        return false;
-      }
-      if (alt[0] && (!writeLiteral(*sanitizer.output, "\" alt=\"") || !writeXmlText(*sanitizer.output, alt))) {
-        return false;
-      }
-      return writeLiteral(*sanitizer.output, "\"/>");
-    }
-    return !alt[0] || writeXmlText(*sanitizer.output, alt);
-  }
-  if (sanitizer.skip || sanitizer.skipHead || strcmp(name, "html") == 0 || strcmp(name, "body") == 0 ||
-      !WeReadProtocol::isAllowedXhtmlTag(name)) {
-    return true;
-  }
-  if (!writeLiteral(*sanitizer.output, "<")) return false;
-  if (closing && !writeLiteral(*sanitizer.output, "/")) return false;
-  if (!writeLiteral(*sanitizer.output, name)) return false;
-  if (!closing && (selfClosing || strcmp(name, "br") == 0 || strcmp(name, "hr") == 0) &&
-      !writeLiteral(*sanitizer.output, "/")) {
-    return false;
-  }
-  return writeLiteral(*sanitizer.output, ">");
-}
-
-bool sanitizeToXhtml(const std::string& inputPath, const std::string& outputPath, const std::string& imageIndexPath,
-                     const uint32_t chapterIndex, const char* title, const bool plainText, uint8_t* readBuffer,
-                     const size_t readBufferSize, char* tagBuffer, const size_t tagBufferSize) {
-  HalFile input;
-  if (!readBuffer || readBufferSize == 0 || !tagBuffer || tagBufferSize < sizeof(WeReadStore::ImageRecord::url) ||
-      !Storage.openFileForRead("WR", inputPath, input)) {
-    return false;
-  }
-  const std::string partPath = outputPath + ".part";
-  if (Storage.exists(partPath.c_str())) Storage.remove(partPath.c_str());
-  if (Storage.exists(imageIndexPath.c_str()) && !Storage.remove(imageIndexPath.c_str())) return false;
-  HalFile output;
-  if (!Storage.openFileForWrite("WR", partPath, output)) return false;
-  WeReadStore::IndexWriter imageWriter;
-  if (!imageWriter.begin(imageIndexPath, WeReadStore::kImageMagic, sizeof(WeReadStore::ImageRecord))) return false;
-
-  const bool written = [&]() {
-    if (!writeLiteral(output,
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                      "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>") ||
-        !writeXmlText(output, title) || !writeLiteral(output, "</title></head><body>") ||
-        (plainText && !writeLiteral(output, "<p>"))) {
-      return false;
-    }
-
-    XhtmlSanitizer sanitizer{&output, &imageWriter, tagBuffer, tagBufferSize, chapterIndex, plainText};
-    while (input.available()) {
-      const int got = input.read(readBuffer, readBufferSize);
-      if (got <= 0) return false;
-      for (int i = 0; i < got;) {
-        if (!sanitizer.inTag && !sanitizer.inEntity && !sanitizer.skip && !sanitizer.skipHead) {
-          const size_t run =
-              WeReadProtocol::safeXhtmlTextRunLength(readBuffer + i, static_cast<size_t>(got - i), plainText);
-          if (run > 0) {
-            if (output.write(readBuffer + i, run) != run) return false;
-            i += static_cast<int>(run);
-            continue;
-          }
-        }
-        const uint8_t value = readBuffer[i++];
-        if (!plainText && sanitizer.inTag) {
-          if (value == '>') {
-            if (!processTag(sanitizer)) return false;
-          } else if (sanitizer.tagLen + 1 < sanitizer.tagCapacity) {
-            sanitizer.tag[sanitizer.tagLen++] = static_cast<char>(value);
-          } else {
-            sanitizer.tagOverflow = true;
-          }
-          continue;
-        }
-        if (!plainText && value == '<') {
-          if (sanitizer.inEntity && !emitEntity(sanitizer)) return false;
-          sanitizer.inTag = true;
-          sanitizer.tagOverflow = false;
-          sanitizer.tagLen = 0;
-          continue;
-        }
-        if (!emitSanitizedTextByte(sanitizer, value)) return false;
-      }
-    }
-    if (sanitizer.inEntity && !emitEntity(sanitizer)) return false;
-    return (!plainText || writeLiteral(output, "</p>")) && writeLiteral(output, "</body></html>");
-  }();
-  if (!written) {
-    imageWriter.abort();
-    output.close();
-    Storage.remove(partPath.c_str());
-    return false;
-  }
-  output.flush();
-  output.close();
-  if (!WeReadStore::atomicReplace(partPath, outputPath) || !imageWriter.finish()) {
-    Storage.remove(partPath.c_str());
-    return false;
-  }
-  return true;
-}
-
 Error writePackageFiles(const std::string& bookDir, const WeReadStore::ShelfRecord& book, const std::string& tocPath,
                         const uint32_t chapterCount, const uint32_t firstChapter, const uint32_t lastChapter,
                         const WeReadStore::ImagePolicy imagePolicy, const std::string& workPath,
@@ -2322,13 +2025,7 @@ bool Operation::beginProgressSync(const char* bookId, ProgressSyncInput input, c
     phase_ = Phase::Failed;
     return false;
   }
-  if (session_.rt[0]) {
-    renewalAttempted_ = true;
-    resumePhase_ = Phase::PrepareProgressSync;
-    phase_ = Phase::Renew;
-  } else {
-    phase_ = Phase::PrepareProgressSync;
-  }
+  phase_ = Phase::PrepareProgressSync;
   logMemory("progress sync start");
   return true;
 }
@@ -3100,17 +2797,29 @@ void Operation::persistInitialProgress() {
 Error Operation::decideProgress() {
   const float remoteFraction = normalizedRemoteProgress();
   progressSyncResult_.remote.percent = remoteFraction * 100.0f;
-  const bool preciseLocal =
-      progressSyncInput_.hasLocalTocIndex &&
-      WeReadStore::mapPageToChapter(tocPath_, progressSyncInput_.localTocIndex, progressSyncInput_.localPageNumber,
-                                    progressSyncInput_.localPageCount, chapter_, progressChapterOffset_,
-                                    progressSyncInput_.localFraction);
+  bool preciseLocal = false;
+  const char* basis = "fraction";
+  switch (progressSyncInput_.localOffsetBasis) {
+    case LocalOffsetBasis::None:
+      break;
+    case LocalOffsetBasis::VisibleText:
+      preciseLocal = WeReadStore::mapVisibleOffsetToChapter(tocPath_, progressSyncInput_.localTocIndex,
+                                                            progressSyncInput_.localOffset, chapter_,
+                                                            progressChapterOffset_, progressSyncInput_.localFraction);
+      if (preciseLocal) basis = "visible_text";
+      break;
+    case LocalOffsetBasis::RawXhtmlUtf16:
+      preciseLocal = WeReadStore::mapNativeOffsetToChapter(
+          tocPath_, progressSyncInput_.localTocIndex, progressSyncInput_.localOffset, chapter_, progressChapterOffset_);
+      if (preciseLocal) basis = "raw_xhtml_utf16";
+      break;
+  }
   if (!preciseLocal && !WeReadStore::mapFractionToChapter(tocPath_, progressSyncInput_.localFraction, chapter_,
                                                           progressChapterOffset_)) {
     return Error::Unavailable;
   }
-  LOG_INF("WR", "local progress mapping: precise=%u toc=%u chapter=%s offset=%u fraction=%lu",
-          static_cast<unsigned>(preciseLocal), static_cast<unsigned>(progressSyncInput_.localTocIndex),
+  LOG_INF("WR", "local progress mapping: precise=%u basis=%s toc=%u chapter=%s offset=%u fraction=%lu",
+          static_cast<unsigned>(preciseLocal), basis, static_cast<unsigned>(progressSyncInput_.localTocIndex),
           chapter_.chapterUid, static_cast<unsigned>(progressChapterOffset_),
           static_cast<unsigned long>(progressSyncInput_.localFraction * 1000000.0f + 0.5f));
   const bool samePosition = sameRemotePosition();
@@ -3666,10 +3375,10 @@ Operation::Event Operation::decodeChapter(const bool plainText) {
     cleanup();
     return retryChapterResponse();
   }
-  const bool ok = sanitizeToXhtml(decoded, WeReadStore::chapterPath(bookDir_, chapterIndex_),
-                                  WeReadStore::imageIndexPath(bookDir_, chapterIndex_), chapterIndex_, chapter_.title,
-                                  plainText, reinterpret_cast<uint8_t*>(url_), sizeof(url_),
-                                  reinterpret_cast<char*>(ioBuffer_), sizeof(ioBuffer_));
+  const bool ok = WeReadXhtmlCodec::sanitizeChapter(
+      decoded, WeReadStore::chapterPath(bookDir_, chapterIndex_), WeReadStore::imageIndexPath(bookDir_, chapterIndex_),
+      chapterIndex_, chapter_.title, plainText, reinterpret_cast<uint8_t*>(url_), sizeof(url_),
+      reinterpret_cast<char*>(ioBuffer_), sizeof(ioBuffer_));
   cleanup();
   if (!ok) return fail(Error::SdCard);
   phase_ = Phase::AdvanceChapter;
@@ -3883,6 +3592,7 @@ Operation::Event Operation::step(const WeReadStore::WorkCallback callback, void*
 
     case Phase::PrepareDownload: {
       if (!preparePaths()) return fail(Error::SdCard);
+      LOG_INF("WR", "download cache mode: refresh=%u", static_cast<unsigned>(Storage.exists(outputPath_.c_str())));
       phase_ = Phase::FetchToc;
       return Event::None;
     }
@@ -4065,7 +3775,8 @@ Operation::Event Operation::step(const WeReadStore::WorkCallback callback, void*
       chapterResponseAttempts_ = 0;
       HalFile imageIndex;
       uint32_t imageCount = 0;
-      if (Storage.exists(WeReadStore::chapterPath(bookDir_, chapterIndex_).c_str()) &&
+      if (reuseChapterFile(Storage.exists(outputPath_.c_str()),
+                           Storage.exists(WeReadStore::chapterPath(bookDir_, chapterIndex_).c_str())) &&
           WeReadStore::openImageIndex(WeReadStore::imageIndexPath(bookDir_, chapterIndex_), imageIndex, imageCount)) {
         phase_ = Phase::AdvanceChapter;
         return Event::None;

--- a/lib/WeReadWebApi/src/WeReadClient.h
+++ b/lib/WeReadWebApi/src/WeReadClient.h
@@ -38,13 +38,17 @@ struct DownloadOptions {
   ChapterScope chapterScope = ChapterScope::WholeBook;
 };
 
+enum class LocalOffsetBasis : uint8_t {
+  None,
+  VisibleText,
+  RawXhtmlUtf16,
+};
+
 struct ProgressSyncInput {
   float localFraction = 0.0f;
   uint32_t localTocIndex = 0;
-  uint16_t localSpineIndex = 0;
-  uint16_t localPageNumber = 0;
-  uint16_t localPageCount = 0;
-  bool hasLocalTocIndex = false;
+  uint32_t localOffset = 0;
+  LocalOffsetBasis localOffsetBasis = LocalOffsetBasis::None;
 };
 static_assert(sizeof(ProgressSyncInput) == 16);
 
@@ -248,6 +252,9 @@ class Operation {
   static constexpr Phase chapterResponseRetryPhase() { return Phase::FetchReader; }
   static constexpr bool shouldRetryPaidPreview(const bool paid, const bool plainText, const bool hasXhtmlTag) {
     return paid && !plainText && !hasXhtmlTag;
+  }
+  static constexpr bool reuseChapterFile(const bool refreshingBook, const bool chapterExists) {
+    return !refreshingBook && chapterExists;
   }
   static constexpr bool imageAttemptPending(const uint8_t attempts) { return attempts < 2; }
   static constexpr bool imageRedirectAllowed(const uint8_t redirects) { return redirects < kMaxImageRedirects; }

--- a/lib/WeReadWebApi/src/WeReadStore.cpp
+++ b/lib/WeReadWebApi/src/WeReadStore.cpp
@@ -761,9 +761,8 @@ bool mapFractionToChapter(const std::string& path, float fraction, TocRecord& ch
   return true;
 }
 
-bool mapPageToChapter(const std::string& path, const uint32_t tocIndex, const uint16_t pageNumber,
-                      const uint16_t pageCount, TocRecord& chapter, uint32_t& chapterOffset, float& fraction) {
-  if (pageCount == 0 || pageNumber >= pageCount) return false;
+bool mapVisibleOffsetToChapter(const std::string& path, const uint32_t tocIndex, const uint32_t visibleTextOffset,
+                               TocRecord& chapter, uint32_t& chapterOffset, float& fraction) {
   HalFile toc;
   uint32_t count = 0;
   if (!openToc(path, toc, count) || tocIndex >= count) return false;
@@ -779,16 +778,18 @@ bool mapPageToChapter(const std::string& path, const uint32_t tocIndex, const ui
   }
   if (chapter.wordCount == 0 || totalWords == 0) return false;
 
-  if (pageCount <= 1) {
-    chapterOffset = 0;
-  } else {
-    const uint64_t denominator = static_cast<uint64_t>(pageCount - 1);
-    const uint64_t numerator = static_cast<uint64_t>(pageNumber) * chapter.wordCount;
-    chapterOffset =
-        static_cast<uint32_t>(std::min<uint64_t>(chapter.wordCount, (numerator + denominator / 2) / denominator));
-  }
+  chapterOffset = std::min(visibleTextOffset, chapter.wordCount);
   fraction = static_cast<float>(static_cast<double>(wordsBefore + chapterOffset) / static_cast<double>(totalWords));
   return true;
+}
+
+bool mapNativeOffsetToChapter(const std::string& path, const uint32_t tocIndex, const uint32_t nativeOffset,
+                              TocRecord& chapter, uint32_t& chapterOffset) {
+  HalFile toc;
+  uint32_t count = 0;
+  if (!openToc(path, toc, count) || tocIndex >= count || !readTocRecord(toc, tocIndex, chapter)) return false;
+  chapterOffset = nativeOffset;
+  return chapter.chapterUid[0] != '\0';
 }
 
 bool mapChapterToPosition(const std::string& path, const char* chapterUid, const uint32_t chapterOffset,

--- a/lib/WeReadWebApi/src/WeReadStore.h
+++ b/lib/WeReadWebApi/src/WeReadStore.h
@@ -201,8 +201,10 @@ std::string finalBookPath(const ShelfRecord& book);
 bool findBookIdForPath(const std::string& path, char* bookId, size_t bookIdSize);
 bool parseGeneratedChapterHref(const std::string& href, uint32_t& tocIndex);
 bool mapFractionToChapter(const std::string& path, float fraction, TocRecord& chapter, uint32_t& chapterOffset);
-bool mapPageToChapter(const std::string& path, uint32_t tocIndex, uint16_t pageNumber, uint16_t pageCount,
-                      TocRecord& chapter, uint32_t& chapterOffset, float& fraction);
+bool mapVisibleOffsetToChapter(const std::string& path, uint32_t tocIndex, uint32_t visibleTextOffset,
+                               TocRecord& chapter, uint32_t& chapterOffset, float& fraction);
+bool mapNativeOffsetToChapter(const std::string& path, uint32_t tocIndex, uint32_t nativeOffset, TocRecord& chapter,
+                              uint32_t& chapterOffset);
 bool mapChapterToFraction(const std::string& path, const char* chapterUid, uint32_t chapterOffset, float& fraction);
 bool mapChapterToPosition(const std::string& path, const char* chapterUid, uint32_t chapterOffset, uint32_t& tocIndex,
                           float& chapterFraction, float& bookFraction);

--- a/lib/WeReadWebApi/src/WeReadXhtmlCodec.cpp
+++ b/lib/WeReadWebApi/src/WeReadXhtmlCodec.cpp
@@ -68,8 +68,8 @@ struct XhtmlSanitizer {
 
 bool writeSourceOffsetMarker(XhtmlSanitizer& sanitizer, const uint32_t offset) {
   char marker[32];
-  const int length = snprintf(marker, sizeof(marker), "<!--%s%u-->", kSourceOffsetMarkerName,
-                              static_cast<unsigned>(offset));
+  const int length =
+      snprintf(marker, sizeof(marker), "<!--%s%u-->", kSourceOffsetMarkerName, static_cast<unsigned>(offset));
   return length > 0 && static_cast<size_t>(length) < sizeof(marker) && writeLiteral(*sanitizer.output, marker);
 }
 
@@ -496,10 +496,9 @@ bool writeXmlText(HalFile& output, const char* text) {
   return true;
 }
 
-bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath,
-                     const std::string& imageIndexPath, const uint32_t chapterIndex, const char* title,
-                     const bool plainText, uint8_t* readBuffer, const size_t readBufferSize, char* tagBuffer,
-                     const size_t tagBufferSize) {
+bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath, const std::string& imageIndexPath,
+                     const uint32_t chapterIndex, const char* title, const bool plainText, uint8_t* readBuffer,
+                     const size_t readBufferSize, char* tagBuffer, const size_t tagBufferSize) {
   HalFile input;
   if (!readBuffer || readBufferSize == 0 || !tagBuffer || tagBufferSize < sizeof(WeReadStore::ImageRecord::url) ||
       !Storage.openFileForRead("WR", inputPath, input)) {

--- a/lib/WeReadWebApi/src/WeReadXhtmlCodec.cpp
+++ b/lib/WeReadWebApi/src/WeReadXhtmlCodec.cpp
@@ -1,0 +1,602 @@
+#include "WeReadXhtmlCodec.h"
+
+#if defined(ENABLE_CHINESE_VERSION) || defined(CROSSPOINT_EMULATED)
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
+#include "WeReadProtocol.h"
+#include "WeReadStore.h"
+
+namespace WeReadXhtmlCodec {
+namespace {
+
+constexpr char kSourceOffsetMarkerName[] = "wr-co:";
+
+bool isUtf8Continuation(const uint8_t value) { return (value & 0xC0) == 0x80; }
+
+uint32_t utf16Width(const uint8_t utf8Lead) { return utf8Lead >= 0xF0 && utf8Lead <= 0xF4 ? 2U : 1U; }
+
+void decodeBasicHtmlEntities(char* text) {
+  if (!text) return;
+  char* read = text;
+  char* write = text;
+  while (*read) {
+    struct Entity {
+      const char* encoded;
+      char decoded;
+    };
+    static constexpr Entity kEntities[] = {
+        {"&amp;", '&'}, {"&lt;", '<'}, {"&gt;", '>'}, {"&quot;", '"'}, {"&apos;", '\''}};
+    bool replaced = false;
+    for (const auto& entity : kEntities) {
+      const size_t length = strlen(entity.encoded);
+      if (strncmp(read, entity.encoded, length) != 0) continue;
+      *write++ = entity.decoded;
+      read += length;
+      replaced = true;
+      break;
+    }
+    if (!replaced) *write++ = *read++;
+  }
+  *write = '\0';
+}
+
+struct XhtmlSanitizer {
+  HalFile* output = nullptr;
+  WeReadStore::IndexWriter* imageWriter = nullptr;
+  char* tag = nullptr;
+  size_t tagCapacity = 0;
+  uint32_t chapterIndex = 0;
+  bool plainText = false;
+  bool inTag = false;
+  bool inEntity = false;
+  bool skip = false;
+  bool skipHead = false;
+  bool tagOverflow = false;
+  bool textRunOpen = false;
+  size_t tagLen = 0;
+  char entity[24] = {};
+  size_t entityLen = 0;
+  uint32_t sourceUtf16Offset = 0;
+  uint32_t tagSourceOffset = 0;
+  uint32_t entitySourceOffset = 0;
+};
+
+bool writeSourceOffsetMarker(XhtmlSanitizer& sanitizer, const uint32_t offset) {
+  char marker[32];
+  const int length = snprintf(marker, sizeof(marker), "<!--%s%u-->", kSourceOffsetMarkerName,
+                              static_cast<unsigned>(offset));
+  return length > 0 && static_cast<size_t>(length) < sizeof(marker) && writeLiteral(*sanitizer.output, marker);
+}
+
+bool advanceSourceUtf16Offset(XhtmlSanitizer& sanitizer, const uint8_t* data, const size_t length) {
+  for (size_t i = 0; i < length; ++i) {
+    if (isUtf8Continuation(data[i])) continue;
+    const uint32_t width = utf16Width(data[i]);
+    if (sanitizer.sourceUtf16Offset > UINT32_MAX - width) return false;
+    sanitizer.sourceUtf16Offset += width;
+  }
+  return true;
+}
+
+bool emitEntity(XhtmlSanitizer& sanitizer) {
+  sanitizer.entity[sanitizer.entityLen] = '\0';
+  if (!sanitizer.skip && !sanitizer.skipHead && !writeSourceOffsetMarker(sanitizer, sanitizer.entitySourceOffset)) {
+    return false;
+  }
+  const char* replacement = nullptr;
+  if (strcmp(sanitizer.entity, "amp") == 0) replacement = "&amp;";
+  if (strcmp(sanitizer.entity, "lt") == 0) replacement = "&lt;";
+  if (strcmp(sanitizer.entity, "gt") == 0) replacement = "&gt;";
+  if (strcmp(sanitizer.entity, "quot") == 0) replacement = "&quot;";
+  if (strcmp(sanitizer.entity, "apos") == 0) replacement = "&apos;";
+  if (strcmp(sanitizer.entity, "nbsp") == 0) replacement = "&#160;";
+  bool numericEntity = sanitizer.entity[0] == '#' && sanitizer.entity[1] != '\0';
+  const bool hexEntity = sanitizer.entity[1] == 'x' || sanitizer.entity[1] == 'X';
+  if (hexEntity && sanitizer.entity[2] == '\0') numericEntity = false;
+  for (size_t i = hexEntity ? 2 : 1; numericEntity && sanitizer.entity[i]; ++i) {
+    numericEntity = hexEntity ? std::isxdigit(static_cast<unsigned char>(sanitizer.entity[i]))
+                              : std::isdigit(static_cast<unsigned char>(sanitizer.entity[i]));
+  }
+  if (numericEntity) {
+    char numeric[32];
+    const int written = snprintf(numeric, sizeof(numeric), "&%s;", sanitizer.entity);
+    if (written <= 0 || static_cast<size_t>(written) >= sizeof(numeric)) return false;
+    replacement = numeric;
+    const bool ok = writeLiteral(*sanitizer.output, replacement);
+    sanitizer.entityLen = 0;
+    sanitizer.inEntity = false;
+    return ok;
+  }
+  bool ok = true;
+  if (replacement) {
+    ok = writeLiteral(*sanitizer.output, replacement);
+  } else {
+    ok = writeLiteral(*sanitizer.output, "&amp;") && writeLiteral(*sanitizer.output, sanitizer.entity) &&
+         writeLiteral(*sanitizer.output, ";");
+  }
+  sanitizer.entityLen = 0;
+  sanitizer.inEntity = false;
+  return ok;
+}
+
+bool emitSanitizedTextByte(XhtmlSanitizer& sanitizer, const uint8_t value, const uint32_t sourceOffset) {
+  if (sanitizer.skip || sanitizer.skipHead) return true;
+  if (sanitizer.plainText) {
+    if (value == '\r') return true;
+    if (value == '\n') {
+      return writeSourceOffsetMarker(sanitizer, sourceOffset) && writeLiteral(*sanitizer.output, "<br/>");
+    }
+  }
+  if (sanitizer.inEntity) {
+    if (value == ';') return emitEntity(sanitizer);
+    if (sanitizer.entityLen + 1 >= sizeof(sanitizer.entity) || value == '<' || value == '&' || std::isspace(value)) {
+      if (!writeSourceOffsetMarker(sanitizer, sanitizer.entitySourceOffset) ||
+          !writeLiteral(*sanitizer.output, "&amp;") ||
+          sanitizer.output->write(reinterpret_cast<const uint8_t*>(sanitizer.entity), sanitizer.entityLen) !=
+              sanitizer.entityLen) {
+        return false;
+      }
+      sanitizer.entityLen = 0;
+      sanitizer.inEntity = false;
+    } else {
+      sanitizer.entity[sanitizer.entityLen++] = static_cast<char>(value);
+      return true;
+    }
+  }
+  if (value == '&') {
+    sanitizer.inEntity = true;
+    sanitizer.entityLen = 0;
+    sanitizer.entitySourceOffset = sourceOffset;
+    return true;
+  }
+  if (value < 0x20 && value != '\t' && value != '\n') return true;
+  if (!writeSourceOffsetMarker(sanitizer, sourceOffset)) return false;
+  if (value == '<') return writeLiteral(*sanitizer.output, "&lt;");
+  if (value == '>') return writeLiteral(*sanitizer.output, "&gt;");
+  return sanitizer.output->write(value) == 1;
+}
+
+bool processTag(XhtmlSanitizer& sanitizer) {
+  if (sanitizer.tagOverflow || !sanitizer.tag || sanitizer.tagCapacity == 0) {
+    sanitizer.tagLen = 0;
+    sanitizer.inTag = false;
+    sanitizer.tagOverflow = false;
+    return true;
+  }
+  sanitizer.tag[sanitizer.tagLen] = '\0';
+  const char* tagEnd = sanitizer.tag + sanitizer.tagLen;
+  while (tagEnd > sanitizer.tag && std::isspace(static_cast<unsigned char>(tagEnd[-1]))) --tagEnd;
+  const bool selfClosing = tagEnd > sanitizer.tag && tagEnd[-1] == '/';
+  const char* cursor = sanitizer.tag;
+  while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) ++cursor;
+  bool closing = false;
+  if (*cursor == '/') {
+    closing = true;
+    ++cursor;
+  }
+  char name[24] = {};
+  size_t len = 0;
+  while (*cursor && !std::isspace(static_cast<unsigned char>(*cursor)) && *cursor != '/' && *cursor != '>' &&
+         len + 1 < sizeof(name)) {
+    name[len++] = static_cast<char>(std::tolower(static_cast<unsigned char>(*cursor++)));
+  }
+  name[len] = '\0';
+  sanitizer.tagLen = 0;
+  sanitizer.inTag = false;
+  if (!name[0] || name[0] == '!' || name[0] == '?') return true;
+
+  if (strcmp(name, "head") == 0) {
+    sanitizer.skipHead = !closing && !selfClosing;
+    return true;
+  }
+  if (strcmp(name, "script") == 0 || strcmp(name, "style") == 0) {
+    sanitizer.skip = !closing && !selfClosing;
+    return true;
+  }
+  if (!closing && strcmp(name, "img") == 0 && !sanitizer.skip && !sanitizer.skipHead) {
+    WeReadStore::ImageRecord record;
+    char alt[256] = {};
+    const bool extracted =
+        WeReadProtocol::extractImageAttributes(sanitizer.tag, record.url, sizeof(record.url), alt, sizeof(alt));
+    const WeReadProtocol::ImageType type =
+        extracted ? WeReadProtocol::normalizeImageUrl(record.url, sanitizer.tag, sizeof(record.url))
+                  : WeReadProtocol::ImageType::None;
+    decodeBasicHtmlEntities(alt);
+    if (!writeSourceOffsetMarker(sanitizer, sanitizer.tagSourceOffset)) return false;
+    if (type != WeReadProtocol::ImageType::None) {
+      memcpy(record.url, sanitizer.tag, strlen(sanitizer.tag) + 1);
+      const char* extension = type == WeReadProtocol::ImageType::Jpeg ? "jpg" : "png";
+      const int hrefLen = snprintf(record.href, sizeof(record.href), "images/ch%06u-%u.%s",
+                                   static_cast<unsigned>(sanitizer.chapterIndex),
+                                   static_cast<unsigned>(sanitizer.imageWriter->count()), extension);
+      if (hrefLen <= 0 || static_cast<size_t>(hrefLen) >= sizeof(record.href) ||
+          !sanitizer.imageWriter->append(&record) || !writeLiteral(*sanitizer.output, "<img src=\"") ||
+          !writeLiteral(*sanitizer.output, record.href)) {
+        return false;
+      }
+      if (alt[0] && (!writeLiteral(*sanitizer.output, "\" alt=\"") || !writeXmlText(*sanitizer.output, alt))) {
+        return false;
+      }
+      return writeLiteral(*sanitizer.output, "\"/>");
+    }
+    return !alt[0] || writeXmlText(*sanitizer.output, alt);
+  }
+  if (sanitizer.skip || sanitizer.skipHead || strcmp(name, "html") == 0 || strcmp(name, "body") == 0 ||
+      !WeReadProtocol::isAllowedXhtmlTag(name)) {
+    return true;
+  }
+  if (!closing && (strcmp(name, "br") == 0 || strcmp(name, "hr") == 0) &&
+      !writeSourceOffsetMarker(sanitizer, sanitizer.tagSourceOffset)) {
+    return false;
+  }
+  if (!writeLiteral(*sanitizer.output, "<")) return false;
+  if (closing && !writeLiteral(*sanitizer.output, "/")) return false;
+  if (!writeLiteral(*sanitizer.output, name)) return false;
+  if (!closing && (selfClosing || strcmp(name, "br") == 0 || strcmp(name, "hr") == 0) &&
+      !writeLiteral(*sanitizer.output, "/")) {
+    return false;
+  }
+  return writeLiteral(*sanitizer.output, ">");
+}
+
+enum class SourceOffsetDirection : uint8_t {
+  VisibleToNative,
+  NativeToVisible,
+};
+
+class SourceOffsetResolver {
+ public:
+  SourceOffsetResolver(const SourceOffsetDirection direction, const uint32_t target)
+      : direction_(direction), target_(target) {}
+
+  bool feed(const uint8_t* data, const size_t length) {
+    if (!data) return false;
+    for (size_t i = 0; i < length && !invalid_; ++i) consume(data[i]);
+    return !invalid_;
+  }
+
+  bool finish(uint32_t& result) {
+    if (invalid_ || state_ != State::Text || !hasMarker_) return false;
+    if (!found_) {
+      switch (direction_) {
+        case SourceOffsetDirection::VisibleToNative:
+          if (visibleOffset_ == target_) setResult(nativeOffset_);
+          break;
+        case SourceOffsetDirection::NativeToVisible:
+          if (target_ <= nativeOffset_) setResult(visibleOffset_);
+          break;
+      }
+    }
+    if (!found_) return false;
+    result = result_;
+    return true;
+  }
+
+ private:
+  enum class State : uint8_t {
+    Text,
+    Tag,
+    Entity,
+  };
+
+  void setResult(const uint32_t value) {
+    if (found_) return;
+    result_ = value;
+    found_ = true;
+  }
+
+  void consume(const uint8_t value) {
+    switch (state_) {
+      case State::Text:
+        consumeText(value);
+        return;
+      case State::Tag:
+        consumeTag(value);
+        return;
+      case State::Entity:
+        consumeEntity(value);
+        return;
+    }
+  }
+
+  void consumeText(const uint8_t value) {
+    if (value == '<') {
+      previousWasCarriageReturn_ = false;
+      state_ = State::Tag;
+      tokenLength_ = 0;
+      tokenOverflow_ = false;
+      return;
+    }
+    if (!insideBody_) return;
+    if (value == '&') {
+      previousWasCarriageReturn_ = false;
+      state_ = State::Entity;
+      tokenLength_ = 0;
+      tokenOverflow_ = false;
+      return;
+    }
+    if (isUtf8Continuation(value)) return;
+    if (value == '\n' && previousWasCarriageReturn_) {
+      if (hasMarker_) {
+        if (direction_ == SourceOffsetDirection::NativeToVisible && target_ <= nativeOffset_) {
+          setResult(visibleOffset_);
+          return;
+        }
+        ++nativeOffset_;
+      }
+      previousWasCarriageReturn_ = false;
+      return;
+    }
+    onVisibleCodepoint(utf16Width(value));
+    previousWasCarriageReturn_ = value == '\r';
+  }
+
+  void consumeTag(const uint8_t value) {
+    if (value == '>') {
+      token_[tokenLength_] = '\0';
+      processTag();
+      state_ = State::Text;
+      return;
+    }
+    if (tokenLength_ + 1 < sizeof(token_)) {
+      token_[tokenLength_++] = static_cast<char>(value);
+    } else {
+      tokenOverflow_ = true;
+    }
+  }
+
+  void consumeEntity(const uint8_t value) {
+    if (value == ';') {
+      token_[tokenLength_] = '\0';
+      // Entities are bounded by source markers, so only advance the visible
+      // coordinate. The following marker supplies the next native offset.
+      onVisibleCodepoint(0);
+      state_ = State::Text;
+      return;
+    }
+    if (value == '<' || value == '&' || std::isspace(value) || tokenLength_ + 1 >= sizeof(token_)) {
+      invalid_ = true;
+      return;
+    }
+    token_[tokenLength_++] = static_cast<char>(value);
+  }
+
+  void processTag() {
+    static constexpr char kCommentPrefix[] = "!--";
+    constexpr size_t kCommentPrefixLength = sizeof(kCommentPrefix) - 1;
+    constexpr size_t kMarkerNameLength = sizeof(kSourceOffsetMarkerName) - 1;
+    constexpr size_t kMarkerPrefixLength = kCommentPrefixLength + kMarkerNameLength;
+    if (!tokenOverflow_ && strncmp(token_, kCommentPrefix, kCommentPrefixLength) == 0 &&
+        strncmp(token_ + kCommentPrefixLength, kSourceOffsetMarkerName, kMarkerNameLength) == 0) {
+      processMarker(kMarkerPrefixLength);
+      return;
+    }
+
+    if (strcmp(token_, "body") == 0) insideBody_ = true;
+    if (strcmp(token_, "/body") == 0) insideBody_ = false;
+  }
+
+  void processMarker(const size_t prefixLength) {
+    if (!insideBody_ || tokenLength_ <= prefixLength + 2 || token_[tokenLength_ - 2] != '-' ||
+        token_[tokenLength_ - 1] != '-') {
+      invalid_ = true;
+      return;
+    }
+    uint32_t value = 0;
+    for (size_t i = prefixLength; i + 2 < tokenLength_; ++i) {
+      if (token_[i] < '0' || token_[i] > '9') {
+        invalid_ = true;
+        return;
+      }
+      const uint32_t digit = static_cast<uint32_t>(token_[i] - '0');
+      if (value > (UINT32_MAX - digit) / 10) {
+        invalid_ = true;
+        return;
+      }
+      value = value * 10 + digit;
+    }
+    if (hasMarker_ && value < lastMarkerOffset_) {
+      invalid_ = true;
+      return;
+    }
+    nativeOffset_ = value;
+    lastMarkerOffset_ = value;
+    hasMarker_ = true;
+    if (direction_ == SourceOffsetDirection::NativeToVisible && target_ <= value) setResult(visibleOffset_);
+  }
+
+  void onVisibleCodepoint(const uint32_t width) {
+    if (hasMarker_) {
+      switch (direction_) {
+        case SourceOffsetDirection::VisibleToNative:
+          if (visibleOffset_ == target_) {
+            setResult(nativeOffset_);
+            return;
+          }
+          break;
+        case SourceOffsetDirection::NativeToVisible:
+          if (target_ <= nativeOffset_ || target_ < nativeOffset_ + width) {
+            setResult(visibleOffset_);
+            return;
+          }
+          break;
+      }
+      nativeOffset_ += width;
+    }
+    ++visibleOffset_;
+  }
+
+  SourceOffsetDirection direction_;
+  uint32_t target_ = 0;
+  uint32_t visibleOffset_ = 0;
+  uint32_t nativeOffset_ = 0;
+  uint32_t lastMarkerOffset_ = 0;
+  uint32_t result_ = 0;
+  State state_ = State::Text;
+  char token_[40] = {};
+  size_t tokenLength_ = 0;
+  bool insideBody_ = false;
+  bool tokenOverflow_ = false;
+  bool hasMarker_ = false;
+  bool found_ = false;
+  bool invalid_ = false;
+  bool previousWasCarriageReturn_ = false;
+};
+
+bool resolveSourceOffset(const std::string& path, const SourceOffsetDirection direction, const uint32_t input,
+                         uint32_t& output) {
+  HalFile file;
+  if (!Storage.openFileForRead("WR", path, file)) return false;
+  SourceOffsetResolver resolver(direction, input);
+  std::array<uint8_t, 128> buffer{};
+  while (file.available()) {
+    const int count = file.read(buffer.data(), buffer.size());
+    if (count <= 0 || !resolver.feed(buffer.data(), static_cast<size_t>(count))) return false;
+  }
+  return resolver.finish(output);
+}
+
+}  // namespace
+
+bool writeLiteral(HalFile& output, const char* text) {
+  return output.write(reinterpret_cast<const uint8_t*>(text), strlen(text)) == strlen(text);
+}
+
+bool writeXmlText(HalFile& output, const char* text) {
+  if (!text) return true;
+  for (const auto* p = reinterpret_cast<const uint8_t*>(text); *p; ++p) {
+    const char* escaped = nullptr;
+    switch (*p) {
+      case '&':
+        escaped = "&amp;";
+        break;
+      case '<':
+        escaped = "&lt;";
+        break;
+      case '>':
+        escaped = "&gt;";
+        break;
+      case '"':
+        escaped = "&quot;";
+        break;
+      case '\'':
+        escaped = "&apos;";
+        break;
+      default:
+        if (output.write(*p) != 1) return false;
+        continue;
+    }
+    if (output.write(reinterpret_cast<const uint8_t*>(escaped), strlen(escaped)) != strlen(escaped)) return false;
+  }
+  return true;
+}
+
+bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath,
+                     const std::string& imageIndexPath, const uint32_t chapterIndex, const char* title,
+                     const bool plainText, uint8_t* readBuffer, const size_t readBufferSize, char* tagBuffer,
+                     const size_t tagBufferSize) {
+  HalFile input;
+  if (!readBuffer || readBufferSize == 0 || !tagBuffer || tagBufferSize < sizeof(WeReadStore::ImageRecord::url) ||
+      !Storage.openFileForRead("WR", inputPath, input)) {
+    return false;
+  }
+  const std::string partPath = outputPath + ".part";
+  if (Storage.exists(partPath.c_str())) Storage.remove(partPath.c_str());
+  if (Storage.exists(imageIndexPath.c_str()) && !Storage.remove(imageIndexPath.c_str())) return false;
+  HalFile output;
+  if (!Storage.openFileForWrite("WR", partPath, output)) return false;
+  WeReadStore::IndexWriter imageWriter;
+  if (!imageWriter.begin(imageIndexPath, WeReadStore::kImageMagic, sizeof(WeReadStore::ImageRecord))) return false;
+
+  const bool written = [&]() {
+    if (!writeLiteral(output,
+                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                      "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>") ||
+        !writeXmlText(output, title) || !writeLiteral(output, "</title></head><body>") ||
+        (plainText && !writeLiteral(output, "<p>"))) {
+      return false;
+    }
+
+    XhtmlSanitizer sanitizer{&output, &imageWriter, tagBuffer, tagBufferSize, chapterIndex, plainText};
+    bool firstChunk = true;
+    while (input.available()) {
+      const int got = input.read(readBuffer, readBufferSize);
+      if (got <= 0) return false;
+      int i = 0;
+      if (firstChunk && got >= 3 && readBuffer[0] == 0xEF && readBuffer[1] == 0xBB && readBuffer[2] == 0xBF) i = 3;
+      firstChunk = false;
+      for (; i < got;) {
+        if (!sanitizer.inTag && !sanitizer.inEntity && !sanitizer.skip && !sanitizer.skipHead) {
+          const size_t run =
+              WeReadProtocol::safeXhtmlTextRunLength(readBuffer + i, static_cast<size_t>(got - i), plainText);
+          if (run > 0) {
+            // A logical run spans input reads so a marker can never split a UTF-8 codepoint.
+            if ((!sanitizer.textRunOpen && !writeSourceOffsetMarker(sanitizer, sanitizer.sourceUtf16Offset)) ||
+                output.write(readBuffer + i, run) != run || !advanceSourceUtf16Offset(sanitizer, readBuffer + i, run)) {
+              return false;
+            }
+            sanitizer.textRunOpen = true;
+            i += static_cast<int>(run);
+            continue;
+          }
+        }
+        sanitizer.textRunOpen = false;
+        const uint8_t value = readBuffer[i++];
+        const uint32_t sourceOffset = sanitizer.sourceUtf16Offset;
+        if (!advanceSourceUtf16Offset(sanitizer, &value, 1)) return false;
+        if (!plainText && sanitizer.inTag) {
+          if (value == '>') {
+            if (!processTag(sanitizer)) return false;
+          } else if (sanitizer.tagLen + 1 < sanitizer.tagCapacity) {
+            sanitizer.tag[sanitizer.tagLen++] = static_cast<char>(value);
+          } else {
+            sanitizer.tagOverflow = true;
+          }
+          continue;
+        }
+        if (!plainText && value == '<') {
+          if (sanitizer.inEntity && !emitEntity(sanitizer)) return false;
+          sanitizer.inTag = true;
+          sanitizer.tagOverflow = false;
+          sanitizer.tagLen = 0;
+          sanitizer.tagSourceOffset = sourceOffset;
+          continue;
+        }
+        if (!emitSanitizedTextByte(sanitizer, value, sourceOffset)) return false;
+      }
+    }
+    if (sanitizer.inEntity && !emitEntity(sanitizer)) return false;
+    return writeSourceOffsetMarker(sanitizer, sanitizer.sourceUtf16Offset) &&
+           (!plainText || writeLiteral(output, "</p>")) && writeLiteral(output, "</body></html>");
+  }();
+  if (!written) {
+    imageWriter.abort();
+    output.close();
+    Storage.remove(partPath.c_str());
+    return false;
+  }
+  output.flush();
+  output.close();
+  if (!WeReadStore::atomicReplace(partPath, outputPath) || !imageWriter.finish()) {
+    Storage.remove(partPath.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool visibleToNativeOffset(const std::string& path, const uint32_t visibleOffset, uint32_t& nativeOffset) {
+  return resolveSourceOffset(path, SourceOffsetDirection::VisibleToNative, visibleOffset, nativeOffset);
+}
+
+bool nativeToVisibleOffset(const std::string& path, const uint32_t nativeOffset, uint32_t& visibleOffset) {
+  return resolveSourceOffset(path, SourceOffsetDirection::NativeToVisible, nativeOffset, visibleOffset);
+}
+
+}  // namespace WeReadXhtmlCodec
+
+#endif

--- a/lib/WeReadWebApi/src/WeReadXhtmlCodec.h
+++ b/lib/WeReadWebApi/src/WeReadXhtmlCodec.h
@@ -11,9 +11,9 @@ namespace WeReadXhtmlCodec {
 bool writeLiteral(HalFile& output, const char* text);
 bool writeXmlText(HalFile& output, const char* text);
 
-bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath,
-                     const std::string& imageIndexPath, uint32_t chapterIndex, const char* title, bool plainText,
-                     uint8_t* readBuffer, size_t readBufferSize, char* tagBuffer, size_t tagBufferSize);
+bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath, const std::string& imageIndexPath,
+                     uint32_t chapterIndex, const char* title, bool plainText, uint8_t* readBuffer,
+                     size_t readBufferSize, char* tagBuffer, size_t tagBufferSize);
 
 bool visibleToNativeOffset(const std::string& path, uint32_t visibleOffset, uint32_t& nativeOffset);
 bool nativeToVisibleOffset(const std::string& path, uint32_t nativeOffset, uint32_t& visibleOffset);

--- a/lib/WeReadWebApi/src/WeReadXhtmlCodec.h
+++ b/lib/WeReadWebApi/src/WeReadXhtmlCodec.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace WeReadXhtmlCodec {
+
+bool writeLiteral(HalFile& output, const char* text);
+bool writeXmlText(HalFile& output, const char* text);
+
+bool sanitizeChapter(const std::string& inputPath, const std::string& outputPath,
+                     const std::string& imageIndexPath, uint32_t chapterIndex, const char* title, bool plainText,
+                     uint8_t* readBuffer, size_t readBufferSize, char* tagBuffer, size_t tagBufferSize);
+
+bool visibleToNativeOffset(const std::string& path, uint32_t visibleOffset, uint32_t& nativeOffset);
+bool nativeToVisibleOffset(const std::string& path, uint32_t nativeOffset, uint32_t& visibleOffset);
+
+}  // namespace WeReadXhtmlCodec

--- a/src/activities/apps/weread/WeReadProgressContext.h
+++ b/src/activities/apps/weread/WeReadProgressContext.h
@@ -2,13 +2,16 @@
 
 #include <cstdint>
 
+#include "WeReadBackend.h"
+
 struct WeReadProgressContext {
   float localFraction = 0.0f;
   uint32_t localTocIndex = 0;
+  uint32_t localOffset = 0;
   uint16_t localSpineIndex = 0;
   uint16_t localPageNumber = 0;
   uint16_t localPageCount = 0;
-  bool hasLocalTocIndex = false;
+  WeReadBackend::Client::LocalOffsetBasis localOffsetBasis = WeReadBackend::Client::LocalOffsetBasis::None;
 };
 
-static_assert(sizeof(WeReadProgressContext) == 16);
+static_assert(sizeof(WeReadProgressContext) == 20);

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "CrossPointSettings.h"
@@ -23,6 +24,7 @@
 #include "ProgressMapper.h"
 #include "ReadingStatsStore.h"
 #include "SilentRestart.h"
+#include "WeReadXhtmlCodec.h"
 #include "activities/ActivityManager.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/reader/EpubReaderUtils.h"
@@ -43,25 +45,39 @@ WeReadProgressSyncActivity::WeReadProgressSyncActivity(GfxRenderer& renderer, Ma
   if (bookId) strncpy(bookId_, bookId, sizeof(bookId_) - 1);
   input_.localFraction = context.localFraction;
   input_.localTocIndex = context.localTocIndex;
-  input_.localSpineIndex = context.localSpineIndex;
-  input_.localPageNumber = context.localPageNumber;
-  input_.localPageCount = context.localPageCount;
-  input_.hasLocalTocIndex = context.hasLocalTocIndex;
+  input_.localOffset = context.localOffset;
+  input_.localOffsetBasis = context.localOffsetBasis;
+  localSpineIndex_ = context.localSpineIndex;
+  localPageNumber_ = context.localPageNumber;
+  localPageCount_ = context.localPageCount;
 }
 
 WeReadProgressContext WeReadProgressSyncActivity::makeContext(const Epub& epub, const char* bookId,
-                                                              const float localFraction, const uint16_t localSpineIndex,
-                                                              const uint16_t localPageNumber,
-                                                              const uint16_t localPageCount) {
+                                                              const float localFraction,
+                                                              const CrossPointPosition& localPosition) {
   WeReadProgressContext context;
   context.localFraction = localFraction;
-  context.localSpineIndex = localSpineIndex;
-  context.localPageNumber = localPageNumber;
-  context.localPageCount = localPageCount;
+  context.localSpineIndex = static_cast<uint16_t>(localPosition.spineIndex);
+  context.localPageNumber = static_cast<uint16_t>(localPosition.pageNumber);
+  context.localPageCount = static_cast<uint16_t>(localPosition.totalPages);
+  if (!localPosition.hasVisibleTextOffset) return context;
+
+  const std::string bookDir = WeReadStore::bookDirectory(bookId);
   WeReadStore::BookOptions options;
-  context.hasLocalTocIndex =
-      WeReadStore::loadBookOptions(WeReadStore::bookDirectory(bookId), options) &&
-      WeReadStore::parseGeneratedChapterHref(epub.getSpineItem(localSpineIndex).href, context.localTocIndex);
+  if (!WeReadStore::loadBookOptions(bookDir, options) ||
+      !WeReadStore::parseGeneratedChapterHref(epub.getSpineItem(localPosition.spineIndex).href,
+                                              context.localTocIndex)) {
+    return context;
+  }
+
+  context.localOffset = localPosition.visibleTextOffset;
+  context.localOffsetBasis = WeReadClient::LocalOffsetBasis::VisibleText;
+  uint32_t nativeOffset = 0;
+  if (WeReadXhtmlCodec::visibleToNativeOffset(WeReadStore::chapterPath(bookDir, context.localTocIndex),
+                                              context.localOffset, nativeOffset)) {
+    context.localOffset = nativeOffset;
+    context.localOffsetBasis = WeReadClient::LocalOffsetBasis::RawXhtmlUtf16;
+  }
   return context;
 }
 
@@ -263,17 +279,24 @@ void WeReadProgressSyncActivity::applyRemoteProgress(const WeReadProtocol::Remot
                   1000000.0f +
               0.5f));
   const CrossPointPosition target =
-      preciseRemote
-          ? ProgressMapper::fromSpineProgress(epubView, exactSpineIndex, chapterFraction, renderer,
-                                              input_.localSpineIndex, input_.localPageCount)
-          : ProgressMapper::toCrossPoint(epubView, fallback, renderer, input_.localSpineIndex, input_.localPageCount);
+      preciseRemote ? ProgressMapper::fromSpineProgress(epubView, exactSpineIndex, chapterFraction, renderer,
+                                                        localSpineIndex_, localPageCount_)
+                    : ProgressMapper::toCrossPoint(epubView, fallback, renderer, localSpineIndex_, localPageCount_);
   if (target.totalPages <= 0) {
     error_ = WeReadClient::Error::Unavailable;
     state_ = State::Failed;
     requestUpdate();
     return;
   }
-  if (!EpubReaderUtils::saveProgress(*uniqueEpub, target.spineIndex, target.pageNumber, target.totalPages)) {
+  std::optional<uint32_t> visibleTextOffset;
+  uint32_t resolvedVisibleOffset = 0;
+  if (preciseRemote && WeReadXhtmlCodec::nativeToVisibleOffset(
+                           WeReadStore::chapterPath(WeReadStore::bookDirectory(bookId_), remoteTocIndex),
+                           remoteProgress.chapterOffset, resolvedVisibleOffset)) {
+    visibleTextOffset = resolvedVisibleOffset;
+  }
+  if (!EpubReaderUtils::saveProgress(*uniqueEpub, target.spineIndex, target.pageNumber, target.totalPages,
+                                     visibleTextOffset)) {
     error_ = WeReadClient::Error::SdCard;
     state_ = State::Failed;
     requestUpdate();
@@ -427,8 +450,8 @@ void WeReadProgressSyncActivity::render(RenderLock&&) {
       char remoteValue[24];
       snprintf(remoteValue, sizeof(remoteValue), "%.2f%%", remoteFraction_ * 100.0f);
       char localValue[64];
-      snprintf(localValue, sizeof(localValue), tr(STR_PAGE_TOTAL_OVERALL_FORMAT), input_.localPageNumber + 1,
-               input_.localPageCount, input_.localFraction * 100.0f);
+      snprintf(localValue, sizeof(localValue), tr(STR_PAGE_TOTAL_OVERALL_FORMAT), localPageNumber_ + 1, localPageCount_,
+               input_.localFraction * 100.0f);
       const int remoteLabelY = contentTop + lineHeight * 2;
       UITheme::drawCenteredText(renderer, textBounds, UI_10_FONT_ID, remoteLabelY, tr(STR_REMOTE_LABEL), true,
                                 EpdFontFamily::BOLD);

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
@@ -8,6 +8,7 @@
 #include "activities/Activity.h"
 
 class Epub;
+struct CrossPointPosition;
 
 class WeReadProgressSyncActivity final : public Activity {
  public:
@@ -15,7 +16,7 @@ class WeReadProgressSyncActivity final : public Activity {
                              const char* bookId, WeReadProgressContext context);
 
   static WeReadProgressContext makeContext(const Epub& epub, const char* bookId, float localFraction,
-                                           uint16_t localSpineIndex, uint16_t localPageNumber, uint16_t localPageCount);
+                                           const CrossPointPosition& localPosition);
 
   void onEnter() override;
   void onExit() override;
@@ -48,6 +49,9 @@ class WeReadProgressSyncActivity final : public Activity {
   std::string epubPath_;
   char bookId_[64] = {};
   WeReadClient::ProgressSyncInput input_;
+  uint16_t localSpineIndex_ = 0;
+  uint16_t localPageNumber_ = 0;
+  uint16_t localPageCount_ = 0;
   float remoteFraction_ = 0.0f;
   bool uploadConflict_ = false;
   bool wifiActivated_ = false;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1030,6 +1030,7 @@ bool EpubReaderActivity::launchWeReadSync() {
   const float chapterFraction =
       totalPages > 1 ? static_cast<float>(currentPage) / static_cast<float>(totalPages - 1) : 0.0f;
   const float localFraction = epub->calculateProgress(currentSpineIndex, chapterFraction);
+  const CrossPointPosition localPosition = getCurrentPosition();
   std::string savedEpubPath = epub->getPath();
 
   if (!saveProgress(currentSpineIndex, currentPage, totalPages)) {
@@ -1039,9 +1040,7 @@ bool EpubReaderActivity::launchWeReadSync() {
     return true;
   }
 
-  const auto context = WeReadProgressSyncActivity::makeContext(
-      *epub, wereadBookId_, localFraction, static_cast<uint16_t>(currentSpineIndex), static_cast<uint16_t>(currentPage),
-      static_cast<uint16_t>(totalPages));
+  const auto context = WeReadProgressSyncActivity::makeContext(*epub, wereadBookId_, localFraction, localPosition);
   auto sync = makeUniqueNoThrow<WeReadProgressSyncActivity>(renderer, mappedInput, std::move(savedEpubPath),
                                                             wereadBookId_, context);
   if (!sync) {
@@ -1253,7 +1252,6 @@ void EpubReaderActivity::renderBook() {
     const bool cacheLoaded = section->loadSectionFile(renderSpec);
     if (cacheLoaded) {
       cachedChapterTotalPageCount = 0;
-      cachedVisibleTextOffset.reset();
     }
     const bool cacheComplete = cacheLoaded && !section->isPartial();
     const bool explicitOffsetJump = pendingOffsetJump.has_value();

--- a/test/weread_webapi/CMakeLists.txt
+++ b/test/weread_webapi/CMakeLists.txt
@@ -41,6 +41,10 @@ add_executable(WeReadStoreTest
   ${REPO_ROOT}/lib/WeReadWebApi/src/WeReadBrowse.cpp
   ${REPO_ROOT}/lib/WeReadWebApi/src/WeReadProtocol.cpp
   ${REPO_ROOT}/lib/WeReadWebApi/src/WeReadStore.cpp
+  ${REPO_ROOT}/lib/WeReadWebApi/src/WeReadXhtmlCodec.cpp
+  ${REPO_ROOT}/lib/expat/xmlparse.c
+  ${REPO_ROOT}/lib/expat/xmlrole.c
+  ${REPO_ROOT}/lib/expat/xmltok.c
   ${REPO_ROOT}/src/util/StringUtils.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
   ${crosspoint_simulator_SOURCE_DIR}/src/HalStorage.cpp
@@ -56,11 +60,14 @@ target_include_directories(WeReadStoreTest BEFORE PRIVATE
   ${REPO_ROOT}/lib/Memory
   ${REPO_ROOT}/lib/Serialization
   ${REPO_ROOT}/lib/Utf8
+  ${REPO_ROOT}/lib/expat
 )
 
 target_compile_definitions(WeReadStoreTest PRIVATE
   CROSSPOINT_EMULATED=1
   DESTRUCTOR_CLOSES_FILE=1
+  XML_CONTEXT_BYTES=1024
+  XML_GE=0
 )
 
 target_link_libraries(WeReadStoreTest PRIVATE

--- a/test/weread_webapi/WeReadProtocolTest.cpp
+++ b/test/weread_webapi/WeReadProtocolTest.cpp
@@ -47,6 +47,9 @@ struct OperationTestPeer {
   static bool shouldRetryPaidPreview(const bool paid, const bool plainText, const bool hasXhtmlTag) {
     return Operation::shouldRetryPaidPreview(paid, plainText, hasXhtmlTag);
   }
+  static bool reuseChapterFile(const bool refreshingBook, const bool chapterExists) {
+    return Operation::reuseChapterFile(refreshingBook, chapterExists);
+  }
   static bool imageAttemptPending(const uint8_t attempts) { return Operation::imageAttemptPending(attempts); }
   static bool imageRedirectAllowed(const uint8_t redirects) { return Operation::imageRedirectAllowed(redirects); }
   static bool validChapterRange(const uint32_t first, const uint32_t last, const uint32_t count) {
@@ -435,6 +438,14 @@ TEST(WeReadClientState, RetryableChapterResponsesNeverSignalCompletion) {
   EXPECT_FALSE(WeReadClient::OperationTestPeer::shouldRetryPaidPreview(false, false, false));
   EXPECT_FALSE(WeReadClient::OperationTestPeer::shouldRetryPaidPreview(true, true, false));
   EXPECT_FALSE(WeReadClient::OperationTestPeer::shouldRetryPaidPreview(true, false, true));
+}
+
+TEST(WeReadClientState, ReusesChaptersOnlyWhenResumingAnInitialDownload) {
+  const auto reuse = WeReadClient::OperationTestPeer::reuseChapterFile;
+  EXPECT_TRUE(reuse(false, true));
+  EXPECT_FALSE(reuse(false, false));
+  EXPECT_FALSE(reuse(true, true));
+  EXPECT_FALSE(reuse(true, false));
 }
 
 TEST(WeReadClientState, ExposesDetailBeforePendingCover) {

--- a/test/weread_webapi/WeReadStoreTest.cpp
+++ b/test/weread_webapi/WeReadStoreTest.cpp
@@ -1,4 +1,5 @@
 #include <ObfuscationUtils.h>
+#include <expat.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -15,6 +16,7 @@
 
 #include "WeReadBrowse.h"
 #include "WeReadStore.h"
+#include "WeReadXhtmlCodec.h"
 
 namespace obfuscation {
 
@@ -237,7 +239,7 @@ TEST_F(WeReadStoreTest, RejectsWrt1AndMapsProgressWithoutLoadingTheCatalog) {
   EXPECT_FALSE(WeReadStore::mapChapterToFraction(tocPath, "missing", 0, fraction));
 }
 
-TEST_F(WeReadStoreTest, MapsGeneratedChapterPagesWithoutWholeBookApproximation) {
+TEST_F(WeReadStoreTest, MapsGeneratedChapterVisibleOffsetsWithoutWholeBookApproximation) {
   ASSERT_TRUE(WeReadStore::ensureRoot());
   const std::string tocPath = WeReadStore::tocPath("precise-book");
   WeReadStore::IndexWriter writer;
@@ -255,26 +257,33 @@ TEST_F(WeReadStoreTest, MapsGeneratedChapterPagesWithoutWholeBookApproximation) 
   WeReadStore::TocRecord chapter;
   uint32_t offset = 0;
   float fraction = 0.0f;
-  ASSERT_TRUE(WeReadStore::mapPageToChapter(tocPath, 0, 1, 3, chapter, offset, fraction));
+  ASSERT_TRUE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 0, 50, chapter, offset, fraction));
   EXPECT_STREQ(chapter.chapterUid, "chapter-0");
   EXPECT_EQ(offset, 50U);
   EXPECT_FLOAT_EQ(fraction, 0.125f);
 
-  ASSERT_TRUE(WeReadStore::mapPageToChapter(tocPath, 2, 1, 3, chapter, offset, fraction));
+  ASSERT_TRUE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 2, 150, chapter, offset, fraction));
   EXPECT_STREQ(chapter.chapterUid, "chapter-2");
   EXPECT_EQ(offset, 150U);
   EXPECT_FLOAT_EQ(fraction, 0.625f);
 
-  ASSERT_TRUE(WeReadStore::mapPageToChapter(tocPath, 2, 0, 3, chapter, offset, fraction));
+  ASSERT_TRUE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 2, 0, chapter, offset, fraction));
   EXPECT_EQ(offset, 0U);
   EXPECT_FLOAT_EQ(fraction, 0.25f);
-  ASSERT_TRUE(WeReadStore::mapPageToChapter(tocPath, 2, 2, 3, chapter, offset, fraction));
+  ASSERT_TRUE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 2, 400, chapter, offset, fraction));
   EXPECT_EQ(offset, 300U);
   EXPECT_FLOAT_EQ(fraction, 1.0f);
 
-  EXPECT_FALSE(WeReadStore::mapPageToChapter(tocPath, 1, 0, 1, chapter, offset, fraction));
-  EXPECT_FALSE(WeReadStore::mapPageToChapter(tocPath, 3, 0, 1, chapter, offset, fraction));
-  EXPECT_FALSE(WeReadStore::mapPageToChapter(tocPath, 0, 3, 3, chapter, offset, fraction));
+  EXPECT_FALSE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 1, 0, chapter, offset, fraction));
+  EXPECT_FALSE(WeReadStore::mapVisibleOffsetToChapter(tocPath, 3, 0, chapter, offset, fraction));
+
+  ASSERT_TRUE(WeReadStore::mapNativeOffsetToChapter(tocPath, 0, 1234, chapter, offset));
+  EXPECT_STREQ(chapter.chapterUid, "chapter-0");
+  EXPECT_EQ(offset, 1234U);
+  ASSERT_TRUE(WeReadStore::mapNativeOffsetToChapter(tocPath, 1, 456, chapter, offset));
+  EXPECT_STREQ(chapter.chapterUid, "chapter-1");
+  EXPECT_EQ(offset, 456U);
+  EXPECT_FALSE(WeReadStore::mapNativeOffsetToChapter(tocPath, 3, 0, chapter, offset));
 
   uint32_t tocIndex = 0;
   float chapterFraction = 0.0f;
@@ -282,6 +291,114 @@ TEST_F(WeReadStoreTest, MapsGeneratedChapterPagesWithoutWholeBookApproximation) 
   EXPECT_EQ(tocIndex, 2U);
   EXPECT_NEAR(chapterFraction, 1.0f / 3.0f, 0.000001f);
   EXPECT_FLOAT_EQ(fraction, 0.5f);
+}
+
+TEST_F(WeReadStoreTest, MapsGeneratedVisibleOffsetsToRawXhtmlUtf16Coordinates) {
+  const std::string bookDir = WeReadStore::bookDirectory("source-offset-book");
+  ASSERT_TRUE(Storage.ensureDirectoryExists((bookDir + "/chapters").c_str()));
+  const std::string path = WeReadStore::chapterPath(bookDir, 0);
+  std::ofstream chapter(hostPath(path.c_str()), std::ios::binary);
+  ASSERT_TRUE(chapter.good());
+  // The first 15-byte marker starts at byte 123, crossing the resolver's
+  // 128-byte read boundary.
+  chapter << "\xEF\xBB\xBF<?xml version=\"1.0\"?><html><head><title>" << std::string(59, 'x')
+          << "</title></head><body>"
+             "<!--wr-co:10-->A中"
+             "<!--wr-co:20-->&amp;"
+             "<!--wr-co:25-->😀"
+             "<!--wr-co:30-->\r\nZ"
+             "<!--wr-co:33-->"
+             "<!--wr-co:40--><img src=\"image.png\"/>"
+             "<!--wr-co:50--></body></html>";
+  chapter.close();
+
+  struct Mapping {
+    uint32_t visible;
+    uint32_t native;
+  };
+  static constexpr Mapping kMappings[] = {{0, 10}, {1, 11}, {2, 20}, {3, 25}, {4, 30}, {5, 32}, {6, 50}};
+  for (const auto& mapping : kMappings) {
+    uint32_t native = 0;
+    ASSERT_TRUE(WeReadXhtmlCodec::visibleToNativeOffset(path, mapping.visible, native));
+    EXPECT_EQ(native, mapping.native) << "visible=" << mapping.visible;
+  }
+
+  static constexpr Mapping kReverseMappings[] = {
+      {0, 0},  {0, 10}, {1, 11}, {2, 12}, {2, 20}, {3, 25}, {3, 26},
+      {4, 30}, {5, 31}, {5, 32}, {6, 33}, {6, 40}, {6, 50},
+  };
+  for (const auto& mapping : kReverseMappings) {
+    uint32_t visible = UINT32_MAX;
+    ASSERT_TRUE(WeReadXhtmlCodec::nativeToVisibleOffset(path, mapping.native, visible));
+    EXPECT_EQ(visible, mapping.visible) << "native=" << mapping.native;
+  }
+  uint32_t rejected = 0;
+  EXPECT_FALSE(WeReadXhtmlCodec::visibleToNativeOffset(path, 7, rejected));
+  EXPECT_FALSE(WeReadXhtmlCodec::nativeToVisibleOffset(path, 51, rejected));
+}
+
+TEST_F(WeReadStoreTest, KeepsUtf8CodepointsIntactAcrossSanitizerReadBoundaries) {
+  const std::string bookDir = WeReadStore::bookDirectory("utf8-boundary-book");
+  ASSERT_TRUE(Storage.ensureDirectoryExists((bookDir + "/chapters").c_str()));
+  const std::string inputPath = bookDir + "/decoded.xhtml";
+  const std::string outputPath = WeReadStore::chapterPath(bookDir, 0);
+  const std::string imageIndexPath = WeReadStore::imageIndexPath(bookDir, 0);
+
+  std::string input = "<p>";
+  input.append(508, 'a');
+  input += "中";  // Lead byte is the last byte of the first 512-byte read.
+  input.append(1022 - input.size(), 'b');
+  input += "😀";  // Two bytes land on each side of the next read boundary.
+  input += "c</p>";
+  {
+    std::ofstream source(hostPath(inputPath.c_str()), std::ios::binary);
+    ASSERT_TRUE(source.good());
+    source.write(input.data(), static_cast<std::streamsize>(input.size()));
+  }
+
+  std::array<uint8_t, 512> readBuffer{};
+  std::array<char, 4096> tagBuffer{};
+  ASSERT_TRUE(WeReadXhtmlCodec::sanitizeChapter(inputPath, outputPath, imageIndexPath, 0, "Boundary", false,
+                                                readBuffer.data(), readBuffer.size(), tagBuffer.data(),
+                                                tagBuffer.size()));
+
+  std::ifstream generated(hostPath(outputPath.c_str()), std::ios::binary);
+  ASSERT_TRUE(generated.good());
+  const std::string xhtml((std::istreambuf_iterator<char>(generated)), std::istreambuf_iterator<char>());
+  XML_Parser parser = XML_ParserCreate(nullptr);
+  ASSERT_NE(parser, nullptr);
+  const XML_Status status = XML_Parse(parser, xhtml.data(), static_cast<int>(xhtml.size()), XML_TRUE);
+  EXPECT_EQ(status, XML_STATUS_OK) << XML_ErrorString(XML_GetErrorCode(parser));
+  XML_ParserFree(parser);
+
+  uint32_t nativeOffset = 0;
+  EXPECT_TRUE(WeReadXhtmlCodec::visibleToNativeOffset(outputPath, 508, nativeOffset));
+  EXPECT_EQ(nativeOffset, 511U);
+  EXPECT_TRUE(WeReadXhtmlCodec::visibleToNativeOffset(outputPath, 1017, nativeOffset));
+  EXPECT_EQ(nativeOffset, 1020U);
+  EXPECT_TRUE(WeReadXhtmlCodec::visibleToNativeOffset(outputPath, 1018, nativeOffset));
+  EXPECT_EQ(nativeOffset, 1022U);
+
+  uint32_t visibleOffset = 0;
+  EXPECT_TRUE(WeReadXhtmlCodec::nativeToVisibleOffset(outputPath, 1021, visibleOffset));
+  EXPECT_EQ(visibleOffset, 1017U);
+}
+
+TEST_F(WeReadStoreTest, RejectsMissingAndMalformedSourceOffsetMarkers) {
+  const std::string bookDir = WeReadStore::bookDirectory("bad-source-offset-book");
+  ASSERT_TRUE(Storage.ensureDirectoryExists((bookDir + "/chapters").c_str()));
+  const std::string path = WeReadStore::chapterPath(bookDir, 0);
+  uint32_t output = 0;
+  const auto reject = [&](const char* xhtml, const uint32_t visibleOffset) {
+    {
+      std::ofstream chapter(hostPath(path.c_str()), std::ios::binary | std::ios::trunc);
+      chapter << xhtml;
+    }
+    EXPECT_FALSE(WeReadXhtmlCodec::visibleToNativeOffset(path, visibleOffset, output));
+  };
+  reject("<html><body>text</body></html>", 0);
+  reject("<html><body><!--wr-co:bad-->text</body></html>", 0);
+  reject("<html><body><!--wr-co:20-->a<!--wr-co:10-->b</body></html>", 0);
 }
 
 TEST(WeReadStore, ParsesOnlyGeneratedChapterHrefs) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the existing WeRead progress sync reliable and position uploads/downloads at the same text location when native chapter coordinates are available.
* **What changes are included?**
  * Keep valid saved sessions and renew only after an authentication failure.
  * Upload native raw-XHTML UTF-16 `chapterOffset` values, convert downloaded offsets back to visible-text coordinates, and retain visible-text/fraction fallbacks for older or non-standard books.
  * Generate `wr-co` anchors without splitting UTF-8 codepoints and centralize XHTML sanitizing plus bidirectional coordinate conversion in `WeReadXhtmlCodec`.
  * Preserve the existing Cookie, EPUB marker, pagination cache, and 10-byte `progress.bin` formats while simplifying the coordinate basis state.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this repairs the existing WeRead implementation rather than adding a connector).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Host validation: 83/83 WeRead tests passed; clang-format and `git diff --check` passed.
* Firmware validation: `pio run -e gh_release_cn` passed.
* Resource impact: Flash `5,877,121 -> 5,877,683` bytes (+562 B); static RAM remains `55,724` bytes.
* Layout impact: `ProgressSyncInput` remains 16 B; `WeReadProgressContext` drops from 24 B to 20 B; Operation and sync Activity sizes are unchanged.
* Compatibility: older cached books without anchors continue through the visible-text or whole-book fraction fallback; they are not automatically redownloaded.
* Remaining device gates: consecutive sync without proactive renewal, re-cache without invalid XHTML, raw `chapterUid/co` read-back equality, same-text positioning, and legacy fallback behavior. Keep this PR Draft until those checks pass.

---

### AI Usage

Did you use AI tools to help write this code? **YES**