### PR TITLE
feat: make AirPage QR URL capability-driven

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -105,7 +105,10 @@ void AirPageActivity::onEnter() {
   uploadUrl_ += kAirPageBase;
   uploadUrl_ += "/?id=";
   uploadUrl_ += deviceId;
-  uploadUrl_ += gpio.deviceIsX3() ? "&type=xteink-x3" : "&type=xteink-x4";
+  char displayParams[48];
+  snprintf(displayParams, sizeof(displayParams), "&w=%u&h=%u&mode=gray4",
+           static_cast<unsigned>(renderer.getDisplayHeight()), static_cast<unsigned>(renderer.getDisplayWidth()));
+  uploadUrl_ += displayParams;
 
   downloadUrl_.reserve(64 + deviceId.size());
   downloadUrl_ = "https://";

--- a/src/activities/apps/airpage/AirPageConnection.cpp
+++ b/src/activities/apps/airpage/AirPageConnection.cpp
@@ -22,6 +22,8 @@ constexpr char kMqttHost[] = "mqtt-cn.uipcat.com";
 constexpr uint16_t kMqttPort = 1883;
 constexpr uint16_t kMqttSocketTimeoutSeconds = 5;
 constexpr uint16_t kMqttKeepAliveSeconds = 57;
+constexpr char kMqttOnline[] = "online";
+constexpr char kMqttOffline[] = "offline";
 constexpr uint32_t kWifiConnectTimeoutMs = 15000u;
 constexpr uint32_t kLiveRetryWindowMs = 120000u;
 constexpr uint32_t kRetryDelaysMs[] = {5000u, 10000u, 20000u, 30000u};
@@ -59,7 +61,7 @@ AirPageConnection::Event AirPageConnection::begin(const bool realtime) {
 }
 
 void AirPageConnection::stop() {
-  if (mqtt_.connected()) mqtt_.disconnect();
+  disconnectBroker();
   state_ = State::Off;
   sPushPending = false;
   teardownWifi();
@@ -87,7 +89,7 @@ AirPageConnection::Event AirPageConnection::setRealtime(const bool enabled) {
   retryCount_ = 0;
 
   if (!realtime_) {
-    if (mqtt_.connected()) mqtt_.disconnect();
+    disconnectBroker();
     if (wifiConnected()) {
       state_ = State::WifiOnline;
     } else {
@@ -147,7 +149,7 @@ AirPageConnection::Event AirPageConnection::scheduleRetry() {
 }
 
 AirPageConnection::Event AirPageConnection::pause(const Event event) {
-  if (mqtt_.connected()) mqtt_.disconnect();
+  disconnectBroker();
   state_ = State::Paused;
   teardownWifi();
   return event;
@@ -156,20 +158,37 @@ AirPageConnection::Event AirPageConnection::pause(const Event event) {
 bool AirPageConnection::connectBroker() {
   char clientId[24];
   snprintf(clientId, sizeof(clientId), "%s-%s", gpio.deviceIsX3() ? "x3" : "x4", deviceId().c_str());
-  if (!mqtt_.connect(clientId)) {
+  char statusTopic[64];
+  snprintf(statusTopic, sizeof(statusTopic), "airpage/device/%s/status", deviceId().c_str());
+  if (!mqtt_.connect(clientId, statusTopic, 0, true, kMqttOffline)) {
     LOG_ERR("AIRP", "MQTT connect failed (state=%d)", mqtt_.state());
     return false;
   }
 
-  char topic[64];
-  snprintf(topic, sizeof(topic), "airpage/device/%s/refresh", deviceId().c_str());
-  if (!mqtt_.subscribe(topic)) {
-    LOG_ERR("AIRP", "MQTT subscribe failed: %s", topic);
-    mqtt_.disconnect();
+  char refreshTopic[64];
+  snprintf(refreshTopic, sizeof(refreshTopic), "airpage/device/%s/refresh", deviceId().c_str());
+  if (!mqtt_.subscribe(refreshTopic)) {
+    LOG_ERR("AIRP", "MQTT subscribe failed: %s", refreshTopic);
+    disconnectBroker();
     return false;
   }
-  LOG_INF("AIRP", "MQTT online, subscribed %s", topic);
+  if (!mqtt_.publish(statusTopic, kMqttOnline, true)) {
+    LOG_ERR("AIRP", "MQTT online status failed: %s", statusTopic);
+    disconnectBroker();
+    return false;
+  }
+  LOG_INF("AIRP", "MQTT online, subscribed %s", refreshTopic);
   return true;
+}
+
+void AirPageConnection::disconnectBroker() {
+  if (!mqtt_.connected()) return;
+  char statusTopic[64];
+  snprintf(statusTopic, sizeof(statusTopic), "airpage/device/%s/status", deviceId().c_str());
+  if (!mqtt_.publish(statusTopic, kMqttOffline, true)) {
+    LOG_ERR("AIRP", "MQTT offline status failed: %s", statusTopic);
+  }
+  mqtt_.disconnect();
 }
 
 AirPageConnection::Event AirPageConnection::pump(const bool allowPush) {

--- a/src/activities/apps/airpage/AirPageConnection.cpp
+++ b/src/activities/apps/airpage/AirPageConnection.cpp
@@ -21,7 +21,7 @@ namespace {
 constexpr char kMqttHost[] = "mqtt-cn.uipcat.com";
 constexpr uint16_t kMqttPort = 1883;
 constexpr uint16_t kMqttSocketTimeoutSeconds = 5;
-constexpr uint16_t kMqttKeepAliveSeconds = 30;
+constexpr uint16_t kMqttKeepAliveSeconds = 57;
 constexpr uint32_t kWifiConnectTimeoutMs = 15000u;
 constexpr uint32_t kLiveRetryWindowMs = 120000u;
 constexpr uint32_t kRetryDelaysMs[] = {5000u, 10000u, 20000u, 30000u};

--- a/src/activities/apps/airpage/AirPageConnection.h
+++ b/src/activities/apps/airpage/AirPageConnection.h
@@ -50,6 +50,7 @@ class AirPageConnection final {
   bool startWifiAssociation();
   void teardownWifi();
   bool connectBroker();
+  void disconnectBroker();
   void resetRetryWindow();
   Event scheduleRetry();
   Event pause(Event event);


### PR DESCRIPTION
## Summary

- encode the AirPage QR URL with the device ID, runtime portrait width and height, and `mode=gray4`
- remove the X3/X4 model branch so supported future devices need no frontend model preset
- format capability parameters in a small stack buffer while reusing the existing URL allocation
- set the device MQTT keepalive to 57 seconds
- publish retained `online`/`offline` availability, including an `offline` last will and graceful disconnect publication

## MQTT availability

- Topic: `airpage/device/<deviceId>/status`
- Payload: `online` or `offline`
- QoS 0, retain enabled

## Tests

- `./bin/clang-format-fix --check`
- `pio run`
- `git diff --check`

## Manual verification

- [ ] Confirm X3 QR contains `w=528&h=792&mode=gray4`
- [ ] Confirm X4 QR contains `w=480&h=800&mode=gray4`
- [ ] Scan, select a template, push, and refresh on both devices
- [ ] Confirm normal exit publishes `offline` immediately and unexpected loss is detected through the 57-second keepalive/LWT
- [ ] Compare AirPage free heap and largest block before and after this change

Companion web PR: https://github.com/0x1abin/airpage/pull/10