### PR TITLE
fix: complete touch interaction coverage

### DIFF
--- a/src/activities/apps/README.md
+++ b/src/activities/apps/README.md
@@ -184,6 +184,8 @@ mode needs Wi-Fi. Network-dependent apps use the shared Wi-Fi picker on demand;
 cancelling it leaves the app on its current screen so the user can retry.
 Its mapped bottom actions are Back, Settings, Images, and Refresh; logical
 previous/next also map the side buttons to Images/Refresh in every orientation.
+Touch devices render those QR-page actions as a tappable footer, and tapping a
+full-screen image opens the same actions plus Set Cover in a modal menu.
 Connecting or reconnecting never downloads an image by itself; only Refresh or
 a live MQTT push starts a download.
 Settings uses the standard themed list for manual/live mode and the optional

--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -18,12 +18,15 @@
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
 #include "util/QrUtils.h"
 #include "util/TimeUtils.h"
 
 namespace {
+
+namespace fui = freeink::ui;
 
 constexpr char kAirPageBase[] = "airpage." CROSSMUX_HOST;
 constexpr uint32_t kWallpaperNoticeDurationMs = 1000u;
@@ -63,6 +66,10 @@ bool formatArchiveDate(const uint64_t archiveId, char* buffer, const size_t buff
 
 void AirPageActivity::onEnter() {
   Activity::onEnter();
+
+  resetUi();
+  app.on(ACTION_TOUCH, &AirPageActivity::onTouchAction, this);
+  app.setScreen(&AirPageActivity::touchScreen, this);
 
   phase_ = Phase::Idle;
   screen_ = Screen::Qr;
@@ -159,13 +166,13 @@ bool AirPageActivity::processImageDisplayResult() {
       switch (imageStore_.rejectDisplayedImage(selectedImage_)) {
         case airpage::AirPageImageStore::RejectResult::CurrentRestored:
         case airpage::AirPageImageStore::RejectResult::CurrentInvalid:
-          screen_ = Screen::Qr;
+          setAirPageScreen(Screen::Qr);
           break;
         case airpage::AirPageImageStore::RejectResult::HistoryInvalid:
           if (historySelection_ >= static_cast<int>(imageStore_.historyCount())) {
             historySelection_ = imageStore_.historyCount() == 0 ? 0 : static_cast<int>(imageStore_.historyCount() - 1);
           }
-          screen_ = Screen::History;
+          setAirPageScreen(Screen::History);
           break;
       }
       notice_ = Notice::InvalidImage;
@@ -185,19 +192,19 @@ void AirPageActivity::applyConnectionEvent(const airpage::AirPageConnection::Eve
       break;
     case airpage::AirPageConnection::Event::WifiRequired:
       notice_ = Notice::WifiRequired;
-      screen_ = Screen::Qr;
+      setAirPageScreen(Screen::Qr);
       break;
     case airpage::AirPageConnection::Event::WifiFailed:
       notice_ = Notice::WifiFailed;
-      screen_ = Screen::Qr;
+      setAirPageScreen(Screen::Qr);
       break;
     case airpage::AirPageConnection::Event::RealtimeRetrying:
       notice_ = Notice::RealtimeRetrying;
-      screen_ = Screen::Qr;
+      setAirPageScreen(Screen::Qr);
       break;
     case airpage::AirPageConnection::Event::RealtimePaused:
       notice_ = Notice::RealtimePaused;
-      screen_ = Screen::Qr;
+      setAirPageScreen(Screen::Qr);
       break;
     case airpage::AirPageConnection::Event::PushRequested:
       queueFetch();
@@ -228,6 +235,21 @@ void AirPageActivity::loop() {
   if (processImageDisplayResult()) return;
   if (consumeInputReleaseBarrier()) return;
 
+  if (imageMenu_.handleInput(mappedInput, [this] { requestUpdate(); })) {
+    if (!imageMenu_.isActive()) {
+      closeRouting();
+      imageNeedsDisplay_ = true;
+      requestUpdate();
+    }
+    return;
+  }
+
+  if (phase_ == Phase::Idle && (screen_ == Screen::Qr || screen_ == Screen::Image)) {
+    const auto touch = routeTouch(mappedInput);
+    if (touch.routed && app.invalidated()) requestUpdate();
+    if (touch) return;
+  }
+
   switch (screen_) {
     case Screen::Qr:
       if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
@@ -251,7 +273,7 @@ void AirPageActivity::loop() {
     case Screen::Settings: {
       if (mappedInput.wasAnyReleased() && notice_ == Notice::SettingsSaveFailed) notice_ = Notice::None;
       if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-        screen_ = Screen::Qr;
+        setAirPageScreen(Screen::Qr);
         requestUpdate();
         return;
       }
@@ -286,7 +308,7 @@ void AirPageActivity::loop() {
     case Screen::History: {
       if (mappedInput.wasAnyReleased() && notice_ == Notice::InvalidImage) notice_ = Notice::None;
       if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-        screen_ = Screen::Qr;
+        setAirPageScreen(Screen::Qr);
         requestUpdate();
         return;
       }
@@ -322,7 +344,7 @@ void AirPageActivity::loop() {
     case Screen::Image:
       if (mappedInput.wasAnyReleased()) wallpaperResult_ = WallpaperResult::None;
       if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-        screen_ = Screen::Qr;
+        setAirPageScreen(Screen::Qr);
         requestUpdate();
         return;
       }
@@ -343,9 +365,95 @@ void AirPageActivity::loop() {
   applyConnectionEvent(connection_.pump(phase_ == Phase::Idle && screen_ != Screen::Settings));
 }
 
+void AirPageActivity::setAirPageScreen(const Screen screen) {
+  if (screen_ == screen) return;
+  closeRouting();
+  screen_ = screen;
+}
+
+void AirPageActivity::touchScreen(UiScreen& screen, void* user) {
+  static_cast<AirPageActivity*>(user)->buildTouchScreen(screen);
+}
+
+void AirPageActivity::buildTouchScreen(UiScreen& screen) {
+  if (!mappedInput.hasTouch() || phase_ != Phase::Idle || wallpaperResult_ != WallpaperResult::None) return;
+
+  switch (screen_) {
+    case Screen::Qr: {
+      const fui::FooterAction actions[] = {
+          {tr(STR_BACK), ACTION_TOUCH, static_cast<int16_t>(TouchAction::BackToApps)},
+          {tr(STR_AIRPAGE_SETTINGS_ACTION), ACTION_TOUCH, static_cast<int16_t>(TouchAction::Settings)},
+          {tr(STR_AIRPAGE_IMAGES_ACTION), ACTION_TOUCH, static_cast<int16_t>(TouchAction::Images)},
+          {refreshActionText(), ACTION_TOUCH, static_cast<int16_t>(TouchAction::Refresh)},
+      };
+      screen.footer(actions, 4);
+      return;
+    }
+    case Screen::Image: {
+      const fui::TapZone zone{screen.frame().screen(), ACTION_TOUCH, static_cast<int16_t>(TouchAction::OpenImageMenu)};
+      fui::TapZonesProps props;
+      props.zones = &zone;
+      props.count = 1;
+      fui::tapZones(screen.frame(), screen.frame().screen(), props);
+      return;
+    }
+    case Screen::Settings:
+    case Screen::History:
+      return;
+  }
+}
+
+void AirPageActivity::onTouchAction(const fui::ActionEvent& event, void* user) {
+  auto* self = static_cast<AirPageActivity*>(user);
+  self->app.clearTapFlash();
+  self->applyTouchAction(static_cast<TouchAction>(event.value));
+}
+
+void AirPageActivity::applyTouchAction(const TouchAction action) {
+  switch (action) {
+    case TouchAction::BackToApps:
+      activityManager.goToApps();
+      return;
+    case TouchAction::ShowQr:
+      setAirPageScreen(Screen::Qr);
+      requestUpdate();
+      return;
+    case TouchAction::Settings:
+      openSettings();
+      return;
+    case TouchAction::Images:
+      openHistory();
+      return;
+    case TouchAction::Refresh:
+      handleRefresh();
+      return;
+    case TouchAction::SetWallpaper:
+      openWallpaperConfirmation();
+      return;
+    case TouchAction::OpenImageMenu:
+      openImageMenu();
+      return;
+  }
+}
+
+void AirPageActivity::openImageMenu() {
+  if (phase_ != Phase::Idle || screen_ != Screen::Image || selectedImage_.path[0] == '\0') return;
+  static constexpr int OPTION_COUNT = 5;
+  static constexpr TouchAction ACTIONS[OPTION_COUNT] = {TouchAction::ShowQr, TouchAction::Settings, TouchAction::Images,
+                                                        TouchAction::Refresh, TouchAction::SetWallpaper};
+  const char* options[OPTION_COUNT] = {tr(STR_DISPLAY_QR), tr(STR_AIRPAGE_SETTINGS_ACTION),
+                                       tr(STR_AIRPAGE_IMAGES_ACTION), refreshActionText(), tr(STR_SET_SLEEP_COVER)};
+  imageMenu_.show(tr(STR_AIRPAGE_TITLE), options, OPTION_COUNT, 0, [this](const int index) {
+    if (index < 0 || index >= OPTION_COUNT) return;
+    applyTouchAction(ACTIONS[index]);
+  });
+  closeRouting();
+  requestUpdate();
+}
+
 void AirPageActivity::openSettings() {
   if (phase_ != Phase::Idle) return;
-  screen_ = Screen::Settings;
+  setAirPageScreen(Screen::Settings);
   settingsSelection_ = 0;
   requestUpdate();
 }
@@ -388,7 +496,7 @@ void AirPageActivity::applySettingsSelection() {
 void AirPageActivity::openHistory() {
   if (phase_ != Phase::Idle) return;
   historySelection_ = 0;
-  screen_ = Screen::History;
+  setAirPageScreen(Screen::History);
   requestUpdate();
 }
 
@@ -402,7 +510,7 @@ void AirPageActivity::openSelectedHistoryImage() {
     return;
   }
   wallpaperResult_ = WallpaperResult::None;
-  screen_ = Screen::Image;
+  setAirPageScreen(Screen::Image);
   imageNeedsDisplay_ = true;
   requestUpdate();
 }
@@ -457,6 +565,7 @@ void AirPageActivity::handleRefresh() {
 
 void AirPageActivity::queueFetch() {
   if (phase_ != Phase::Idle || screen_ == Screen::Settings) return;
+  closeRouting();
   phase_ = Phase::FetchRequested;
   requestUpdate();
 }
@@ -466,7 +575,7 @@ void AirPageActivity::openWifiSelection(const bool fetchAfterConnect) {
   if (!wifi) {
     LOG_ERR("AIRP", "OOM: WifiSelectionActivity (%u bytes)", static_cast<unsigned>(sizeof(WifiSelectionActivity)));
     notice_ = Notice::WifiFailed;
-    screen_ = Screen::Qr;
+    setAirPageScreen(Screen::Qr);
     requestUpdate();
     return;
   }
@@ -515,7 +624,7 @@ void AirPageActivity::doFetch() {
 
   if (!imageStore_.ensureDirectories()) {
     notice_ = Notice::DownloadFailed;
-    screen_ = Screen::Qr;
+    setAirPageScreen(Screen::Qr);
     return;
   }
 
@@ -527,20 +636,20 @@ void AirPageActivity::doFetch() {
   if (error != HttpDownloader::OK) {
     LOG_ERR("AIRP", "Download failed: %d", static_cast<int>(error));
     notice_ = Notice::DownloadFailed;
-    screen_ = Screen::Qr;
+    setAirPageScreen(Screen::Qr);
     return;
   }
 
   switch (imageStore_.stageDownloadedImage(currentArchiveDateKey())) {
     case airpage::AirPageImageStore::StageResult::Failed:
       notice_ = Notice::DownloadFailed;
-      screen_ = Screen::Qr;
+      setAirPageScreen(Screen::Qr);
       return;
 
     case airpage::AirPageImageStore::StageResult::Unchanged:
       airpage::AirPageImageRenderer::resetSessionFailures();
       imageStore_.selectCurrent(selectedImage_);
-      screen_ = Screen::Image;
+      setAirPageScreen(Screen::Image);
       imageNeedsDisplay_ = true;
       notice_ = Notice::None;
       LOG_INF("AIRP", "Fetched image is unchanged");
@@ -551,7 +660,7 @@ void AirPageActivity::doFetch() {
       imageStore_.selectCurrent(selectedImage_);
       imageNeedsDisplay_ = true;
       notice_ = Notice::None;
-      screen_ = Screen::Image;
+      setAirPageScreen(Screen::Image);
       LOG_INF("AIRP", "Fetched latest image; awaiting display validation");
       return;
   }
@@ -561,7 +670,10 @@ Rect AirPageActivity::contentViewport() const {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safeArea = UITheme::getInstance().getScreenSafeArea(renderer, true, true);
   const int contentTop = safeArea.y + metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
-  const int contentHeight = safeArea.height - metrics.topPadding - metrics.headerHeight - metrics.verticalSpacing * 2;
+  int contentHeight = safeArea.height - metrics.topPadding - metrics.headerHeight - metrics.verticalSpacing * 2;
+  if (mappedInput.hasTouch() && screen_ == Screen::Qr) {
+    contentHeight = std::max(0, contentHeight - app.theme().footerHeight - metrics.verticalSpacing);
+  }
   return Rect{safeArea.x, contentTop, safeArea.width, contentHeight};
 }
 
@@ -584,6 +696,8 @@ void AirPageActivity::render(RenderLock&&) {
     return;
   }
 
+  if (imageMenu_.processRender(renderer, mappedInput)) return;
+
   if (screen_ == Screen::Image && phase_ == Phase::Idle) {
     const bool screenSizeChanged =
         displayedScreenWidth_ != fullScreen.width || displayedScreenHeight_ != fullScreen.height;
@@ -600,6 +714,7 @@ void AirPageActivity::render(RenderLock&&) {
           renderer.displayBuffer(HalDisplay::FAST_REFRESH);
         }
         imageDisplayResult_.store(ImageDisplayResult::Success, std::memory_order_release);
+        if (mappedInput.hasTouch()) renderUi();
       } else {
         imageDisplayResult_.store(ImageDisplayResult::Failure, std::memory_order_release);
       }
@@ -612,6 +727,7 @@ void AirPageActivity::render(RenderLock&&) {
       GUI.drawPopup(renderer, message);
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);
     }
+    if (mappedInput.hasTouch()) renderUi();
     return;
   }
 
@@ -666,6 +782,8 @@ void AirPageActivity::render(RenderLock&&) {
     case Screen::Image:
       break;
   }
+
+  if (mappedInput.hasTouch()) renderUi();
 
   renderer.displayBuffer();
   imageNeedsDisplay_ = true;

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -7,13 +7,15 @@
 #include "../../Activity.h"
 #include "AirPageConnection.h"
 #include "AirPageImageStore.h"
+#include "components/OptionPopup.h"
+#include "components/UiAppHost.h"
 
 struct Rect;
 
-class AirPageActivity final : public Activity {
+class AirPageActivity final : public Activity, private UiAppHost {
  public:
   explicit AirPageActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("AirPage", renderer, mappedInput), connection_(renderer) {}
+      : Activity("AirPage", renderer, mappedInput), UiAppHost(renderer), connection_(renderer) {}
 
   void onEnter() override;
   void onExit() override;
@@ -39,6 +41,15 @@ class AirPageActivity final : public Activity {
   enum class SettingRow : uint8_t { Mode, AutoWallpaper, Count };
   enum class WallpaperResult : uint8_t { None, Saved, Failed };
   enum class ImageDisplayResult : uint8_t { None, Success, Failure };
+  enum class TouchAction : int16_t {
+    BackToApps,
+    ShowQr,
+    Settings,
+    Images,
+    Refresh,
+    SetWallpaper,
+    OpenImageMenu,
+  };
 
   bool processImageDisplayResult();
   void applyConnectionEvent(airpage::AirPageConnection::Event event);
@@ -56,6 +67,14 @@ class AirPageActivity final : public Activity {
   void openWifiSelection(bool fetchAfterConnect);
   void handleWifiResult(const ActivityResult& result, bool fetchAfterConnect);
   bool consumeInputReleaseBarrier();
+  void setAirPageScreen(Screen screen);
+  void openImageMenu();
+  void applyTouchAction(TouchAction action);
+
+  static constexpr freeink::ui::ActionId ACTION_TOUCH = 1;
+  static void touchScreen(UiScreen& screen, void* user);
+  static void onTouchAction(const freeink::ui::ActionEvent& event, void* user);
+  void buildTouchScreen(UiScreen& screen);
 
   void renderQr(const Rect& viewport);
   void renderStatus(const Rect& viewport, const char* msg);
@@ -78,6 +97,7 @@ class AirPageActivity final : public Activity {
   airpage::AirPageImageStore imageStore_;
   airpage::AirPageConnection connection_;
   airpage::SelectedImage selectedImage_;
+  OptionPopup imageMenu_;
 
   bool imageNeedsDisplay_ = true;
   bool waitForInputRelease_ = false;

--- a/src/activities/settings/DateTimeSettingsActivity.cpp
+++ b/src/activities/settings/DateTimeSettingsActivity.cpp
@@ -15,8 +15,11 @@
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 #include "util/TimeUtils.h"
+
+namespace fui = freeink::ui;
 
 namespace {
 
@@ -41,6 +44,11 @@ std::string twoDigits(const unsigned value) {
 
 void DateTimeSettingsActivity::onEnter() {
   Activity::onEnter();
+  resetUi();
+  app.on(ACTION_STEP, &DateTimeSettingsActivity::onStep, this);
+  app.on(ACTION_CANCEL, &DateTimeSettingsActivity::onCancel, this);
+  app.on(ACTION_OK, &DateTimeSettingsActivity::onOk, this);
+  app.setScreen(&DateTimeSettingsActivity::manualScreen, this);
   if (SETTINGS.clockUtcOffsetQ > 104) SETTINGS.clockUtcOffsetQ = 48;
   if (SETTINGS.clockFormat > 1) SETTINGS.clockFormat = 0;
   if (SETTINGS.clockAutoSync > 1) SETTINGS.clockAutoSync = 1;
@@ -159,21 +167,22 @@ void DateTimeSettingsActivity::beginManualEdit() {
     minute = 0;
   }
   selectedEditField = 0;
+  closeRouting();
   mode = Mode::ManualEdit;
   requestUpdate();
 }
 
 void DateTimeSettingsActivity::loopManualEdit() {
+  const auto touch = routeTouch(mappedInput);
+  if (touch.routed && app.invalidated()) requestUpdate();
+  if (touch) return;
+
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    mode = Mode::Menu;
-    requestUpdate();
+    cancelManualEdit();
     return;
   }
   if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-    if (applyManualTime()) {
-      mode = Mode::Menu;
-      requestUpdate();
-    }
+    confirmManualEdit();
     return;
   }
 
@@ -223,6 +232,77 @@ bool DateTimeSettingsActivity::applyManualTime() {
     return false;
   }
   return true;
+}
+
+void DateTimeSettingsActivity::cancelManualEdit() {
+  closeRouting();
+  mode = Mode::Menu;
+  requestUpdate();
+}
+
+void DateTimeSettingsActivity::confirmManualEdit() {
+  if (!applyManualTime()) return;
+  closeRouting();
+  mode = Mode::Menu;
+  requestUpdate();
+}
+
+void DateTimeSettingsActivity::manualScreen(UiScreen& screen, void* user) {
+  static_cast<DateTimeSettingsActivity*>(user)->buildManualScreen(screen);
+}
+
+void DateTimeSettingsActivity::buildManualScreen(UiScreen& screen) {
+  if (mode != Mode::ManualEdit || !mappedInput.hasTouch()) return;
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  screen.setContentMargin(fui::Insets{
+      static_cast<int16_t>(metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing),
+      static_cast<int16_t>(metrics.contentSidePadding), 0, static_cast<int16_t>(metrics.contentSidePadding)});
+  addDialogCancelOk(screen, ACTION_CANCEL, ACTION_OK);
+
+  static constexpr StrId names[] = {StrId::STR_YEAR, StrId::STR_MONTH, StrId::STR_DAY, StrId::STR_HOUR,
+                                    StrId::STR_MINUTE};
+  char values[EDIT_FIELD_COUNT][5];
+  snprintf(values[0], sizeof(values[0]), "%d", year);
+  snprintf(values[1], sizeof(values[1]), "%02u", month);
+  snprintf(values[2], sizeof(values[2]), "%02u", day);
+  snprintf(values[3], sizeof(values[3]), "%02u", hour);
+  snprintf(values[4], sizeof(values[4]), "%02u", minute);
+  for (int index = 0; index < EDIT_FIELD_COUNT; ++index) {
+    fui::StepperRowProps props;
+    props.row.label = I18N.get(names[index]);
+    props.row.labelText = screen.theme().bodyText;
+    props.row.valueText = screen.theme().bodyText;
+    props.row.minTouchSize = screen.theme().minTouchSize;
+    props.row.state = index == selectedEditField ? fui::StateFocused : fui::StateNormal;
+    props.value = values[index];
+    props.widestValue = index == 0 ? "2099" : "00";
+    props.decrement = ACTION_STEP;
+    props.increment = ACTION_STEP;
+    props.decrementValue = static_cast<int16_t>(-(index + 1));
+    props.incrementValue = static_cast<int16_t>(index + 1);
+    screen.stepperRow(props);
+  }
+}
+
+void DateTimeSettingsActivity::onStep(const fui::ActionEvent& event, void* user) {
+  auto* self = static_cast<DateTimeSettingsActivity*>(user);
+  if (self->mode != Mode::ManualEdit || event.value == 0) return;
+  self->selectedEditField = event.value > 0 ? event.value - 1 : -event.value - 1;
+  self->adjustEditField(event.value > 0 ? 1 : -1);
+}
+
+void DateTimeSettingsActivity::onCancel(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<DateTimeSettingsActivity*>(user);
+  if (self->mode != Mode::ManualEdit) return;
+  self->app.clearTapFlash();
+  self->cancelManualEdit();
+}
+
+void DateTimeSettingsActivity::onOk(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<DateTimeSettingsActivity*>(user);
+  if (self->mode != Mode::ManualEdit) return;
+  self->app.clearTapFlash();
+  self->confirmManualEdit();
 }
 
 void DateTimeSettingsActivity::render(RenderLock&&) {
@@ -303,32 +383,36 @@ void DateTimeSettingsActivity::renderManualEdit() {
   const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing * 2;
 
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_SET_DATE_AND_TIME));
-  GUI.drawList(
-      renderer, Rect{0, contentTop, pageWidth, contentHeight}, EDIT_FIELD_COUNT, selectedEditField,
-      [](int index) {
-        static constexpr StrId NAMES[] = {StrId::STR_YEAR, StrId::STR_MONTH, StrId::STR_DAY, StrId::STR_HOUR,
-                                          StrId::STR_MINUTE};
-        return std::string(I18N.get(NAMES[index]));
-      },
-      nullptr, nullptr,
-      [this](int index) {
-        switch (static_cast<EditField>(index)) {
-          case EditField::Year:
-            return std::to_string(year);
-          case EditField::Month:
-            return twoDigits(month);
-          case EditField::Day:
-            return twoDigits(day);
-          case EditField::Hour:
-            return twoDigits(hour);
-          case EditField::Minute:
-            return twoDigits(minute);
-          case EditField::Count:
-            return std::string();
-        }
-        return std::string();
-      },
-      true);
+  if (mappedInput.hasTouch()) {
+    renderUi();
+  } else {
+    GUI.drawList(
+        renderer, Rect{0, contentTop, pageWidth, contentHeight}, EDIT_FIELD_COUNT, selectedEditField,
+        [](int index) {
+          static constexpr StrId NAMES[] = {StrId::STR_YEAR, StrId::STR_MONTH, StrId::STR_DAY, StrId::STR_HOUR,
+                                            StrId::STR_MINUTE};
+          return std::string(I18N.get(NAMES[index]));
+        },
+        nullptr, nullptr,
+        [this](int index) {
+          switch (static_cast<EditField>(index)) {
+            case EditField::Year:
+              return std::to_string(year);
+            case EditField::Month:
+              return twoDigits(month);
+            case EditField::Day:
+              return twoDigits(day);
+            case EditField::Hour:
+              return twoDigits(hour);
+            case EditField::Minute:
+              return twoDigits(minute);
+            case EditField::Count:
+              return std::string();
+          }
+          return std::string();
+        },
+        true);
+  }
 
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_CONFIRM), tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/activities/settings/DateTimeSettingsActivity.h
+++ b/src/activities/settings/DateTimeSettingsActivity.h
@@ -3,12 +3,13 @@
 #include <cstdint>
 
 #include "activities/Activity.h"
+#include "components/UiAppHost.h"
 #include "util/ButtonNavigator.h"
 
-class DateTimeSettingsActivity final : public Activity {
+class DateTimeSettingsActivity final : public Activity, private UiAppHost {
  public:
   explicit DateTimeSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("DateTimeSettings", renderer, mappedInput) {}
+      : Activity("DateTimeSettings", renderer, mappedInput), UiAppHost(renderer) {}
 
   void onEnter() override;
   void onExit() override;
@@ -60,4 +61,15 @@ class DateTimeSettingsActivity final : public Activity {
   void beginManualEdit();
   void adjustEditField(int delta);
   bool applyManualTime();
+  void cancelManualEdit();
+  void confirmManualEdit();
+
+  static constexpr freeink::ui::ActionId ACTION_STEP = 1;
+  static constexpr freeink::ui::ActionId ACTION_CANCEL = 2;
+  static constexpr freeink::ui::ActionId ACTION_OK = 3;
+  static void manualScreen(UiScreen& screen, void* user);
+  static void onStep(const freeink::ui::ActionEvent& event, void* user);
+  static void onCancel(const freeink::ui::ActionEvent& event, void* user);
+  static void onOk(const freeink::ui::ActionEvent& event, void* user);
+  void buildManualScreen(UiScreen& screen);
 };

--- a/src/activities/settings/DictionaryDownloadActivity.cpp
+++ b/src/activities/settings/DictionaryDownloadActivity.cpp
@@ -23,6 +23,8 @@
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
 
+namespace fui = freeink::ui;
+
 namespace {
 
 constexpr const char* MANIFEST_TMP = "/dictionary_manifest.tmp";
@@ -58,10 +60,15 @@ void logHeap(const char* phase) {
 }  // namespace
 
 DictionaryDownloadActivity::DictionaryDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-    : Activity("DictionaryDownload", renderer, mappedInput) {}
+    : Activity("DictionaryDownload", renderer, mappedInput), UiAppHost(renderer) {}
 
 void DictionaryDownloadActivity::onEnter() {
   Activity::onEnter();
+  resetUi();
+  app.on(ACTION_CANCEL_DOWNLOAD, &DictionaryDownloadActivity::onCancelDownload, this);
+  app.on(ACTION_RETURN_TO_LIST, &DictionaryDownloadActivity::onReturnToList, this);
+  app.on(ACTION_RETRY_DOWNLOAD, &DictionaryDownloadActivity::onRetryDownload, this);
+  app.setScreen(&DictionaryDownloadActivity::stateScreen, this);
   startWifiSelection();
 }
 
@@ -362,6 +369,7 @@ DictionaryDownloadActivity::DownloadResult DictionaryDownloadActivity::downloadI
     state_ = State::Downloading;
     downloadingIndex_ = static_cast<int>(&item - items_.data());
     cancelRequested_ = false;
+    goHomeRequested_ = false;
   }
   requestUpdateAndWait();
   logHeap("download start");
@@ -386,6 +394,11 @@ DictionaryDownloadActivity::DownloadResult DictionaryDownloadActivity::downloadI
               mappedInput.wasPressed(MappedInputManager::Button::Back)) {
             cancelRequested_ = true;
           }
+          if (mappedInput.wasHomeGesture()) {
+            cancelRequested_ = true;
+            goHomeRequested_ = true;
+          }
+          routeTouch(mappedInput);
           const uint32_t now = millis();
           if (now - lastRefresh >= PROGRESS_REFRESH_MS) {
             lastRefresh = now;
@@ -396,6 +409,10 @@ DictionaryDownloadActivity::DownloadResult DictionaryDownloadActivity::downloadI
     if (download == HttpDownloader::ABORTED) {
       Storage.removeDir(staging);
       operation_ = Operation::None;
+      if (goHomeRequested_) {
+        onGoHome();
+        return DownloadResult::Cancelled;
+      }
       waitForBackRelease_ = true;
       RenderLock lock(*this);
       state_ = State::List;
@@ -534,6 +551,12 @@ void DictionaryDownloadActivity::loop() {
     return;
   }
 
+  if (state_ == State::Downloading || state_ == State::Complete || state_ == State::Error) {
+    const auto touch = routeTouch(mappedInput);
+    if (touch.routed && app.invalidated()) requestUpdate();
+    if (touch) return;
+  }
+
   if (state_ == State::List) {
     auto activate = [this] {
       if (isUpdateAllRow(selectedIndex_)) {
@@ -608,12 +631,9 @@ void DictionaryDownloadActivity::loop() {
     });
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) activate();
   } else if (state_ == State::Complete) {
-    int x = 0;
-    int y = 0;
     if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-        mappedInput.wasPressed(MappedInputManager::Button::Confirm) || mappedInput.wasScreenTapped(x, y)) {
-      state_ = State::List;
-      requestUpdate();
+        mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      returnToList();
     }
   } else if (state_ == State::Error) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
@@ -622,13 +642,71 @@ void DictionaryDownloadActivity::loop() {
         finish();
         return;
       }
-      state_ = State::List;
-      requestUpdate();
+      returnToList();
     } else if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      closeRouting();
       retryOperation();
       requestUpdateAndWait();
     }
   }
+}
+
+void DictionaryDownloadActivity::stateScreen(UiScreen& screen, void* user) {
+  static_cast<DictionaryDownloadActivity*>(user)->buildStateScreen(screen);
+}
+
+void DictionaryDownloadActivity::buildStateScreen(UiScreen& screen) {
+  if (!mappedInput.hasTouch()) return;
+  fui::FooterAction actions[2];
+  uint8_t count = 0;
+  switch (state_) {
+    case State::Downloading:
+      actions[count++] = {tr(STR_CANCEL), ACTION_CANCEL_DOWNLOAD};
+      break;
+    case State::Complete:
+      actions[count++] = {tr(STR_BACK), ACTION_RETURN_TO_LIST};
+      break;
+    case State::Error:
+      actions[count++] = {tr(STR_BACK), ACTION_RETURN_TO_LIST};
+      actions[count++] = {tr(STR_RETRY), ACTION_RETRY_DOWNLOAD};
+      break;
+    default:
+      break;
+  }
+  if (count > 0) screen.footer(actions, count);
+}
+
+void DictionaryDownloadActivity::onCancelDownload(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<DictionaryDownloadActivity*>(user);
+  if (self->state_ == State::Downloading) self->cancelRequested_ = true;
+}
+
+void DictionaryDownloadActivity::returnToList() {
+  closeRouting();
+  operation_ = Operation::None;
+  state_ = State::List;
+  requestUpdate();
+}
+
+void DictionaryDownloadActivity::onReturnToList(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<DictionaryDownloadActivity*>(user);
+  if (self->state_ != State::Complete && self->state_ != State::Error) return;
+  if (self->state_ == State::Error && self->items_.empty()) {
+    self->app.clearTapFlash();
+    self->finish();
+    return;
+  }
+  self->app.clearTapFlash();
+  self->returnToList();
+}
+
+void DictionaryDownloadActivity::onRetryDownload(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<DictionaryDownloadActivity*>(user);
+  if (self->state_ != State::Error) return;
+  self->app.clearTapFlash();
+  self->closeRouting();
+  self->retryOperation();
+  self->requestUpdateAndWait();
 }
 
 std::string DictionaryDownloadActivity::formatSize(const size_t bytes) {
@@ -740,5 +818,6 @@ void DictionaryDownloadActivity::render(RenderLock&&) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_RETRY), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   }
+  if (state_ == State::Downloading || state_ == State::Complete || state_ == State::Error) renderUi();
   renderer.displayBuffer();
 }

--- a/src/activities/settings/DictionaryDownloadActivity.h
+++ b/src/activities/settings/DictionaryDownloadActivity.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "activities/Activity.h"
+#include "components/UiAppHost.h"
 #include "util/ButtonNavigator.h"
 #include "util/DictionaryResource.h"
 
@@ -14,7 +15,7 @@
 #define DICTIONARY_MANIFEST_URL "https://" CROSSMUX_HOST "/api/assets/dictionaries/manifest?version=1"
 #endif
 
-class DictionaryDownloadActivity final : public Activity {
+class DictionaryDownloadActivity final : public Activity, private UiAppHost {
  public:
   DictionaryDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput);
 
@@ -66,6 +67,17 @@ class DictionaryDownloadActivity final : public Activity {
   bool cancelRequested_ = false;
   bool waitForConfirmRelease_ = false;
   bool waitForBackRelease_ = false;
+  bool goHomeRequested_ = false;
+
+  static constexpr freeink::ui::ActionId ACTION_CANCEL_DOWNLOAD = 1;
+  static constexpr freeink::ui::ActionId ACTION_RETURN_TO_LIST = 2;
+  static constexpr freeink::ui::ActionId ACTION_RETRY_DOWNLOAD = 3;
+  static void stateScreen(UiScreen& screen, void* user);
+  static void onCancelDownload(const freeink::ui::ActionEvent& event, void* user);
+  static void onReturnToList(const freeink::ui::ActionEvent& event, void* user);
+  static void onRetryDownload(const freeink::ui::ActionEvent& event, void* user);
+  void buildStateScreen(UiScreen& screen);
+  void returnToList();
 
   void startWifiSelection();
   void onWifiSelectionComplete(bool success);

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -90,6 +90,9 @@ void FontDownloadActivity::activateIndex(const int index) {
 
 void FontDownloadActivity::onEnter() {
   UiListActivity::onEnter();
+  app.on(ACTION_CANCEL_DOWNLOAD, &FontDownloadActivity::onCancelDownload, this);
+  app.on(ACTION_RETURN_TO_LIST, &FontDownloadActivity::onReturnToList, this);
+  app.on(ACTION_RETRY_DOWNLOAD, &FontDownloadActivity::onRetryDownload, this);
   if (purpose_ == Purpose::PromptThenManage) {
     auto confirmation = makeUniqueNoThrow<ConfirmationActivity>(renderer, mappedInput, tr(STR_CHINESE_FONT_INCOMPLETE),
                                                                 tr(STR_DOWNLOAD_FULL_CHINESE_FONT),
@@ -469,6 +472,7 @@ FontDownloadActivity::DownloadResult FontDownloadActivity::downloadFile(const Ma
           cancelRequested_ = true;
           goHomeRequested_ = true;
         }
+        UiAppHost::routeTouch(mappedInput);
         requestUpdate(true);
       },
       &cancelRequested_);
@@ -736,6 +740,28 @@ void FontDownloadActivity::buildScreen(UiScreen& screen) {
                                       static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
+  if (state_ != FAMILY_LIST) {
+    if (!mappedInput.hasTouch()) return;
+    fui::FooterAction actions[2];
+    uint8_t count = 0;
+    switch (state_) {
+      case DOWNLOADING:
+        actions[count++] = {tr(STR_CANCEL), ACTION_CANCEL_DOWNLOAD};
+        break;
+      case COMPLETE:
+        actions[count++] = {tr(STR_BACK), ACTION_RETURN_TO_LIST};
+        break;
+      case ERROR:
+        actions[count++] = {tr(STR_BACK), ACTION_RETURN_TO_LIST};
+        actions[count++] = {tr(STR_RETRY), ACTION_RETRY_DOWNLOAD};
+        break;
+      default:
+        break;
+    }
+    if (count > 0) screen.footer(actions, count);
+    return;
+  }
+
   if (families_.empty()) {
     screen.centeredText(tr(STR_NO_FONTS_AVAILABLE), screen.theme().bodyText);
     return;
@@ -754,6 +780,38 @@ void FontDownloadActivity::buildScreen(UiScreen& screen) {
   props.valueInset = 8;               // air between the status and the row edge
   syncListViewport(screen, props, /*hasSubtitle=*/true);
   screen.list(props);
+}
+
+void FontDownloadActivity::onCancelDownload(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<FontDownloadActivity*>(user);
+  if (self->state_ == DOWNLOADING) self->cancelRequested_ = true;
+}
+
+void FontDownloadActivity::returnToFamilyList() {
+  closeRouting();
+  {
+    RenderLock lock(*this);
+    state_ = FAMILY_LIST;
+    operation_ = DownloadOperation::None;
+    rowsDirty_ = true;
+  }
+  requestUpdate();
+}
+
+void FontDownloadActivity::onReturnToList(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<FontDownloadActivity*>(user);
+  if (self->state_ != COMPLETE && self->state_ != ERROR) return;
+  self->app.clearTapFlash();
+  self->returnToFamilyList();
+}
+
+void FontDownloadActivity::onRetryDownload(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<FontDownloadActivity*>(user);
+  if (self->state_ != ERROR) return;
+  self->app.clearTapFlash();
+  self->closeRouting();
+  self->retryDownloadOperation();
+  self->requestUpdateAndWait();
 }
 
 // Rebuilds rowLabels_/rowItems_ from families_. Only called when rowsDirty_ is
@@ -798,40 +856,23 @@ bool FontDownloadActivity::handleCustomInput() {
     return false;
   }
 
+  const auto touch = UiAppHost::routeTouch(mappedInput);
+  if (touch.routed && app.invalidated()) requestUpdate();
+  if (touch) return true;
+
   if (state_ == COMPLETE) {
-    int x = 0;
-    int y = 0;
     if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-        mappedInput.wasPressed(MappedInputManager::Button::Confirm) || mappedInput.wasScreenTapped(x, y)) {
-      {
-        RenderLock lock(*this);
-        state_ = FAMILY_LIST;
-        operation_ = DownloadOperation::None;
-        rowsDirty_ = true;  // the completed download changed installed/hasUpdate
-      }
-      requestUpdate();
+        mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      returnToFamilyList();
     }
   } else if (state_ == ERROR) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-      {
-        RenderLock lock(*this);
-        state_ = FAMILY_LIST;
-        operation_ = DownloadOperation::None;
-        rowsDirty_ = true;  // the failed download reset installed/hasUpdate
-      }
-      requestUpdate();
+      returnToFamilyList();
     } else if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      closeRouting();
       retryDownloadOperation();
       requestUpdateAndWait();
       return true;
-    } else {
-      int x = 0;
-      int y = 0;
-      if (mappedInput.wasScreenTapped(x, y)) {
-        retryDownloadOperation();
-        requestUpdateAndWait();
-        return true;
-      }
     }
   }
 
@@ -921,6 +962,8 @@ void FontDownloadActivity::render(RenderLock&&) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_RETRY), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   }
+
+  if (state_ == DOWNLOADING || state_ == COMPLETE || state_ == ERROR) renderUi();
 
   renderer.displayBuffer();
 }

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -119,6 +119,14 @@ class FontDownloadActivity final : public UiListActivity {
   bool rowsDirty_ = true;
   void rebuildRowItems();
 
+  static constexpr freeink::ui::ActionId ACTION_CANCEL_DOWNLOAD = ACTION_USER;
+  static constexpr freeink::ui::ActionId ACTION_RETURN_TO_LIST = ACTION_USER + 1;
+  static constexpr freeink::ui::ActionId ACTION_RETRY_DOWNLOAD = ACTION_USER + 2;
+  static void onCancelDownload(const freeink::ui::ActionEvent& event, void* user);
+  static void onReturnToList(const freeink::ui::ActionEvent& event, void* user);
+  static void onRetryDownload(const freeink::ui::ActionEvent& event, void* user);
+  void returnToFamilyList();
+
   int listCount() const override { return listItemCount(); }
   void buildScreen(UiScreen& screen) override;
   void activateIndex(int index) override;

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -40,8 +40,9 @@ fui::TextStyle releaseNoteStyle() {
   return style;
 }
 
-Rect releaseNotesBody(const Rect& safeArea, const ThemeMetrics& metrics, const bool firstPage) {
+Rect releaseNotesBody(const Rect& safeArea, const ThemeMetrics& metrics, const bool firstPage, const int bottomInset) {
   Rect body = SubpageLayout::contentRect(safeArea, metrics);
+  body.height = std::max(0, body.height - bottomInset);
   if (firstPage) {
     const int versionTop = safeArea.y + metrics.topPadding + metrics.headerHeight;
     const int notesTop = versionTop + metrics.tabBarHeight * 2 + SubpageLayout::sectionGap(metrics);
@@ -124,6 +125,10 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
 void OtaUpdateActivity::onEnter() {
   Activity::onEnter();
 
+  resetUi();
+  app.on(ACTION_RELEASE_PAGE, &OtaUpdateActivity::onReleasePage, this);
+  app.on(ACTION_INSTALL_UPDATE, &OtaUpdateActivity::onInstallUpdate, this);
+  app.setScreen(&OtaUpdateActivity::updateScreen, this);
   state = State::Ready;
   selectedChannel = SETTINGS.otaNightlyEnabled ? OtaUpdater::Channel::Nightly : OtaUpdater::Channel::Stable;
   selectedReadyRow = CHECK_UPDATES_ROW;
@@ -209,7 +214,7 @@ void OtaUpdateActivity::showUpdateConfirmation() {
   requestUpdate();
 }
 
-void OtaUpdateActivity::rebuildReleaseNotePages(const Rect& safeArea) {
+void OtaUpdateActivity::rebuildReleaseNotePages(const Rect& safeArea, const int bottomInset) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const auto notes = updater.getReleaseNotes();
   releaseNotePageCount = 1;
@@ -231,7 +236,7 @@ void OtaUpdateActivity::rebuildReleaseNotePages(const Rect& safeArea) {
   uint8_t noteIndex = 0;
   while (noteIndex < notes.size() && pageCount < ReleaseJsonParser::RELEASE_NOTE_COUNT_MAX) {
     releaseNotePageStarts[pageCount] = noteIndex;
-    const Rect body = releaseNotesBody(safeArea, metrics, pageCount == 0);
+    const Rect body = releaseNotesBody(safeArea, metrics, pageCount == 0, bottomInset);
     const int availableHeight = std::max(0, body.height - titleHeight - sectionGap);
     const int textWidth = std::max(1, body.width - bulletIndent);
     int usedHeight = 0;
@@ -253,7 +258,8 @@ void OtaUpdateActivity::rebuildReleaseNotePages(const Rect& safeArea) {
 
 void OtaUpdateActivity::renderUpdateAvailable(const Rect& safeArea) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  rebuildReleaseNotePages(safeArea);
+  const int bottomInset = mappedInput.hasTouch() ? app.theme().footerHeight : 0;
+  rebuildReleaseNotePages(safeArea, bottomInset);
 
   GUI.drawHeader(renderer, Rect{safeArea.x, safeArea.y + metrics.topPadding, safeArea.width, metrics.headerHeight},
                  tr(STR_UPDATE));
@@ -267,7 +273,7 @@ void OtaUpdateActivity::renderUpdateAvailable(const Rect& safeArea) {
                       tr(STR_NEW_VERSION), latestVersionLabel(updater));
   }
 
-  const Rect body = releaseNotesBody(safeArea, metrics, releaseNotePage == 0);
+  const Rect body = releaseNotesBody(safeArea, metrics, releaseNotePage == 0, bottomInset);
   const int titleHeight = renderer.getLineHeight(UI_12_FONT_ID);
   const int relatedGap = SubpageLayout::relatedGap(metrics);
   const int sectionGap = SubpageLayout::sectionGap(metrics);
@@ -311,6 +317,37 @@ void OtaUpdateActivity::renderUpdateAvailable(const Rect& safeArea) {
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_UPDATE), releaseNotePage > 0 ? tr(STR_DIR_UP) : "",
                                             releaseNotePage + 1 < releaseNotePageCount ? tr(STR_DIR_DOWN) : "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  renderUi();
+}
+
+void OtaUpdateActivity::updateScreen(UiScreen& screen, void* user) {
+  static_cast<OtaUpdateActivity*>(user)->buildUpdateScreen(screen);
+}
+
+void OtaUpdateActivity::buildUpdateScreen(UiScreen& screen) {
+  if (!mappedInput.hasTouch() || (state != State::UpdateAvailable && state != State::ConfirmingUpdate)) return;
+  const fui::FooterAction actions[] = {
+      {tr(STR_PREV_PAGE), ACTION_RELEASE_PAGE, -1, fui::StateNormal, releaseNotePage > 0},
+      {tr(STR_UPDATE), ACTION_INSTALL_UPDATE},
+      {tr(STR_NEXT_PAGE), ACTION_RELEASE_PAGE, 1, fui::StateNormal, releaseNotePage + 1 < releaseNotePageCount},
+  };
+  screen.footer(actions, 3);
+}
+
+void OtaUpdateActivity::onReleasePage(const fui::ActionEvent& event, void* user) {
+  auto* self = static_cast<OtaUpdateActivity*>(user);
+  if (self->state != State::UpdateAvailable) return;
+  const int next = static_cast<int>(self->releaseNotePage) + event.value;
+  if (next < 0 || next >= self->releaseNotePageCount) return;
+  self->releaseNotePage = static_cast<uint8_t>(next);
+  self->requestUpdate();
+}
+
+void OtaUpdateActivity::onInstallUpdate(const fui::ActionEvent&, void* user) {
+  auto* self = static_cast<OtaUpdateActivity*>(user);
+  if (self->state != State::UpdateAvailable) return;
+  self->app.clearTapFlash();
+  self->showUpdateConfirmation();
 }
 
 void OtaUpdateActivity::render(RenderLock&&) {
@@ -521,7 +558,10 @@ void OtaUpdateActivity::loop() {
       }
       return;
     }
-    case State::UpdateAvailable:
+    case State::UpdateAvailable: {
+      const auto touch = routeTouch(mappedInput);
+      if (touch.routed && app.invalidated()) requestUpdate();
+      if (touch) return;
       if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
         finish();
         return;
@@ -540,6 +580,7 @@ void OtaUpdateActivity::loop() {
         requestUpdate();
       }
       return;
+    }
     case State::ConfirmingUpdate:
       if (updateConfirmation.handleInput(mappedInput, [this] { requestUpdate(); })) {
         if (state == State::ConfirmingUpdate && !updateConfirmation.isActive()) {

--- a/src/activities/settings/OtaUpdateActivity.h
+++ b/src/activities/settings/OtaUpdateActivity.h
@@ -5,9 +5,10 @@
 
 #include "activities/Activity.h"
 #include "components/OptionPopup.h"
+#include "components/UiAppHost.h"
 #include "network/OtaUpdater.h"
 
-class OtaUpdateActivity : public Activity {
+class OtaUpdateActivity : public Activity, private UiAppHost {
   enum class State : uint8_t {
     Ready,
     WifiSelection,
@@ -44,12 +45,19 @@ class OtaUpdateActivity : public Activity {
   void onWifiSelectionComplete(bool success);
   void showUpdateConfirmation();
   void renderUpdateAvailable(const Rect& safeArea);
-  void rebuildReleaseNotePages(const Rect& safeArea);
+  void rebuildReleaseNotePages(const Rect& safeArea, int bottomInset);
   void runUpdateInstall();
+
+  static constexpr freeink::ui::ActionId ACTION_RELEASE_PAGE = 1;
+  static constexpr freeink::ui::ActionId ACTION_INSTALL_UPDATE = 2;
+  static void updateScreen(UiScreen& screen, void* user);
+  static void onReleasePage(const freeink::ui::ActionEvent& event, void* user);
+  static void onInstallUpdate(const freeink::ui::ActionEvent& event, void* user);
+  void buildUpdateScreen(UiScreen& screen);
 
  public:
   explicit OtaUpdateActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("OtaUpdate", renderer, mappedInput), updater() {}
+      : Activity("OtaUpdate", renderer, mappedInput), UiAppHost(renderer), updater() {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -60,6 +60,16 @@ class OptionPopup {
     const int total = static_cast<int>(ownedStrings.size());
     const int count = UITheme::getInstance().hasMainTabs() ? total : std::min(total, MAX_OPTIONS);
     const freeink::ui::InputSnapshot snap = touchSnapshotFrom(input);
+    if (ignoreInitialTouchContact) {
+      if (snap.touchPressed || snap.touchHeld || snap.touchReleased) {
+        // A popup can be opened while the activating finger is still down.
+        // Own that contact through release so it cannot select or dismiss the
+        // new popup; a normal entry clears the barrier on the first idle pass.
+        if (snap.touchReleased) ignoreInitialTouchContact = false;
+        return true;
+      }
+      ignoreInitialTouchContact = false;
+    }
     if (snap.touchPressed || snap.touchReleased || snap.touchHeld) {
       // Interactions are registered on the render task; only route once the
       // first render after show() has populated the table (uiReady handshake).
@@ -263,6 +273,7 @@ class OptionPopup {
     selectedIndex = std::clamp(currentIndex, 0, count - 1);
     onSelectCallback = std::move(onSelect);
     ignoreInitialConfirmRelease = true;
+    ignoreInitialTouchContact = true;
     uiReady = false;
     active = true;
   }
@@ -281,6 +292,7 @@ class OptionPopup {
   int selectedIndex = 0;
   std::function<void(int)> onSelectCallback;
   bool ignoreInitialConfirmRelease = false;
+  bool ignoreInitialTouchContact = false;
   // Written by the render task (frame registration), routed by the loop task;
   // uiReady closes the rebuild window exactly like UiListActivity::uiReady.
   mutable freeink::ui::InteractionBuffer<INTERACTION_CAPACITY> interactions;

--- a/test/inx_navigation/CMakeLists.txt
+++ b/test/inx_navigation/CMakeLists.txt
@@ -1,7 +1,10 @@
 add_executable(InxNavigationTest InxNavigationTest.cpp)
 
 target_include_directories(InxNavigationTest BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/stubs)
-target_include_directories(InxNavigationTest PRIVATE ${REPO_ROOT}/src)
+target_include_directories(InxNavigationTest PRIVATE
+  ${REPO_ROOT}/src
+  ${REPO_ROOT}/freeink-sdk/libs/ui/FreeInkUI/include
+)
 target_link_libraries(InxNavigationTest PRIVATE crosspoint_test_common GTest::gtest_main)
 
 gtest_discover_tests(InxNavigationTest)

--- a/test/inx_navigation/InxNavigationTest.cpp
+++ b/test/inx_navigation/InxNavigationTest.cpp
@@ -1,3 +1,4 @@
+#include <FreeInkUICore.h>
 #include <gtest/gtest.h>
 
 #include <type_traits>
@@ -152,6 +153,109 @@ TEST(InxNavigation, KeepsOptionPopupOnFiveCenteredRows) {
   EXPECT_EQ(InxOptionGeometry::start(7, 8), 3);
   EXPECT_EQ(InxOptionGeometry::headerHeight, 62);
   EXPECT_EQ(InxOptionGeometry::rowHeight, 62);
+}
+
+TEST(InxNavigation, RoutesPopupReleaseAgainstPublishedRotatedHitRects) {
+  namespace fui = freeink::ui;
+  constexpr fui::ActionId cancel = 1;
+  constexpr fui::ActionId confirm = 2;
+  fui::DeviceContext paperMono;
+  paperMono.width = 800;
+  paperMono.height = 480;
+  paperMono.touchOrientation = fui::touchOrientationFor(fui::Orientation::LandscapeClockwise);
+
+  const fui::Point cancelPoint = fui::touchToLogical(paperMono, 0.75f, 0.75f);
+  const fui::Point confirmPoint = fui::touchToLogical(paperMono, 0.25f, 0.75f);
+  fui::InteractionBuffer<2> interactions;
+  interactions.beginPublishCycle();
+  interactions.clear();
+  EXPECT_TRUE(interactions.addInteraction({fui::Rect{100, 100, 300, 100}, cancel, 0, fui::InputTouch}));
+  EXPECT_TRUE(interactions.addInteraction({fui::Rect{400, 100, 300, 100}, confirm, 1, fui::InputTouch}));
+  interactions.publish();
+
+  fui::InputSnapshot press;
+  press.touchPressed = true;
+  press.touchX = cancelPoint.x;
+  press.touchY = cancelPoint.y;
+  EXPECT_FALSE(interactions.routePublished(press));
+
+  // A repaint may publish the next complete generation while the finger is
+  // down; its release must still resolve exactly once against the new table.
+  interactions.beginPublishCycle();
+  interactions.clear();
+  EXPECT_TRUE(interactions.addInteraction({fui::Rect{100, 100, 300, 100}, cancel, 0, fui::InputTouch}));
+  EXPECT_TRUE(interactions.addInteraction({fui::Rect{400, 100, 300, 100}, confirm, 1, fui::InputTouch}));
+  interactions.publish();
+
+  fui::InputSnapshot release = press;
+  release.touchPressed = false;
+  release.touchReleased = true;
+  EXPECT_EQ(interactions.routePublished(release).action, cancel);
+  release.touchX = confirmPoint.x;
+  release.touchY = confirmPoint.y;
+  EXPECT_EQ(interactions.routePublished(release).action, confirm);
+  release.touchX = 20;
+  release.touchY = 20;
+  EXPECT_FALSE(interactions.routePublished(release));
+}
+
+TEST(InxNavigation, RoutesAirPageFooterAndImageTapOnRotatedTouch) {
+  namespace fui = freeink::ui;
+  constexpr fui::ActionId footerActions[] = {10, 11, 12, 13};
+  constexpr fui::ActionId imageMenu = 14;
+  fui::DeviceContext paperMono;
+  paperMono.width = 800;
+  paperMono.height = 480;
+  paperMono.touchOrientation = fui::touchOrientationFor(fui::Orientation::LandscapeClockwise);
+
+  fui::InteractionBuffer<4> interactions;
+  auto publishFooter = [&] {
+    interactions.beginPublishCycle();
+    interactions.clear();
+    for (int index = 0; index < 4; ++index) {
+      EXPECT_TRUE(interactions.addInteraction(
+          {fui::Rect{static_cast<int16_t>(index * 200), 420, 200, 60}, footerActions[index], 0, fui::InputTouch}));
+    }
+    interactions.publish();
+  };
+  publishFooter();
+
+  for (int index = 0; index < 4; ++index) {
+    const float logicalX = static_cast<float>(index * 200 + 100) / paperMono.width;
+    const float logicalY = 450.0f / paperMono.height;
+    const fui::Point point = fui::touchToLogical(paperMono, 1.0f - logicalX, 1.0f - logicalY);
+    fui::InputSnapshot release;
+    release.touchReleased = true;
+    release.touchX = point.x;
+    release.touchY = point.y;
+    EXPECT_EQ(interactions.routePublished(release).action, footerActions[index]);
+  }
+
+  const fui::Point center = fui::touchToLogical(paperMono, 0.5f, 0.5f);
+  auto publishImageTap = [&] {
+    interactions.beginPublishCycle();
+    interactions.clear();
+    EXPECT_TRUE(interactions.addInteraction({paperMono.screen(), imageMenu, 0, fui::InputTouch}));
+    interactions.publish();
+  };
+  publishImageTap();
+
+  fui::InputSnapshot press;
+  press.touchPressed = true;
+  press.touchX = center.x;
+  press.touchY = center.y;
+  EXPECT_FALSE(interactions.routePublished(press));
+
+  publishImageTap();
+
+  fui::InputSnapshot release = press;
+  release.touchPressed = false;
+  release.touchReleased = true;
+  EXPECT_EQ(interactions.routePublished(release).action, imageMenu);
+  release.touchX = -1;
+  release.touchY = -1;
+  release.swipeRight = true;
+  EXPECT_FALSE(interactions.routePublished(release));
 }
 
 TEST(InxNavigation, KeepsStatisticsViewsInsideBounds) {


### PR DESCRIPTION
## Summary

- Fix shared confirmation popup touch routing and add touch controls to font, dictionary, OTA, and manual date/time flows.
- Add a touch footer and full-screen image action menu to AirPage while preserving physical-button navigation.
- Keep touch interactions on the shared FUI routing path without public API, configuration, cache, or protocol changes.

## Testing

- ./bin/ci-check
- 395 host tests
- sticky_cn
- x4pro_cn
- papermono_cn
- eego_a4_cn
- murphy_m4_cn
- waveshare_epaper_397_cn
- PaperMono hardware touch and heap-stability acceptance (user-confirmed)