### PR TITLE
build(s3): publish international and Chinese hardware betas

### DIFF
--- a/.github/workflows/hardware-beta.yml
+++ b/.github/workflows/hardware-beta.yml
@@ -79,15 +79,19 @@ jobs:
             waveshare-epaper-397) environment=waveshare_epaper_397 ;;
             *) exit 2 ;;
           esac
-          pio run -e "$environment"
-          python3 scripts/package_hardware_beta.py "${{ inputs.device }}"
-          (cd "dist/${{ inputs.device }}" && sha256sum --check SHA256SUMS)
+          pio run -e "$environment" -e "${environment}_cn"
+          python3 scripts/package_hardware_beta.py "${{ inputs.device }}" \
+            --flavor global --output dist/global
+          python3 scripts/package_hardware_beta.py "${{ inputs.device }}" \
+            --flavor zh-CN --output dist/cn
+          (cd dist/global && sha256sum --check SHA256SUMS)
+          (cd dist/cn && sha256sum --check SHA256SUMS)
 
       - name: Upload private build artifact
         uses: actions/upload-artifact@v6
         with:
           name: hardware-beta-${{ inputs.device }}
-          path: dist/${{ inputs.device }}
+          path: dist
           if-no-files-found: error
           retention-days: 14
 
@@ -108,16 +112,27 @@ jobs:
 
       - name: Build release notes
         run: |
-          cat > release-body.md <<EOF
+          cat > release-body-global.md <<EOF
           # CrossMux ${{ inputs.device }} hardware beta
 
-          Experimental build from \`main\`.
+          International experimental build from \`main\`.
 
           - CrossMux: \`${{ needs.build.outputs.crossmux_sha }}\`
           - Partition profile: \`crossmux-sticky-v1\`
           - Flash: ESP32-S3, DIO, 80 MHz, 16 MB
 
           Back up the complete 16 MB flash before first installation.
+          EOF
+          cat > release-body-cn.md <<EOF
+          # CrossMux ${{ inputs.device }} 中文硬件 Beta
+
+          从 \`main\` 构建的简体中文实验固件。
+
+          - CrossMux: \`${{ needs.build.outputs.crossmux_sha }}\`
+          - 分区布局: \`crossmux-sticky-v1\`
+          - Flash: ESP32-S3, DIO, 80 MHz, 16 MB
+
+          首次安装前请备份完整的 16 MB Flash。
           EOF
 
       - name: Publish rolling GitHub prerelease
@@ -126,11 +141,11 @@ jobs:
         run: |
           set -euo pipefail
           gh release delete "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
-          gh release create "$RELEASE_TAG" dist/* \
+          gh release create "$RELEASE_TAG" dist/global/* \
             --repo "$GITHUB_REPOSITORY" \
             --target "${{ needs.build.outputs.crossmux_sha }}" \
             --title "CrossMux ${{ inputs.device }} Hardware Beta" \
-            --notes-file release-body.md \
+            --notes-file release-body-global.md \
             --prerelease
 
       - name: Verify GitHub release assets
@@ -152,13 +167,13 @@ jobs:
             "CrossMux ${{ inputs.device }} Hardware Beta" \
             "true" \
             "${{ needs.build.outputs.crossmux_sha }}" \
-            release-body.md \
-            dist/SHA256SUMS \
-            dist/boot_app0.bin \
-            dist/bootloader.bin \
-            dist/firmware.bin \
-            dist/manifest.json \
-            dist/partitions.bin
+            release-body-cn.md \
+            dist/cn/SHA256SUMS \
+            dist/cn/boot_app0.bin \
+            dist/cn/bootloader.bin \
+            dist/cn/firmware.bin \
+            dist/cn/manifest.json \
+            dist/cn/partitions.bin
 
       - name: Verify Gitee release assets
         env:

--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -168,6 +168,10 @@ pio run -e sticky_cn -e x4pro_cn -e papermono_cn -e eego_a4_cn \
 
 Each S3 `_cn` environment inherits its device's hardware flags and uses the
 same Chinese-only resources and `crossmux.cn` host as `gh_release_cn`.
+Hardware-beta publishes build the international and `_cn` environments
+together. The same rolling tag contains the international package on GitHub
+and the Simplified-Chinese package on Gitee; each package keeps the standard
+six asset names and its own manifest and checksums.
 
 The committed headers were regenerated with source SHA-256
 `2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b`.

--- a/docs/engineering/device-variants.md
+++ b/docs/engineering/device-variants.md
@@ -36,9 +36,11 @@ pio run -e murphy_m4
 pio run -e waveshare_epaper_397
 ```
 
-All six S3 targets publish separate rolling hardware-beta artifacts. Manual
-flashing must use the matching build; the embedded board tag rejects a tagged
-image for a different board.
+All six S3 targets publish separate rolling hardware-beta artifacts. Each
+publish builds both flavors: GitHub carries the international package and
+Gitee carries the Simplified-Chinese package under the same rolling tag.
+Manual flashing must use the matching build; the embedded board tag rejects a
+tagged image for a different board.
 
 The X3-vs-X4 choice is **not** a compile-time decision. Do not add a `-DX3`
 build flag or a `[env:...x3]` — see the next section for why.

