### PR TITLE
build(s3): publish all six hardware betas

### DIFF
--- a/.github/workflows/hardware-beta.yml
+++ b/.github/workflows/hardware-beta.yml
@@ -10,6 +10,8 @@ on:
         type: choice
         options:
           - sticky
+          - x4pro
+          - papermono
           - eego-a4
           - murphy-m4
           - waveshare-epaper-397
@@ -25,7 +27,6 @@ permissions:
   contents: write
 
 env:
-  BETA_REF: beta/s3-hardware
   RELEASE_TAG: hardware-beta-${{ inputs.device }}
   GITEE_REPO: x1abin/crossmux
 
@@ -38,7 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BETA_REF }}
           fetch-depth: 0
           submodules: recursive
 
@@ -72,6 +72,8 @@ jobs:
           set -euo pipefail
           case "${{ inputs.device }}" in
             sticky) environment=sticky ;;
+            x4pro) environment=x4pro ;;
+            papermono) environment=papermono ;;
             eego-a4) environment=eego_a4 ;;
             murphy-m4) environment=murphy_m4 ;;
             waveshare-epaper-397) environment=waveshare_epaper_397 ;;
@@ -109,7 +111,7 @@ jobs:
           cat > release-body.md <<EOF
           # CrossMux ${{ inputs.device }} hardware beta
 
-          Experimental build from \`${{ env.BETA_REF }}\`.
+          Experimental build from \`main\`.
 
           - CrossMux: \`${{ needs.build.outputs.crossmux_sha }}\`
           - Partition profile: \`crossmux-sticky-v1\`

--- a/docs/engineering/device-variants.md
+++ b/docs/engineering/device-variants.md
@@ -36,10 +36,9 @@ pio run -e murphy_m4
 pio run -e waveshare_epaper_397
 ```
 
-X4 Pro and PaperMono remain compile/CI targets only. Sticky retains its existing
-beta channel; eego A4, Murphy M4, and Waveshare use experimental hardware-beta
-artifacts. Manual flashing must use the matching build; the embedded board tag
-rejects a tagged image for a different board.
+All six S3 targets publish separate rolling hardware-beta artifacts. Manual
+flashing must use the matching build; the embedded board tag rejects a tagged
+image for a different board.
 
 The X3-vs-X4 choice is **not** a compile-time decision. Do not add a `-DX3`
 build flag or a `[env:...x3]` — see the next section for why.

--- a/scripts/package_hardware_beta.py
+++ b/scripts/package_hardware_beta.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 DEVICES = {
     'sticky': 'sticky',
+    'x4pro': 'x4pro',
+    'papermono': 'papermono',
     'eego-a4': 'eego_a4',
     'murphy-m4': 'murphy_m4',
     'waveshare-epaper-397': 'waveshare_epaper_397',

--- a/scripts/tests/test_package_hardware_beta.py
+++ b/scripts/tests/test_package_hardware_beta.py
@@ -11,6 +11,16 @@ SPEC.loader.exec_module(package_hardware_beta)
 
 
 class FirmwareValidationTest(unittest.TestCase):
+    def test_all_s3_beta_device_mappings(self):
+        self.assertEqual(package_hardware_beta.DEVICES, {
+            'sticky': 'sticky',
+            'x4pro': 'x4pro',
+            'papermono': 'papermono',
+            'eego-a4': 'eego_a4',
+            'murphy-m4': 'murphy_m4',
+            'waveshare-epaper-397': 'waveshare_epaper_397',
+        })
+
     def write_image(self, chip_id=package_hardware_beta.ESP32S3_CHIP_ID, board='eego_a4'):
         image = bytearray(24)
         image[0] = 0xE9


### PR DESCRIPTION
## Summary
- expose all six ESP32-S3 environments in the rolling hardware-beta workflow
- build workflow-dispatch main SHA and package global manifests
- document all six targets as rolling hardware betas

## Verification
- python3 -m unittest scripts/tests/test_package_hardware_beta.py
- pio run -e sticky -e x4pro -e papermono -e eego_a4 -e murphy_m4 -e waveshare_epaper_397
- packaged all six devices; verified manifests, partition tables, release file sets, and SHA256SUMS