### PR TITLE
chore(release): prepare 1.5.7

### DIFF
--- a/.github/release-notes/1.5.7.md
+++ b/.github/release-notes/1.5.7.md
@@ -1,0 +1,30 @@
+CrossMux 1.5.7 syncs upstream reader and interface changes while improving WeRead progress sync, OTA low-memory recovery, AirPage updates, and sleep-screen handling.
+
+## Reader and interface
+
+- Adopt upstream FreeInkUI lists and tabs plus the unified reader architecture through `develop` commit `eef20504`, while preserving CrossMux themes, apps, Chinese firmware, and release behavior.
+- Add extra-wide line spacing, improve EPUB image and dark-mode rendering, support StarDict synonyms and HTML definitions, and speed up CJK text and list rendering.
+- Add build support for X4 Pro and PaperMono. These devices are not included in stable release assets or OTA selection.
+
+## Sync and reliability
+
+- Keep valid WeRead sessions, use native chapter coordinates for more accurate progress sync when available, and retain visible-text and book-fraction fallbacks for older cached books.
+- Avoid splitting UTF-8 text while generating WeRead anchors without changing cookies, completed EPUBs, pagination caches, or the existing progress file format.
+- Release dynamic lists and render caches before OTA TLS handshakes, stop automatic SNTP from competing for network heap, and improve OTA note pagination and the Wi-Fi scan header.
+- Keep the current AirPage image visible during updates, restore transparent sleep overlays and the INX file-list font size, and retain opaque white pixels in sleep images.
+
+## Upgrade notes
+
+- Existing books, reading progress, settings, and downloaded WeRead EPUBs are preserved.
+- EPUB book cache version remains 11. Section caches advance to version 56 for international builds and 57 for Chinese builds, causing a one-time pagination cache rebuild.
+- TXT page indexes remain version 7. WeRead cookie and progress file formats remain unchanged, and older cached books keep their compatibility fallbacks.
+
+> **WeRead security notice:** WeRead uses an unofficial Web protocol that may change without notice. Device traffic is encrypted with wolfSSL, but the current client does not verify the server CA or host identity. Use WeRead only on a trusted network.
+
+## Firmware assets
+
+- `firmware.bin` — international firmware
+- `firmware-cn.bin` — Simplified Chinese firmware
+- `bootloader.bin` and `partitions.bin` — complete web/USB flashing support
+
+**Full Changelog**: https://github.com/0x1abin/crossmux/compare/1.5.6...1.5.7

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **CrossMux** is a community fork of [CrossPoint Reader](https://github.com/crosspoint-reader/crosspoint-reader) that turns the device into more than a reader — it adds an Apps hub of mini-games and tools, richer standby faces, and a first-class Simplified Chinese build.
 
-**Version:** CrossMux 1.5.6 (based on CrossPoint Reader 1.5.0 plus upstream `develop` through `596f0d3f`)
+**Version:** CrossMux 1.5.7 (based on CrossPoint Reader 1.5.0 plus upstream `develop` through `eef20504`)
 
 **Now running on:** ESP32C3-based Xteink [X4](https://www.xteink.com/products/xteink-x4) and [X3](https://www.xteink.com/products/xteink-x3).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 **CrossMux** 是 [CrossPoint Reader](https://github.com/crosspoint-reader/crosspoint-reader) 的社区 fork：在原有电子书阅读体验之上，新增了一个 Apps 应用中心（小游戏 / 小工具）、更丰富的待机表盘，以及一套完整的简体中文固件。
 
-**版本：** CrossMux 1.5.6（基于 CrossPoint Reader 1.5.0，并同步上游 `develop` 至 `596f0d3f`）
+**版本：** CrossMux 1.5.7（基于 CrossPoint Reader 1.5.0，并同步上游 `develop` 至 `eef20504`）
 
 **运行设备：** 基于 ESP32-C3 的 Xteink [X4](https://www.xteink.com/products/xteink-x4) 与 [X3](https://www.xteink.com/products/xteink-x3)。
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.5.6
+version = 1.5.7
 
 [crossmux]
 global_host = crossmux.com


### PR DESCRIPTION
## Summary

- bump CrossMux to 1.5.7 and record the upstream sync point at `eef20504`
- add curated 1.5.7 release notes, including cache migration and supported asset scope
- keep release workflows, APIs, dependencies, and binary formats unchanged

## Local validation

- OTA notes generator self-test and planned EN/ZH marker validation
- `git diff --check`
- `./bin/clang-format-fix -g --check`
- host tests: 376/376 passed
- `pio run -e gh_release -j 1` (RAM 17.0%, Flash 94.5%)
- clean `pio run -e gh_release_cn -j 1` (RAM 17.0%, Flash 89.7%)

## Hardware acceptance

Not claimed by this PR. X3/X4 WeRead same-page behavior, INX visuals, and OTA on-device regression remain separate physical-device checks.