--- a/scripts/package_hardware_beta.py
+++ b/scripts/package_hardware_beta.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Package one S3 hardware beta build with the CrossMux/Sticky flash layout."""
+"""Package one S3 hardware beta flavor with the CrossMux/Sticky flash layout."""
 
 import argparse
 import configparser
@@ -19,6 +19,10 @@ DEVICES = {
     'murphy-m4': 'murphy_m4',
     'waveshare-epaper-397': 'waveshare_epaper_397',
 }
+FLAVOR_SUFFIXES = {
+    'global': '',
+    'zh-CN': '_cn',
+}
 SEGMENTS = (
     ('bootloader', 'bootloader.bin', 0x0000),
     ('partitions', 'partitions.bin', 0x8000),
@@ -31,6 +35,15 @@ EXPECTED_PARTITIONS = {
     'app1': (0x650000, 0x640000),
 }
 ESP32S3_CHIP_ID = 0x0009
+
+
+def environment_for(device, flavor):
+    return DEVICES[device] + FLAVOR_SUFFIXES[flavor]
+
+
+def version_for(base_version, device, flavor, short_sha):
+    flavor_suffix = '-cn' if FLAVOR_SUFFIXES[flavor] else ''
+    return f'{base_version}-{device}{flavor_suffix}-beta+{short_sha}'
 
 
 def sha256(path):
@@ -93,13 +106,16 @@ def verify_firmware(path, board):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('device', choices=DEVICES)
+    parser.add_argument('--flavor', choices=FLAVOR_SUFFIXES, default='global')
     parser.add_argument('--output', type=Path)
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parent.parent
-    environment = DEVICES[args.device]
+    board = DEVICES[args.device]
+    environment = environment_for(args.device, args.flavor)
     build = root / '.pio/build' / environment
-    output = (args.output or root / 'dist' / args.device).resolve()
+    output_name = args.device if args.flavor == 'global' else f'{args.device}-cn'
+    output = (args.output or root / 'dist' / output_name).resolve()
     output.mkdir(parents=True, exist_ok=True)
 
     verify_partition_csv(root)
@@ -111,12 +127,12 @@ def main():
     firmware_size = (output / 'firmware.bin').stat().st_size
     if firmware_size > EXPECTED_PARTITIONS['app0'][1]:
         raise SystemExit(f'firmware.bin is {firmware_size} bytes; app slot is 0x640000 bytes')
-    verify_firmware(output / 'firmware.bin', environment)
+    verify_firmware(output / 'firmware.bin', board)
 
     config = configparser.ConfigParser()
     config.read(root / 'platformio.ini')
     short_sha = git_value(root, 'rev-parse', '--short', 'HEAD')
-    version = f"{config['crosspoint']['version']}-{args.device}-beta+{short_sha}"
+    version = version_for(config['crosspoint']['version'], args.device, args.flavor, short_sha)
     assets = []
     for role, name, offset in SEGMENTS:
         path = output / name
@@ -132,7 +148,7 @@ def main():
         'device': args.device,
         'environment': environment,
         'chip': 'ESP32-S3',
-        'flavor': 'global',
+        'flavor': args.flavor,
         'version': version,
         'crossmuxSha': git_value(root, 'rev-parse', 'HEAD'),
         'sdkSha': git_value(root / 'freeink-sdk', 'rev-parse', 'HEAD'),

--- a/scripts/publish-gitee-release.sh
+++ b/scripts/publish-gitee-release.sh
@@ -6,8 +6,8 @@
 # (China) deployment reads release metadata + binaries from this Gitee repo when
 # FIRMWARE_MIRROR=gitee (see crosspoint-web server/handlers.ts).
 #
-# This publishes the SAME binaries GitHub Actions just built — it does NOT
-# rebuild on Gitee — so the firmware is byte-identical across both hosts.
+# This uploads binaries built by GitHub Actions; workflows may select regional
+# variants (for example, Simplified-Chinese hardware betas) for Gitee.
 #
 # The stable-release workflow treats mirror failures as errors; nightly remains
 # best-effort at the workflow level.

--- a/scripts/tests/test_package_hardware_beta.py
+++ b/scripts/tests/test_package_hardware_beta.py
@@ -21,6 +21,23 @@ class FirmwareValidationTest(unittest.TestCase):
             'waveshare-epaper-397': 'waveshare_epaper_397',
         })
 
+    def test_global_and_chinese_beta_variants(self):
+        for device, environment in package_hardware_beta.DEVICES.items():
+            self.assertEqual(package_hardware_beta.environment_for(device, 'global'), environment)
+            self.assertEqual(package_hardware_beta.environment_for(device, 'zh-CN'), f'{environment}_cn')
+        self.assertEqual(
+            package_hardware_beta.version_for('1.5.7', 'sticky', 'global', '12345678'),
+            '1.5.7-sticky-beta+12345678',
+        )
+        self.assertEqual(
+            package_hardware_beta.version_for('1.5.7', 'sticky', 'zh-CN', '12345678'),
+            '1.5.7-sticky-cn-beta+12345678',
+        )
+        with self.assertRaises(KeyError):
+            package_hardware_beta.environment_for('sticky', 'invalid')
+        with self.assertRaises(KeyError):
+            package_hardware_beta.version_for('1.5.7', 'sticky', 'invalid', '12345678')
+
     def write_image(self, chip_id=package_hardware_beta.ESP32S3_CHIP_ID, board='eego_a4'):
         image = bytearray(24)
         image[0] = 0xE9


### PR DESCRIPTION
Summary:
- build and package International and Simplified-Chinese firmware together for each S3 hardware beta
- publish International assets to GitHub and Simplified-Chinese assets to Gitee under the same rolling tag
- document regional package behavior

Validation:
- python3 -m unittest scripts/tests/test_package_hardware_beta.py
- all 12 PlatformIO environments built successfully
- all 12 packages passed board, ESP32-S3, partition, file-set, and SHA-256 validation