### PR TITLE
fix(eego-a4): restore fast page turns, clean frontlight overlay, unstick text settings

### DIFF
--- a/lib/GfxRenderer/FontCacheManager.cpp
+++ b/lib/GfxRenderer/FontCacheManager.cpp
@@ -5,6 +5,7 @@
 #include <SdCardFont.h>
 
 #include <cstring>
+#include <iterator>
 
 #ifdef ENABLE_CHINESE_VERSION
 namespace {
@@ -100,6 +101,16 @@ bool FontCacheManager::isScanning() const { return scanMode_ == ScanMode::Scanni
 void FontCacheManager::recordText(const char* text, const int fontId, EpdFontFamily::Style style) {
   scanText_ += text;
   if (scanFontId_ < 0) scanFontId_ = fontId;
+  if (scanFontIdCount_ < static_cast<int>(std::size(scanFontIds_))) {
+    bool known = false;
+    for (int i = 0; i < scanFontIdCount_; i++) {
+      if (scanFontIds_[i] == fontId) {
+        known = true;
+        break;
+      }
+    }
+    if (!known) scanFontIds_[scanFontIdCount_++] = fontId;
+  }
   const uint8_t baseStyle = static_cast<uint8_t>(style) & 0x03;
   const unsigned char* p = reinterpret_cast<const unsigned char*>(text);
   uint32_t cpCount = 0;
@@ -135,6 +146,10 @@ FontCacheManager::PrewarmScope::PrewarmScope(FontCacheManager& manager) : manage
   manager_->scanText_.reserve(2048);  // Pre-allocate to avoid heap fragmentation from repeated concat
   memset(manager_->scanStyleCounts_, 0, sizeof(manager_->scanStyleCounts_));
   manager_->scanFontId_ = -1;
+  manager_->scanFontIdCount_ = 0;
+  for (int i = 0; i < static_cast<int>(std::size(manager_->scanFontIds_)); i++) {
+    manager_->scanFontIds_[i] = -1;
+  }
 #ifdef ENABLE_CHINESE_VERSION
   manager_->missingChineseCodepoint_ = 0;
 #endif
@@ -151,7 +166,18 @@ void FontCacheManager::PrewarmScope::endScanAndPrewarm() {
   }
   if (styleMask == 0) styleMask = 1;  // default to regular
 
-  manager_->prewarmCache(manager_->scanFontId_, manager_->scanText_.c_str(), styleMask);
+  // Prewarm every distinct font seen during the scan: a UI font that drew
+  // before the body text (status bar, placeholders) must not steal the whole
+  // prewarm; the reader font carrying the page text is among the recorded ids.
+  if (manager_->scanFontIdCount_ == 0 && manager_->scanFontId_ >= 0) {
+    manager_->scanFontIds_[0] = manager_->scanFontId_;
+    manager_->scanFontIdCount_ = 1;
+  }
+  for (int i = 0; i < manager_->scanFontIdCount_; i++) {
+    const int fontId = manager_->scanFontIds_[i];
+    if (fontId == -1) continue;  // unused slot; SD font ids are signed FNV hashes and may be negative
+    manager_->prewarmCache(fontId, manager_->scanText_.c_str(), styleMask);
+  }
 
   // Free scan string memory
   manager_->scanText_.clear();

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -61,6 +61,11 @@ class FontCacheManager {
   std::string scanText_;
   uint32_t scanStyleCounts_[4] = {};
   int scanFontId_ = -1;
+  // All distinct font ids seen during the scan; the prewarm runs for each so a
+  // UI font drawn before the body text (e.g. the status bar) can never hijack
+  // the whole scan into the wrong font.
+  int scanFontIds_[4] = {-1, -1, -1, -1};
+  int scanFontIdCount_ = 0;
 #ifdef ENABLE_CHINESE_VERSION
   uint32_t missingChineseCodepoint_ = 0;
 #endif

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1239,6 +1239,11 @@ void EpubReaderActivity::renderBook() {
   } else {
     orientedMarginBottom += std::max(SETTINGS.screenMargin, statusBarHeight);
   }
+#if FREEINK_DEVICE_EEGO_A4
+  // The A4's status bar is lifted 2 px so the bezel does not cover it (see
+  // BaseTheme::drawStatusBar); reserve the same space for the content.
+  orientedMarginBottom += 2;
+#endif
 
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
   const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1240,9 +1240,9 @@ void EpubReaderActivity::renderBook() {
     orientedMarginBottom += std::max(SETTINGS.screenMargin, statusBarHeight);
   }
 #if FREEINK_DEVICE_EEGO_A4
-  // The A4's status bar is lifted 2 px so the bezel does not cover it (see
+  // The A4's status bar is lifted 4 px so the bezel does not cover it (see
   // BaseTheme::drawStatusBar); reserve the same space for the content.
-  orientedMarginBottom += 2;
+  orientedMarginBottom += 4;
 #endif
 
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1650,8 +1650,9 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   std::optional<FontCacheManager::PrewarmScope> prewarmScope;
   if (fcm->needsPrewarmScan(fontId)) {
     prewarmScope.emplace(*fcm);
+    // Scan pass records the page text only (status bar glyphs are flash-resident
+    // UI fonts and would otherwise shadow the reader font in the prewarm).
     renderPage();
-    renderStatusBar();
     prewarmScope->endScanAndPrewarm();
   } else {
     fcm->clearCache();

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -258,9 +258,9 @@ void TxtReaderActivity::initializeReader() {
   cachedOrientedMarginBottom +=
       std::max(cachedScreenMargin, static_cast<uint8_t>(UITheme::getInstance().getStatusBarHeight()));
 #if FREEINK_DEVICE_EEGO_A4
-  // The A4's status bar is lifted 2 px so the bezel does not cover it (see
+  // The A4's status bar is lifted 4 px so the bezel does not cover it (see
   // BaseTheme::drawStatusBar); reserve the same space for the content.
-  cachedOrientedMarginBottom += 2;
+  cachedOrientedMarginBottom += 4;
 #endif
 
   viewportWidth = renderer.getScreenWidth() - cachedOrientedMarginLeft - cachedOrientedMarginRight;

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -257,6 +257,11 @@ void TxtReaderActivity::initializeReader() {
   cachedOrientedMarginRight += cachedScreenMargin;
   cachedOrientedMarginBottom +=
       std::max(cachedScreenMargin, static_cast<uint8_t>(UITheme::getInstance().getStatusBarHeight()));
+#if FREEINK_DEVICE_EEGO_A4
+  // The A4's status bar is lifted 2 px so the bezel does not cover it (see
+  // BaseTheme::drawStatusBar); reserve the same space for the content.
+  cachedOrientedMarginBottom += 2;
+#endif
 
   viewportWidth = renderer.getScreenWidth() - cachedOrientedMarginLeft - cachedOrientedMarginRight;
   const int viewportHeight = renderer.getScreenHeight() - cachedOrientedMarginTop - cachedOrientedMarginBottom;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -533,7 +533,14 @@ void TextSettingsActivity::exitAfterFinalFont(const ExitDestination destination)
   SETTINGS.sdFontFlashPreload = 0;
   SETTINGS.saveToFile();
   exitInProgress_ = false;
-  optionPopup_.show(StrId::STR_FONT_PRELOAD_FAILED, OK_OPTION, static_cast<int>(std::size(OK_OPTION)), 0, [](int) {});
+  // Preload failure is informational (the font still loads from SD at runtime);
+  // acknowledging the popup exits exactly like the success path, with a
+  // cancelled result so the caller does not treat it as a font change.
+  ActivityResult result;
+  result.isCancelled = true;
+  setResult(std::move(result));
+  optionPopup_.show(StrId::STR_FONT_PRELOAD_FAILED, OK_OPTION, static_cast<int>(std::size(OK_OPTION)), 0,
+                    [this](int) { completeExit(); });
   requestUpdate();
 }
 

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <FreeInkUIIcon.h>
 #include <GfxRenderer.h>
+#include <HalDisplay.h>
 #include <HalFrontlight.h>
 #include <I18n.h>
 
@@ -43,6 +44,7 @@ void FrontlightPanelActivity::onEnter() {
   warmth = Frontlight.warmth();
   lightOn = Frontlight.isOn();
   lightOnChanged = false;
+  firstRender = true;
 
   resetUi();
   app.on(ACTION_BRIGHTNESS, &FrontlightPanelActivity::onBrightnessEvent, this);
@@ -69,6 +71,11 @@ void FrontlightPanelActivity::onExit() {
     SETTINGS.saveToFile();
   }
   Activity::onExit();
+#if FREEINK_DEVICE_EEGO_A4
+  // The overlay pops back to the reader's gray AA page; force a clean first
+  // frame so the panel's white region does not ghost over the text.
+  renderer.requestNextFullRefresh();
+#endif
 }
 
 void FrontlightPanelActivity::onBrightnessEvent(const fui::ActionEvent& event, void* user) {
@@ -271,5 +278,6 @@ void FrontlightPanelActivity::render(RenderLock&&) {
   renderUi();
 
   renderer.fillRect(0, panelBottom - 2, pageWidth, 2, true);
-  renderer.displayBuffer();
+  renderer.displayBuffer(firstRender ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
+  firstRender = false;
 }

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -44,7 +44,12 @@ void FrontlightPanelActivity::onEnter() {
   warmth = Frontlight.warmth();
   lightOn = Frontlight.isOn();
   lightOnChanged = false;
-  firstRender = true;
+#if FREEINK_DEVICE_EEGO_A4
+  // The first frame draws over the reader's gray AA page; a HALF refresh keeps
+  // the overlay clean instead of ghosting. Other boards keep the standard
+  // FAST_REFRESH first frame (X4 Pro reference behavior).
+  renderer.requestNextRefresh(HalDisplay::HALF_REFRESH);
+#endif
 
   resetUi();
   app.on(ACTION_BRIGHTNESS, &FrontlightPanelActivity::onBrightnessEvent, this);
@@ -278,6 +283,5 @@ void FrontlightPanelActivity::render(RenderLock&&) {
   renderUi();
 
   renderer.fillRect(0, panelBottom - 2, pageWidth, 2, true);
-  renderer.displayBuffer(firstRender ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
-  firstRender = false;
+  renderer.displayBuffer();
 }

--- a/src/activities/util/FrontlightPanelActivity.h
+++ b/src/activities/util/FrontlightPanelActivity.h
@@ -24,6 +24,9 @@ class FrontlightPanelActivity final : public Activity, private UiAppHost {
   bool lightOnChanged = false;
   bool draggingSlider = false;
   int panelBottom = 0;
+  // First frame after summoning draws over the reader's content (gray AA text
+  // on the A4); a full refresh keeps the overlay clean instead of ghosting.
+  bool firstRender = true;
 
   static void panelScreen(UiScreen& screen, void* user);
   static void onBrightnessEvent(const freeink::ui::ActionEvent& event, void* user);

--- a/src/activities/util/FrontlightPanelActivity.h
+++ b/src/activities/util/FrontlightPanelActivity.h
@@ -24,9 +24,6 @@ class FrontlightPanelActivity final : public Activity, private UiAppHost {
   bool lightOnChanged = false;
   bool draggingSlider = false;
   int panelBottom = 0;
-  // First frame after summoning draws over the reader's content (gray AA text
-  // on the A4); a full refresh keeps the overlay clean instead of ghosting.
-  bool firstRender = true;
 
   static void panelScreen(UiScreen& screen, void* user);
   static void onBrightnessEvent(const freeink::ui::ActionEvent& event, void* user);

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -885,13 +885,18 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
   const auto screenHeight = renderer.getScreenHeight();
   auto textY = screenHeight - UITheme::getInstance().getStatusBarHeight() - orientedMarginBottom - paddingBottom - 4;
 
-  const int leftClusterX = metrics.statusBarHorizontalMargin + orientedMarginLeft + 1;
-  const int rightClusterX = renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight;
+  int leftClusterX = metrics.statusBarHorizontalMargin + orientedMarginLeft + 1;
+  int rightClusterX = renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight;
 #if FREEINK_DEVICE_EEGO_A4
-  // On the physical panel only the bottom ~2 px of the status bar is covered by
-  // the bezel, so lift the cluster by that amount (measured on device). The
-  // horizontal positions are untouched.
-  textY -= 2;
+  // The EEGO A4 panel has physically rounded corners; the status bar text must
+  // stay inside the 28 px UI content inset (eego-a4-template-firmware
+  // SAFE_AREA spec), so clamp the left/right text clusters out of the corner
+  // cutouts. The bottom ~4 px of the bar is covered by the bezel, so the whole
+  // cluster is also lifted by that amount (measured on device).
+  constexpr int kEegoStatusBarSafeInset = 28;
+  leftClusterX = std::max(leftClusterX, kEegoStatusBarSafeInset);
+  rightClusterX = std::min(rightClusterX, renderer.getScreenWidth() - kEegoStatusBarSafeInset);
+  textY -= 4;
 #endif
   int leftClusterWidth = 0;
   int rightClusterWidth = 0;
@@ -921,12 +926,12 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
   // Draw Progress Bar
   if (sb.showsProgressBar()) {
 #if FREEINK_DEVICE_EEGO_A4
-    // The bar's bottom edge is lifted 2 px so the bezel does not cover it
+    // The bar's bottom edge is lifted 4 px so the bezel does not cover it
     // (measured on device); horizontal span is untouched.
     const int barMarginLeft = fillMargin ? 0 : orientedMarginLeft;
     const int barMarginRight = fillMargin ? 0 : orientedMarginRight;
     const int progressBarMaxWidth = renderer.getScreenWidth() - barMarginLeft - barMarginRight;
-    const int progressBarY = renderer.getScreenHeight() - 2 - orientedMarginBottom - sb.progressBarHeightPx -
+    const int progressBarY = renderer.getScreenHeight() - 4 - orientedMarginBottom - sb.progressBarHeightPx -
                              paddingBottom + (fillMargin ? 1 : 0);
 #else
     const int barMarginLeft = fillMargin ? 0 : orientedMarginLeft;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -887,6 +887,12 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
 
   const int leftClusterX = metrics.statusBarHorizontalMargin + orientedMarginLeft + 1;
   const int rightClusterX = renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight;
+#if FREEINK_DEVICE_EEGO_A4
+  // On the physical panel only the bottom ~2 px of the status bar is covered by
+  // the bezel, so lift the cluster by that amount (measured on device). The
+  // horizontal positions are untouched.
+  textY -= 2;
+#endif
   int leftClusterWidth = 0;
   int rightClusterWidth = 0;
 
@@ -914,11 +920,21 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
 
   // Draw Progress Bar
   if (sb.showsProgressBar()) {
+#if FREEINK_DEVICE_EEGO_A4
+    // The bar's bottom edge is lifted 2 px so the bezel does not cover it
+    // (measured on device); horizontal span is untouched.
+    const int barMarginLeft = fillMargin ? 0 : orientedMarginLeft;
+    const int barMarginRight = fillMargin ? 0 : orientedMarginRight;
+    const int progressBarMaxWidth = renderer.getScreenWidth() - barMarginLeft - barMarginRight;
+    const int progressBarY = renderer.getScreenHeight() - 2 - orientedMarginBottom - sb.progressBarHeightPx -
+                             paddingBottom + (fillMargin ? 1 : 0);
+#else
     const int barMarginLeft = fillMargin ? 0 : orientedMarginLeft;
     const int barMarginRight = fillMargin ? 0 : orientedMarginRight;
     const int progressBarMaxWidth = renderer.getScreenWidth() - barMarginLeft - barMarginRight;
     const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom - sb.progressBarHeightPx -
                              paddingBottom + (fillMargin ? 1 : 0);
+#endif
     size_t progress;
     if (sb.progressBarMode == CrossPointSettings::STATUS_BAR_PROGRESS_BAR::BOOK_PROGRESS) {
       progress = static_cast<size_t>(bookProgress);


### PR DESCRIPTION
## 背景

EEGO A4（eego_a4_cn）真机回归修复，四个问题一起修：

### 1. 翻页慢：SD 字体字形预热失效（~14.5s → ~1.37s/页）

- **现象**：AA 开启时每页 11~15 秒，串口显示每页 3486 次"Overflow 8 槽按需加载"，每个字形 ~17ms 单读。
- **根因**：扫描预热只记录**第一个**出现的字体 id。阅读器扫描段先画了状态栏（SMALL_FONT_ID），把预热整体劫持到 UI 字体上，正文 SD 字体（id 为负数的 FNV 哈希，如 -232053333）从未被预热；渲染时每次字形查找都掉进 8 槽 overflow 缓存，三趟渲染（BW/LSB/MSB）各自全量重读。
- **修复**：
  - ecordText() 记录扫描中出现的**所有**不同字体 id，endScanAndPrewarm() 逐个预热（FontCacheManager）。
  - 预热循环只跳过 -1 哨兵槽位——**SD 字体 id 是带符号 FNV 哈希，可能为负**，不能按 ontId < 0 跳过。
  - 阅读器扫描段不再渲染状态栏（其字形是常驻闪存的 UI 字体，且会抢占预热记录），对齐稳定版策略。
- **实测**（COM14 真机串口计时）：prewarmCache(SD) missed=0；稳定态 w_render≈120ms、gray_lsb/msb≈125ms、gray_display≈935ms，**整页 1371ms**（旧稳定版 1975ms，回归前 14500ms）。

### 2. 文字设置无法退出（新固件回归）

- **现象**："预加载失败"弹窗（本设备属正常现象）点 OK 后回到文字设置，再按返回又弹窗，永远退不出。
- **根因**：main 版失败路径重置了 exitInProgress_，但弹窗 OK 回调为空——只关弹窗不退出，返回键又重复触发失败流程。
- **修复**：OK 回调直接 completeExit()，带 cancelled 结果退出（字体运行期仍从 SD 正常加载）。

### 3. 前光面板呼出/关闭后屏幕残影（A4 灰度页）

- **现象**：阅读器内顶部下滑呼出前光面板，覆盖区/关闭后面板白色区域在灰度 AA 页上残影。
- **修复**（eego 限定）：onEnter() 中 equestNextRefresh(HALF_REFRESH) 让首帧全刷显示，onExit() 请求下一帧全刷；其他设备保持标准 FAST_REFRESH 首帧。

### 4. 阅读器状态栏超出安全区/被边框遮挡（eego 限定）

- **现象**：EEGO A4 实体机圆角切角裁掉状态栏左右文字簇（电池/时钟、进度文字），底部约 4px 被面板边框遮挡。
- **修复**（真机实测标定，仅 #if FREEINK_DEVICE_EEGO_A4 生效）：
  - BaseTheme::drawStatusBar：左右文字簇钳制到 28px UI 内容避让内（参考 Lakphy/eego-a4-template-firmware 的 SAFE_AREA.md 规范）；状态栏簇整体上移 4px；进度条横向不变。
  - EpubReaderActivity / TxtReaderActivity：底部预留同步 +4px，正文最后一行不被遮挡。

## 变更文件

- lib/GfxRenderer/FontCacheManager.{h,cpp} — 扫描多字体预热 + 哨兵守卫修正
- src/activities/reader/EpubReaderActivity.cpp — 扫描段移除状态栏渲染 + 底部预留 4px（eego）
- src/activities/settings/TextSettingsActivity.cpp — 预加载失败弹窗 OK 退出
- src/activities/util/FrontlightPanelActivity.{h,cpp} — 首帧全刷（eego 限定）+ 退出干净帧
- src/components/themes/BaseTheme.cpp — 状态栏文字安全区钳制 + 上移 4px（eego）
- src/activities/reader/TxtReaderActivity.cpp — 底部预留 4px（eego）

## 验证

- 真机 COM14（EEGO A4，eego_a4_cn）串口逐页计时确认翻页 1.37s/页
- 前光面板呼出/关闭、文字设置退出、状态栏显示均真机验证通过
- 所有改动均 #if FREEINK_DEVICE_EEGO_A4 限定或通用路径，其他设备行为不变