### PR TITLE
docs(papermono): correct display controller name

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -454,7 +454,7 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2
 
-; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
+; --- M5Stack Paper Mono — ESP32-S3, SSD1677 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK
 ; sequences them itself. Touch, frontlight, RTC, and other capabilities are
 ; selected by the Paper Mono BoardConfig profile.
@@ -466,7 +466,7 @@ board_build.mcu = esp32s3
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_PAPERMONO=1
-  ; The SSD1683 grayscale target planes are batched in PSRAM.
+  ; The SSD1677 grayscale target planes are batched in PSRAM.
   -DBOARD_HAS_PSRAM
   ; Native 1-bit SDMMC is mounted through SdFat's block-device interface.
   -DUSE_BLOCK_DEVICE_INTERFACE=1


### PR DESCRIPTION
## Summary

- correct the Paper Mono controller references from SSD1683 to SSD1677
- align the build comments with the active FreeInk board profile and driver

## Verification

- `git diff --check`
- comments-only change; no firmware behavior changed

Related to #218.