### PR TITLE
refactor: sync Murphy M4 FreeInk drivers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "freeink-sdk"]
 	path = freeink-sdk
 	url = https://github.com/0x1abin/freeink-sdk.git
-	branch = crossmux/inx-compat
+	branch = crossmux

--- a/docs/engineering/murphy-m4.md
+++ b/docs/engineering/murphy-m4.md
@@ -11,16 +11,18 @@ pio run -e simulator_murphy_m4 -t run_simulator
 ```
 
 Hardware profiles and drivers live in the pinned `0x1abin/freeink-sdk`
-submodule. CrossMux adds only the build, frontlight settings, and experimental
-product gates: AirPage and remote OTA are hidden, while reading, library,
-settings, Web file transfer, and same-target SD firmware update remain.
+submodule on its long-lived `crossmux` branch. The M4 button, FT6336U touch and
+GPIO/LEDC frontlight paths track upstream FreeInk commit `e4d3cc33`; CrossMux
+retains the two display batches, RX8010, GPIO43 charge input, SDMMC and product
+gates. AirPage and remote OTA are hidden, while reading, library, settings, Web
+file transfer, and same-target SD firmware update remain.
 
 The desktop target models the 800x480 panel, `murphy_m4` identity, touch and
 rotation, RTC, buttons, dual-channel frontlight state, and Power-only wake. Use
 the mouse for touch, arrows for Up/Down, `P` for Power, and `S` for sleep; M4
 has no Home key, so `H` is ignored. It does not replace hardware tests for
-display batches/ghosting, FT6336 polling, SDMMC contention, PWM curves, PSRAM,
-or standby current.
+display batches/ghosting, FT6336U IRQ/reset behavior, SDMMC contention, PWM
+curves, PSRAM, or standby current.
 
 The default SSD1677 configuration targets the second production batch with
 R13 fitted and uses the verified `0x50` pseudo-temperature. To build for the
@@ -54,14 +56,23 @@ and app at `0x10000` without overwriting NVS.
 - Verify direction, edge pattern, Full/Fast/grayscale and ghosting on both
   display batches.
 - Verify four-corner touch, swipes and rotations, including a short touch while
-  an e-paper refresh blocks the main loop; record the FT6336 task stack high-water mark.
-- Verify GPIO0/1/2 buttons, concurrent 4-bit SDMMC/display use, ADC9 battery,
-  active-low GPIO43 charging, and RX8010 power-loss retention/VLF handling.
-- Verify warm/cool PWM curves and restoration after wake.
+  an e-paper refresh blocks the main loop; confirm GPIO44 active-low IRQ and
+  that GPIO7 display reset is followed by successful FT6336U reinitialization.
+- Verify GPIO1/2 navigation and GPIO0 shared input: short press emits only
+  Confirm (or only Power when the existing short-power option is enabled), and
+  long press emits only Power.
+- Exercise touch while repeatedly reading/writing RX8010; confirm both devices
+  share I²C1 without conflicts or bus/device recreation. Also verify concurrent
+  4-bit SDMMC/display use, ADC9 battery, active-low GPIO43 charging, and RX8010
+  power-loss retention/VLF handling.
+- Measure GPIO47/48 at about 25 kHz / 10-bit and verify the gamma curve at
+  0/1/5/50/100%, both color-temperature endpoints, off, and wake restoration.
 - Cycle deep sleep and confirm GPIO10/45 rails turn off, frontlight is off,
   GPIO0 wakes the device, and standby current is stable.
-- Record internal heap, largest block and PSRAM through repeated reading,
-  grayscale and Wi-Fi cycles; none may show a continuing decline.
+- Record free heap, minimum free heap, largest block and PSRAM before/after
+  initialization and through repeated touch/RTC/sleep, reading, grayscale and
+  Wi-Fi cycles. The removed M4-only touch task must be absent, I²C handles must
+  be allocated only at startup, and no metric may show a continuing decline.
 
 AHT20, SC7A20, runtime panel-batch settings, AirPage, remote OTA and complex SD
 fallback remain outside this experimental target.

--- a/docs/engineering/murphy-m4.md
+++ b/docs/engineering/murphy-m4.md
@@ -17,6 +17,12 @@ retains the two display batches, RX8010, GPIO43 charge input, SDMMC and product
 gates. AirPage and remote OTA are hidden, while reading, library, settings, Web
 file transfer, and same-target SD firmware update remain.
 
+The M4 keeps its boot CPU frequency fixed because hardware validation found
+FT6336U input unreliable after runtime clock changes. Idle power saving still
+uses the normal 50 ms main-loop delay. Touch initialization reads back the
+volatile mode, threshold, and report-rate registers before accepting input;
+invalid status/event/coordinate frames are discarded without latching contact.
+
 The desktop target models the 800x480 panel, `murphy_m4` identity, touch and
 rotation, RTC, buttons, dual-channel frontlight state, and Power-only wake. Use
 the mouse for touch, arrows for Up/Down, `P` for Power, and `S` for sleep; M4
@@ -57,7 +63,9 @@ and app at `0x10000` without overwriting NVS.
   display batches.
 - Verify four-corner touch, swipes and rotations, including a short touch while
   an e-paper refresh blocks the main loop; confirm GPIO44 active-low IRQ and
-  that GPIO7 display reset is followed by successful FT6336U reinitialization.
+  that GPIO7 display reset is followed by successful FT6336U reinitialization
+  with `0x00=0x00`, `0x80=0x16`, and `0x88=0x04` read back correctly. Confirm
+  invalid frames neither create phantom touches nor leave an active touch stuck.
 - Verify GPIO1/2 navigation and GPIO0 shared input: short press emits only
   Confirm (or only Power when the existing short-power option is enabled), and
   long press emits only Power.
@@ -69,6 +77,8 @@ and app at `0x10000` without overwriting NVS.
   0/1/5/50/100%, both color-temperature endpoints, off, and wake restoration.
 - Cycle deep sleep and confirm GPIO10/45 rails turn off, frontlight is off,
   GPIO0 wakes the device, and standby current is stable.
+- Repeatedly alternate more than three seconds of idle time with touch input;
+  confirm the CPU clock remains at its boot frequency and touch stays responsive.
 - Record free heap, minimum free heap, largest block and PSRAM before/after
   initialization and through repeated touch/RTC/sleep, reading, grayscale and
   Wi-Fi cycles. The removed M4-only touch task must be absent, I²C handles must

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -212,6 +212,8 @@ void HalGPIO::clearTouchTapEvent() { inputMgr.clearTouchTapEvent(); }
 
 void HalGPIO::prepareForDeepSleep() { inputMgr.prepareForDeepSleep(); }
 
+bool HalGPIO::restoreTouchAfterDisplayReset() { return inputMgr.reinitializeTouchAfterSharedReset(); }
+
 void HalGPIO::setSharedConfirmPowerShortPressEmitsPower(const bool enabled) {
   InputManager::setSharedConfirmPowerShortPressEmitsPower(enabled);
 }

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -109,6 +109,7 @@ class HalGPIO {
   // runs mid-frame; without this the incoming activity double-activates).
   void clearTouchTapEvent();
   void prepareForDeepSleep();
+  bool restoreTouchAfterDisplayReset();
   void setSharedConfirmPowerShortPressEmitsPower(bool enabled);
 
   // Verify power button was held long enough after wakeup.

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -36,6 +36,12 @@ void HalPowerManager::begin() {
 }
 
 void HalPowerManager::setPowerSaving(bool enabled) {
+#if FREEINK_DEVICE_MURPHY_M4
+  // Hardware validation found FT6336U touch unreliable after runtime CPU clock
+  // changes. The main loop still uses its 50 ms idle delay on this target.
+  (void)enabled;
+  return;
+#else
   if (normalFreq <= 0) {
     return;  // invalid state
   }
@@ -68,6 +74,7 @@ void HalPowerManager::setPowerSaving(bool enabled) {
   }
 
   // Otherwise, no change needed
+#endif
 }
 
 void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,6 +372,11 @@ bool setupDisplayAndFonts(bool seamless = false) {
 #endif
 
   display.begin(seamless);
+#if FREEINK_DEVICE_MURPHY_M4
+  if (!gpio.restoreTouchAfterDisplayReset()) {
+    LOG_ERR("MAIN", "Failed to restore Murphy M4 touch after display reset");
+  }
+#endif
   renderer.begin();
   activityManager.begin();
   LOG_DBG("MAIN", "Display initialized");


### PR DESCRIPTION
## Summary

- track `0x1abin/freeink-sdk:crossmux` at `c9e9d2f`, based on the retained compatibility line and pinned to upstream FreeInk `e4d3cc33`
- align Murphy M4 buttons, FT6336U touch, shared native I2C1 RTC access, and GPIO/LEDC frontlight gamma behavior with the official implementation
- restore volatile FT6336U settings through the HAL after the display toggles shared reset GPIO7
- keep the M4 CPU at its boot frequency because runtime clock switching destabilizes FT6336U input on hardware
- verify FT6336U configuration readback and reject invalid status, event, coordinate, and stuck `0x01` frames without latching touch
- preserve M4 display batches, RX8010, GPIO43 charging, SDMMC, product restrictions, and experimental status

## SDK branch maintenance

- pushed long-lived SDK branch `crossmux`
- preserved the previous rollback tips as `legacy/crossmux-inx-compat` and `legacy/crossmux-waveshare-397`; the rename was required because Git cannot store `crossmux` beside refs below `crossmux/*`

## Validation

- `git diff --check`
- SDK changed-line `clang-format-21` check
- `./bin/ci-check`: formatting, cppcheck, 7 firmware environments, 395/395 host tests
- `pio run -e murphy_m4`
- `pio run -e murphy_m4_cn`
- `pio run -e simulator_murphy_m4`

Hardware verification remains required for buttons, touch/RTC concurrency, fixed CPU frequency during repeated idle/activity cycles, FT6336U register readback and invalid-frame recovery, GPIO44 IRQ, GPIO7 reset recovery, 25 kHz PWM, sleep/wake, and heap stability.
