### PR TITLE
fix(inx): hide cursor after touch input

### DIFF
--- a/docs/engineering/ui-and-input.md
+++ b/docs/engineering/ui-and-input.md
@@ -164,6 +164,10 @@ action**.
   so the caller can draw its fallback cover.
 * INX front-button hints use black text above a 50% gray bottom line. Empty
   actions draw neither label nor line; directional actions use `<` and `>`.
+* On touch hardware, INX list and app-grid navigation focus follows the last
+  input modality: touch hides it, while a physical button restores it. The
+  logical selection and viewport remain intact, and FreeInkUI's active touch
+  feedback plus semantic values such as checks and switches remain visible.
 
 ## Retained Framebuffer Updates
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -155,6 +155,13 @@ void HalGPIO::begin() {
 
 void HalGPIO::update() {
   inputMgr.update();
+  const bool buttonActivity = inputMgr.wasPressed(BTN_BACK) || inputMgr.wasPressed(BTN_CONFIRM) ||
+                              inputMgr.wasPressed(BTN_LEFT) || inputMgr.wasPressed(BTN_RIGHT) ||
+                              inputMgr.wasPressed(BTN_UP) || inputMgr.wasPressed(BTN_DOWN);
+  const InputModality previous = inputModality.load(std::memory_order_relaxed);
+  const InputModality next = inputModalityAfter(previous, buttonActivity, inputMgr.wasTouchActivity());
+  inputModalityChanged = next != previous;
+  inputModality.store(next, std::memory_order_relaxed);
   const bool connected = isUsbConnected();
   usbStateChanged = (connected != lastUsbConnected);
   lastUsbConnected = connected;

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -3,6 +3,10 @@
 #include <Arduino.h>
 #include <InputManager.h>
 
+#include <atomic>
+
+#include "InputModality.h"
+
 // Display SPI pins (custom pins for XteinkX4, not hardware SPI defaults)
 #define EPD_SCLK 8   // SPI Clock
 #define EPD_MOSI 10  // SPI MOSI (Master Out Slave In)
@@ -45,6 +49,8 @@ class HalGPIO {
 
   bool lastUsbConnected = false;
   bool usbStateChanged = false;
+  std::atomic<InputModality> inputModality{InputModality::Touch};
+  bool inputModalityChanged = false;
 
  public:
   enum class DeviceType : uint8_t { X4, X3 };
@@ -103,6 +109,8 @@ class HalGPIO {
   unsigned long lastTouchHeldMs() const;
   bool wasSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) const;
   bool wasTouchActivity() const;
+  InputModality lastInputModality() const { return inputModality.load(std::memory_order_relaxed); }
+  bool wasInputModalityChanged() const { return inputModalityChanged; }
   // Drop the one-shot touch tap/release edge events. Call on activity
   // transitions so the incoming activity does not re-read a tap the outgoing
   // one consumed (InputManager clears these in update(), but a pushActivity

--- a/lib/hal/InputModality.h
+++ b/lib/hal/InputModality.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+enum class InputModality : uint8_t { Touch, Buttons };
+
+constexpr InputModality inputModalityAfter(const InputModality current, const bool buttonActivity,
+                                           const bool touchActivity) {
+  if (touchActivity) return InputModality::Touch;
+  if (buttonActivity) return InputModality::Buttons;
+  return current;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -212,6 +212,7 @@ build_flags =
   -DDISABLE_FS_H_WARNING=1
   -DDESTRUCTOR_CLOSES_FILE=1
   -Isrc
+  -Ilib/hal
 build_unflags =
   -std=gnu++11
 lib_ignore = hal, PNGdec, JPEGDEC, WebSockets

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -28,7 +28,8 @@ MappedInputManager::Labels Activity::mainTabButtonLabels(const char* back, const
 }
 
 bool Activity::showMainTabContentSelection() const {
-  return !usesMainTabBar() || activityManager.getMainTabFocus() == MainTabFocus::Content;
+  return UITheme::getInstance().showSelectionCursor() &&
+         (!usesMainTabBar() || activityManager.getMainTabFocus() == MainTabFocus::Content);
 }
 
 void Activity::drawPageHeader(const Rect& rect, const char* title, const char* subtitle) const {

--- a/src/components/SelectionCursorPolicy.h
+++ b/src/components/SelectionCursorPolicy.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <FreeInkUICore.h>
+
+#include "InputModality.h"
+
+namespace SelectionCursorPolicy {
+
+constexpr bool visible(const bool inxTheme, const bool hasTouch, const InputModality modality) {
+  return !inxTheme || !hasTouch || modality == InputModality::Buttons;
+}
+
+inline void hideFreeInkListFocus(freeink::ui::ThemeTokens& tokens) {
+  tokens.listRow.selected = tokens.listRow.normal;
+  tokens.listRow.focused = tokens.listRow.normal;
+}
+
+}  // namespace SelectionCursorPolicy

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -11,6 +11,7 @@
 
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
+#include "components/SelectionCursorPolicy.h"
 #include "components/themes/BaseTheme.h"
 #include "components/themes/inx/InxTheme.h"
 #include "components/themes/lyra/Lyra3CoversTheme.h"
@@ -98,6 +99,11 @@ const ThemeMetrics& UITheme::getMetrics() const {
     metricsValid = true;
   }
   return adjustedMetrics;
+}
+
+bool UITheme::showSelectionCursor() const {
+  return SelectionCursorPolicy::visible(currentType == CrossPointSettings::UI_THEME::INX, gpio.hasTouch(),
+                                        gpio.lastInputModality());
 }
 
 int UITheme::getNumberOfItemsPerPage(const GfxRenderer& renderer, bool hasHeader, bool hasTabBar, bool hasButtonHints,

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -102,8 +102,12 @@ const ThemeMetrics& UITheme::getMetrics() const {
 }
 
 bool UITheme::showSelectionCursor() const {
+#ifdef CROSSPOINT_EMULATED
+  return true;
+#else
   return SelectionCursorPolicy::visible(currentType == CrossPointSettings::UI_THEME::INX, gpio.hasTouch(),
                                         gpio.lastInputModality());
+#endif
 }
 
 int UITheme::getNumberOfItemsPerPage(const GfxRenderer& renderer, bool hasHeader, bool hasTabBar, bool hasButtonHints,

--- a/src/components/UITheme.h
+++ b/src/components/UITheme.h
@@ -22,6 +22,7 @@ class UITheme {
   const BaseTheme& getTheme() const { return *currentTheme; }
   bool usesClassicTabs() const { return currentType == CrossPointSettings::UI_THEME::CLASSIC; }
   bool hasMainTabs() const { return currentType == CrossPointSettings::UI_THEME::INX; }
+  bool showSelectionCursor() const;
   Rect getScreenSafeArea(const GfxRenderer& renderer, bool hasFrontButtonHints = false,
                          bool hasSideButtonHints = false);
   static void drawCenteredText(const GfxRenderer& renderer, Rect screen, int fontId, int y, const char* text,

--- a/src/components/UIThemeTokens.h
+++ b/src/components/UIThemeTokens.h
@@ -2,6 +2,7 @@
 #include <BoardConfig.h>
 #include <FreeInkUIGfxRenderer.h>
 
+#include "SelectionCursorPolicy.h"
 #include "UITheme.h"
 
 namespace ui_theme_detail {
@@ -51,5 +52,6 @@ inline freeink::ui::ThemeTokens uiThemeTokens(const freeink::ui::GfxRendererTarg
   tokens.listEmphasizedText = tokens.titleText;
   tokens.listEmphasizedText.bold = true;
   tokens.listValueText = tokens.bodyText;
+  if (!UITheme::getInstance().showSelectionCursor()) SelectionCursorPolicy::hideFreeInkListFocus(tokens);
   return tokens;
 }

--- a/src/components/UiAppHost.cpp
+++ b/src/components/UiAppHost.cpp
@@ -14,6 +14,7 @@ void UiAppHost::resetUi() {
 
 void UiAppHost::renderUi() {
   app.setDevice(uiTarget.deviceContext());
+  refreshSharedUiThemeTokens(uiTarget);
   app.render();
   uiReady = true;
 }

--- a/src/components/themes/inx/InxTheme.cpp
+++ b/src/components/themes/inx/InxTheme.cpp
@@ -11,6 +11,7 @@
 #include "CrossPointSettings.h"
 #include "I18n.h"
 #include "InxItemLayout.h"
+#include "components/UITheme.h"
 #include "components/icons/inx_apps.h"
 #include "components/icons/inx_tabs.h"
 #include "fontIds.h"
@@ -231,11 +232,12 @@ void InxTheme::drawList(const GfxRenderer& renderer, const Rect rect, const int 
   const bool hasScrollBar = itemCount > pageItems;
   const int contentRight = rect.x + rect.width - (hasScrollBar ? 10 : 0);
   const int iconSize = rowSubtitle != nullptr ? kMenuIconSize : kListIconSize;
+  const bool selectionVisible = showSelection && UITheme::getInstance().showSelectionCursor();
 
   for (int index = pageStart; index < pageEnd; ++index) {
     const int slot = index - pageStart;
     const int rowY = rect.y + slot * kRowHeight;
-    const bool selected = showSelection && index == selectedIndex;
+    const bool selected = selectionVisible && index == selectedIndex;
     if (selected) renderer.fillRect(rect.x, rowY, rect.width, kRowHeight, true);
 
     int textX = rect.x + kRowPadding;
@@ -288,9 +290,10 @@ void InxTheme::drawButtonMenu(GfxRenderer& renderer, const Rect rect, const int 
   const int pageItems = InxMenuGeometry::pageItems(rect.height);
   const int pageStart = InxMenuGeometry::pageStart(selectedIndex, buttonCount, rect.height);
   const int pageEnd = std::min(buttonCount, pageStart + pageItems);
+  const bool selectionVisible = UITheme::getInstance().showSelectionCursor();
   for (int index = pageStart; index < pageEnd; ++index) {
     const int rowY = rect.y + (index - pageStart) * kRowHeight;
-    const bool selected = index == selectedIndex;
+    const bool selected = selectionVisible && index == selectedIndex;
     if (selected) renderer.fillRect(rect.x, rowY, rect.width, kRowHeight, true);
 
     int textX = rect.x + kRowPadding;
@@ -334,6 +337,7 @@ void InxTheme::drawOptionPopup(const GfxRenderer& renderer, const char* title, c
   const int panelHeight = InxOptionGeometry::headerHeight + visibleRows * InxOptionGeometry::rowHeight;
   const int panelX = (screenWidth - panelWidth) / 2;
   const int panelY = std::max(0, (screenHeight - panelHeight) / 2);
+  const bool selectionVisible = UITheme::getInstance().showSelectionCursor();
 
   renderer.fillRect(panelX, panelY, panelWidth, panelHeight, false);
   const std::string shownTitle = renderer.truncatedText(UI_10_FONT_ID, title, panelWidth - 32, EpdFontFamily::BOLD);
@@ -345,7 +349,7 @@ void InxTheme::drawOptionPopup(const GfxRenderer& renderer, const char* title, c
   for (int slot = 0; slot < visibleRows; ++slot) {
     const int optionIndex = start + slot;
     const int rowY = panelY + InxOptionGeometry::headerHeight + slot * InxOptionGeometry::rowHeight;
-    const bool isSelected = optionIndex == selected;
+    const bool isSelected = selectionVisible && optionIndex == selected;
     if (isSelected) renderer.fillRect(panelX + 2, rowY, panelWidth - 4, InxOptionGeometry::rowHeight, true);
     const std::string option = renderer.truncatedText(UI_10_FONT_ID, options[optionIndex].c_str(), panelWidth - 44);
     const int textY = rowY + (InxOptionGeometry::rowHeight - renderer.getLineHeight(UI_10_FONT_ID)) / 2;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,10 +736,12 @@ void loop() {
   if (gpio.wasUsbStateChanged()) {
     activityManager.requestUpdate();
   }
+#ifndef CROSSPOINT_EMULATED
   if (gpio.wasInputModalityChanged() && gpio.hasTouch() && UITheme::getInstance().hasMainTabs() &&
       !activityManager.isReaderActivity()) {
     activityManager.requestUpdate();
   }
+#endif
 
   const unsigned long activityStartTime = millis();
   const bool readerWasActive = activityManager.isReaderActivity();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,6 +736,10 @@ void loop() {
   if (gpio.wasUsbStateChanged()) {
     activityManager.requestUpdate();
   }
+  if (gpio.wasInputModalityChanged() && gpio.hasTouch() && UITheme::getInstance().hasMainTabs() &&
+      !activityManager.isReaderActivity()) {
+    activityManager.requestUpdate();
+  }
 
   const unsigned long activityStartTime = millis();
   const bool readerWasActive = activityManager.isReaderActivity();

--- a/test/inx_navigation/CMakeLists.txt
+++ b/test/inx_navigation/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(InxNavigationTest InxNavigationTest.cpp)
 
 target_include_directories(InxNavigationTest BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/stubs)
 target_include_directories(InxNavigationTest PRIVATE
+  ${REPO_ROOT}/lib/hal
   ${REPO_ROOT}/src
   ${REPO_ROOT}/freeink-sdk/libs/ui/FreeInkUI/include
 )

--- a/test/inx_navigation/InxNavigationTest.cpp
+++ b/test/inx_navigation/InxNavigationTest.cpp
@@ -3,9 +3,11 @@
 
 #include <type_traits>
 
+#include "InputModality.h"
 #include "InxItemLayout.h"
 #include "InxRecentLayout.h"
 #include "activities/MainTab.h"
+#include "components/SelectionCursorPolicy.h"
 #include "components/SubpageLayout.h"
 #include "components/icons/inx_apps.h"
 #include "components/themes/BaseTheme.h"
@@ -57,6 +59,42 @@ TEST(InxNavigation, WrapsAcrossFiveTabs) {
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::First, 10), 0);
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::Last, 1), 0);
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::Last, 10), 9);
+}
+
+TEST(InxNavigation, TracksLastInputWithTouchPriority) {
+  InputModality modality = InputModality::Touch;
+  modality = inputModalityAfter(modality, false, false);
+  EXPECT_EQ(modality, InputModality::Touch);
+  modality = inputModalityAfter(modality, true, false);
+  EXPECT_EQ(modality, InputModality::Buttons);
+  modality = inputModalityAfter(modality, false, false);
+  EXPECT_EQ(modality, InputModality::Buttons);
+  modality = inputModalityAfter(modality, true, true);
+  EXPECT_EQ(modality, InputModality::Touch);
+}
+
+TEST(InxNavigation, HidesOnlyInxTouchFocusAndKeepsActiveFeedback) {
+  EXPECT_FALSE(SelectionCursorPolicy::visible(true, true, InputModality::Touch));
+  EXPECT_TRUE(SelectionCursorPolicy::visible(true, true, InputModality::Buttons));
+  EXPECT_TRUE(SelectionCursorPolicy::visible(true, false, InputModality::Touch));
+  EXPECT_TRUE(SelectionCursorPolicy::visible(false, true, InputModality::Touch));
+
+  freeink::ui::ThemeTokens tokens;
+  tokens.listRow.normal.background = freeink::ui::Paint::solid(freeink::ui::Color::White);
+  tokens.listRow.normal.foreground = freeink::ui::Paint::solid(freeink::ui::Color::Black);
+  tokens.listRow.selected.background = freeink::ui::Paint::solid(freeink::ui::Color::Black);
+  tokens.listRow.selected.foreground = freeink::ui::Paint::solid(freeink::ui::Color::White);
+  tokens.listRow.focused.background = freeink::ui::Paint::dither(freeink::ui::Color::LightGray);
+  tokens.listRow.active.background = freeink::ui::Paint::solid(freeink::ui::Color::Black);
+  tokens.listRow.active.foreground = freeink::ui::Paint::solid(freeink::ui::Color::White);
+  const auto active = tokens.listRow.active;
+  SelectionCursorPolicy::hideFreeInkListFocus(tokens);
+  EXPECT_EQ(tokens.listRow.selected.background.kind, tokens.listRow.normal.background.kind);
+  EXPECT_EQ(tokens.listRow.selected.foreground.color, tokens.listRow.normal.foreground.color);
+  EXPECT_EQ(tokens.listRow.focused.background.kind, tokens.listRow.normal.background.kind);
+  EXPECT_EQ(tokens.listRow.focused.foreground.color, tokens.listRow.normal.foreground.color);
+  EXPECT_EQ(tokens.listRow.active.background.kind, active.background.kind);
+  EXPECT_EQ(tokens.listRow.active.foreground.color, active.foreground.color);
 }
 
 TEST(InxNavigation, KeepsLegacyListMetricsIndependentFromLyra) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Hide Inx navigation focus on touch hardware until the user navigates with physical buttons.
* **What changes are included?**
  * Track the last input modality in the HAL with a heap-free atomic enum; touch wins when touch and button activity occur in the same frame.
  * Centralize cursor visibility in UITheme and apply it to Inx app grids, lists, menus, option popups, and FreeInkUI list styles.
  * Preserve selection indices, scrolling, activation, semantic checked/current states, and active touch feedback.
  * Document the behavior and add host coverage for modality transitions and style policy.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this fixes an existing Inx touch/navigation mismatch without adding a new activity or theme).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

* No setting, cache format, dependency, or heap allocation is added.
* `./bin/ci-check` passes: clang-format, cppcheck, all seven firmware environments (`default`, `sticky`, `x4pro`, `papermono`, `eego_a4`, `murphy_m4`, and `waveshare_epaper_397`), and 397/397 host tests.
* `git diff --check` passes.
* X4 Pro build total: 65,668 bytes RAM (20.0%) and 6,059,666 bytes flash (92.5%).
* Pending device verification: on X4 Pro, startup/touch hides the cursor, physical navigation shows it, and the next touch hides it again. Other themes and X3/X4 should continue to show the cursor.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_