### PR TITLE
feat: include device model in OTA checks

### DIFF
--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -1,5 +1,7 @@
 #include "HalSystem.h"
 
+#include <BoardConfig.h>
+
 #include <string>
 
 #include "Arduino.h"
@@ -130,6 +132,8 @@ void clearPanic() {
   }
   clearLastLogs();
 }
+
+const char* getDeviceModel() { return BoardConfig::ACTIVE.name; }
 
 bool getDeviceId(DeviceId& out) {
   out.fill(0);

--- a/lib/hal/HalSystem.h
+++ b/lib/hal/HalSystem.h
@@ -23,6 +23,7 @@ void checkPanic();
 void clearPanic();
 
 using DeviceId = std::array<uint8_t, 6>;
+const char* getDeviceModel();
 bool getDeviceId(DeviceId& out);
 bool getWifiStationMac(DeviceId& out);
 bool getChipTemperatureCelsius(float& out);

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -5,6 +5,7 @@
 // ip4_addr.h unless seen first. Pin this order; clang-format would otherwise sort
 // the local header last and break the build.
 #include "HttpDownloader.h"
+#include <HalSystem.h>
 #include <Logging.h>
 #include <ReleaseJsonParser.h>
 #include <esp_ota_ops.h>
@@ -12,6 +13,7 @@
 // clang-format on
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <string>
 #include <string_view>
@@ -63,11 +65,21 @@ constexpr char nightlyReleaseUrl[] =
 #else
     "https://" CROSSMUX_HOST "/api/ota/manifest?variant=global&channel=nightly";
 #endif
+constexpr size_t deviceModelLengthMax = 32;
+constexpr size_t releaseUrlCapacity = sizeof(nightlyReleaseUrl) + sizeof("&model=") + deviceModelLengthMax;
+static_assert(releaseUrlCapacity < 256);
 }  // namespace
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate(const Channel requestedChannel) {
   channel = requestedChannel;
-  const char* releaseUrl = channel == Channel::Nightly ? nightlyReleaseUrl : latestReleaseUrl;
+  const char* releaseUrlBase = channel == Channel::Nightly ? nightlyReleaseUrl : latestReleaseUrl;
+  char releaseUrl[releaseUrlCapacity];
+  const int releaseUrlLength =
+      snprintf(releaseUrl, sizeof(releaseUrl), "%s&model=%s", releaseUrlBase, HalSystem::getDeviceModel());
+  if (releaseUrlLength < 0 || static_cast<size_t>(releaseUrlLength) >= sizeof(releaseUrl)) {
+    LOG_ERR("OTA", "Release URL exceeds %zu bytes", sizeof(releaseUrl));
+    return INTERNAL_UPDATE_ERROR;
+  }
   LOG_DBG("OTA", "Checking %s channel (current: %s)", channel == Channel::Nightly ? "nightly" : "stable",
           CROSSPOINT_VERSION);
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Include the active hardware model in OTA manifest checks so the backend can identify multi-device requests.
* **What changes are included?**
  - expose `BoardConfig::ACTIVE.name` through `HalSystem::getDeviceModel()`
  - append `model=<device>` to stable and nightly OTA URLs
  - build the URL in a fixed stack buffer and return an internal error if `snprintf` reports truncation
  - leave touch-device button hints unchanged because existing theme/settings code already hides them on touch hardware

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/main/SCOPE.md) and [ROADMAP.md](../blob/main/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this multi-device OTA identification requirement well.
- [x] The relevant maintainer requested and coordinated this OTA/HAL change.

## Testing

- [x] `./bin/ci-check`
  - formatting and cppcheck
  - 7 supported firmware targets
  - 393 host tests

## Additional Context

* No heap allocation is added; the request URL uses a fixed stack buffer under 256 bytes.
* Valid OTA responses and firmware asset selection remain unchanged.
* The companion Web PR must merge and deploy first: https://github.com/0x1abin/crossmux-web/pull/50
* Draft pending hardware verification:
  - [ ] Confirm X3/X4 and one touch-device OTA request URL in logs.
  - [ ] Confirm the legacy URL without `model` still returns the existing firmware.
  - [ ] Confirm touch devices hide bottom hints/settings and X3/X4 keep their existing defaults.

---

### AI Usage

Did you use AI tools to help write this code? **YES**