### PR TITLE
feat: optimize standby display power

### DIFF
--- a/docs/engineering/device-variants.md
+++ b/docs/engineering/device-variants.md
@@ -44,17 +44,18 @@ tagged image for a different board.
 
 ## Standby-display light sleep
 
-Standby-display light sleep is currently enabled only for the runtime-selected
-X3/X3 UC8279 profiles. The HAL arms GPIO3 plus a timer and consumes the released
-power button before returning to the Activity. ESP32-C3 isolates ordinary GPIOs
-in light sleep, so the HAL exempts GPIO13 from that isolation and keeps the X3 SD
-rail powered. Display state and all other power rails remain unchanged.
+Standby-display light sleep is enabled for the runtime-selected X3/X3 UC8279 and
+X4 profiles. The HAL arms GPIO3 plus a timer and consumes the released power
+button before returning to the Activity. ESP32-C3 isolates ordinary GPIOs in
+light sleep, so the HAL exempts GPIO13 from that isolation: it keeps the X3 SD
+rail powered or the X4 battery latch asserted. Display state and all other power
+rails remain unchanged.
 
-X4 light sleep is disabled because hardware testing entered a cold-boot state
-instead of resuming. X4 and all S3 targets remain in the normal downclocked
-standby loop. Add a target only after its wake polarity, repeated wake,
-peripheral recovery, USB behavior, and sleep current have passed hardware
-validation; a successful build is not that acceptance test.
+Repeated timer wake, power-button wake, and button, display, and SD recovery
+after wake passed hardware validation on both X3 and X4. X4 sleep current has
+not yet been quantified, so no measured power reduction is claimed. All S3
+targets remain in the normal downclocked standby loop; a successful build alone
+is not a hardware acceptance test.
 
 The X3-vs-X4 choice is **not** a compile-time decision. Do not add a `-DX3`
 build flag or a `[env:...x3]` — see the next section for why.

--- a/docs/engineering/device-variants.md
+++ b/docs/engineering/device-variants.md
@@ -42,6 +42,20 @@ Gitee carries the Simplified-Chinese package under the same rolling tag.
 Manual flashing must use the matching build; the embedded board tag rejects a
 tagged image for a different board.
 
+## Standby-display light sleep
+
+Standby-display light sleep is currently enabled only for the runtime-selected
+X3/X3 UC8279 profiles. The HAL arms GPIO3 plus a timer and consumes the released
+power button before returning to the Activity. ESP32-C3 isolates ordinary GPIOs
+in light sleep, so the HAL exempts GPIO13 from that isolation and keeps the X3 SD
+rail powered. Display state and all other power rails remain unchanged.
+
+X4 light sleep is disabled because hardware testing entered a cold-boot state
+instead of resuming. X4 and all S3 targets remain in the normal downclocked
+standby loop. Add a target only after its wake polarity, repeated wake,
+peripheral recovery, USB behavior, and sleep current have passed hardware
+validation; a successful build is not that acceptance test.
+
 The X3-vs-X4 choice is **not** a compile-time decision. Do not add a `-DX3`
 build flag or a `[env:...x3]` — see the next section for why.
 

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -4,6 +4,7 @@
 #include <Logging.h>
 #include <PowerManager.h>
 #include <WiFi.h>
+#include <driver/gpio.h>
 #include <esp_sleep.h>
 #include <soc/soc_caps.h>
 
@@ -18,10 +19,29 @@
 
 HalPowerManager powerManager;  // Singleton instance
 
-// GPIO13 controls the X4 battery latch and the X3 SD power rail on the C3
-// Xteink boards. Other boards use it for unrelated signals, including the
-// X4 Pro display chip select.
+// GPIO13 is the existing Xteink C3 deep-sleep shutdown signal; the X3 profile
+// also identifies it as the SD power rail. Its X4 hardware role is unverified.
+// Other boards use it for unrelated signals, including X4 Pro display CS.
 static constexpr gpio_num_t XTEINK_C3_GPIO13 = GPIO_NUM_13;
+
+namespace {
+struct StandbyRetention {
+  int8_t pin;
+  int activeLevel;
+};
+
+StandbyRetention x3StandbyRetention() {
+  const auto& board = BoardConfig::ACTIVE;
+  switch (board.board) {
+    case BoardConfig::Board::XteinkX3:
+    case BoardConfig::Board::XteinkX3Uc8279:
+      return {board.sd.powerEnable, board.sd.powerActiveHigh ? HIGH : LOW};
+    default:
+      // X4 failed hardware validation; all other profiles remain unvalidated.
+      return {BoardConfig::PIN_UNASSIGNED, LOW};
+  }
+}
+}  // namespace
 
 void HalPowerManager::begin() {
 #if FREEINK_DEVICE_WAVESHARE_EPAPER_397
@@ -91,8 +111,8 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
 
 #if !SOC_PM_SUPPORT_EXT1_WAKEUP
   if (gpio.isXteinkDevice()) {
-    // GPIO13 gates the battery MOSFET on both Xteink C3 boards; driving it low
-    // is the battery power-off (the SDK wake source still handles USB power).
+    // Keep the existing GPIO13 deep-sleep shutdown behavior unchanged while
+    // its exact X4 hardware role remains unverified (the SDK still handles wake).
     // Release any surviving pad hold first: hold_en survives deep sleep via
     // the SDK's deepSleep() (esp_sleep_config_gpio_isolate +
     // gpio_deep_sleep_hold_en), and a held pad silently ignores the drive.
@@ -140,6 +160,79 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   // immediately wake the device again), then arms the wake source and sleeps.
   freeink::PowerManager::deepSleepUntilPowerButton();
 #endif
+}
+
+bool HalPowerManager::canStandbyLightSleep(const HalGPIO& gpio) const {
+  return gpio.isXteinkDevice() && BoardConfig::ACTIVE.input.power >= 0 && x3StandbyRetention().pin >= 0;
+}
+
+HalPowerManager::LightSleepWakeReason HalPowerManager::lightSleepFor(const uint32_t seconds) const {
+  const int8_t powerPin = BoardConfig::ACTIVE.input.power;
+  const StandbyRetention retention = x3StandbyRetention();
+  if (seconds == 0 || powerPin < 0 || retention.pin < 0) {
+    LOG_ERR("PWR", "Invalid light-sleep request: seconds=%u powerPin=%d retentionPin=%d",
+            static_cast<unsigned>(seconds), powerPin, retention.pin);
+    return LightSleepWakeReason::Failed;
+  }
+
+  const bool activeHigh = BoardConfig::ACTIVE.input.powerActiveHigh;
+  pinMode(powerPin, activeHigh ? INPUT_PULLDOWN : INPUT_PULLUP);
+  if (digitalRead(powerPin) == (activeHigh ? HIGH : LOW)) {
+    freeink::PowerManager::waitForPowerButtonRelease();
+    return LightSleepWakeReason::PowerButton;
+  }
+
+  const gpio_num_t retentionPin = static_cast<gpio_num_t>(retention.pin);
+  const auto cleanupLightSleep = [&] {
+    esp_err_t cleanupError = gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
+    const auto keepFirstError = [&](const esp_err_t current) {
+      if (cleanupError == ESP_OK && current != ESP_OK) cleanupError = current;
+    };
+    keepFirstError(esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO));
+    keepFirstError(esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
+    keepFirstError(gpio_sleep_sel_en(retentionPin));
+    return cleanupError;
+  };
+
+  // ESP32-C3 isolates ordinary GPIOs in light sleep. Keep the X3 SD rail
+  // actively driven instead of allowing GPIO13 to float.
+  esp_err_t error = gpio_set_level(retentionPin, retention.activeLevel);
+  if (error == ESP_OK) error = gpio_set_direction(retentionPin, GPIO_MODE_OUTPUT);
+  if (error == ESP_OK) error = gpio_sleep_sel_dis(retentionPin);
+  if (error == ESP_OK)
+    error =
+        gpio_wakeup_enable(static_cast<gpio_num_t>(powerPin), activeHigh ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL);
+  if (error == ESP_OK) error = esp_sleep_enable_gpio_wakeup();
+  if (error == ESP_OK) error = esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(seconds) * 1000000ULL);
+  if (error != ESP_OK) {
+    const esp_err_t cleanupError = cleanupLightSleep();
+    LOG_ERR("PWR", "Failed to configure light sleep: %d", static_cast<int>(error));
+    if (cleanupError != ESP_OK) LOG_ERR("PWR", "Failed to clean up light sleep: %d", static_cast<int>(cleanupError));
+    return LightSleepWakeReason::Failed;
+  }
+
+  error = esp_light_sleep_start();
+  const esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+  const esp_err_t cleanupError = cleanupLightSleep();
+  if (cause == ESP_SLEEP_WAKEUP_GPIO) freeink::PowerManager::waitForPowerButtonRelease();
+  if (error != ESP_OK) {
+    LOG_ERR("PWR", "Light sleep failed: %d", static_cast<int>(error));
+    return LightSleepWakeReason::Failed;
+  }
+  if (cleanupError != ESP_OK) {
+    LOG_ERR("PWR", "Failed to clean up light sleep: %d", static_cast<int>(cleanupError));
+    return LightSleepWakeReason::Failed;
+  }
+
+  switch (cause) {
+    case ESP_SLEEP_WAKEUP_TIMER:
+      return LightSleepWakeReason::Timer;
+    case ESP_SLEEP_WAKEUP_GPIO:
+      return LightSleepWakeReason::PowerButton;
+    default:
+      LOG_ERR("PWR", "Unexpected light-sleep wake cause: %d", static_cast<int>(cause));
+      return LightSleepWakeReason::Failed;
+  }
 }
 
 uint16_t HalPowerManager::getBatteryPercentage() const {

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -30,14 +30,16 @@ struct StandbyRetention {
   int activeLevel;
 };
 
-StandbyRetention x3StandbyRetention() {
+StandbyRetention standbyRetention() {
   const auto& board = BoardConfig::ACTIVE;
   switch (board.board) {
+    case BoardConfig::Board::XteinkX4:
+      return {board.power.latch0, HIGH};
     case BoardConfig::Board::XteinkX3:
     case BoardConfig::Board::XteinkX3Uc8279:
       return {board.sd.powerEnable, board.sd.powerActiveHigh ? HIGH : LOW};
     default:
-      // X4 failed hardware validation; all other profiles remain unvalidated.
+      // All other profiles remain unvalidated.
       return {BoardConfig::PIN_UNASSIGNED, LOW};
   }
 }
@@ -163,12 +165,12 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
 }
 
 bool HalPowerManager::canStandbyLightSleep(const HalGPIO& gpio) const {
-  return gpio.isXteinkDevice() && BoardConfig::ACTIVE.input.power >= 0 && x3StandbyRetention().pin >= 0;
+  return gpio.isXteinkDevice() && BoardConfig::ACTIVE.input.power >= 0 && standbyRetention().pin >= 0;
 }
 
 HalPowerManager::LightSleepWakeReason HalPowerManager::lightSleepFor(const uint32_t seconds) const {
   const int8_t powerPin = BoardConfig::ACTIVE.input.power;
-  const StandbyRetention retention = x3StandbyRetention();
+  const StandbyRetention retention = standbyRetention();
   if (seconds == 0 || powerPin < 0 || retention.pin < 0) {
     LOG_ERR("PWR", "Invalid light-sleep request: seconds=%u powerPin=%d retentionPin=%d",
             static_cast<unsigned>(seconds), powerPin, retention.pin);
@@ -188,14 +190,15 @@ HalPowerManager::LightSleepWakeReason HalPowerManager::lightSleepFor(const uint3
     const auto keepFirstError = [&](const esp_err_t current) {
       if (cleanupError == ESP_OK && current != ESP_OK) cleanupError = current;
     };
+    keepFirstError(gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE));
     keepFirstError(esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO));
     keepFirstError(esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER));
     keepFirstError(gpio_sleep_sel_en(retentionPin));
     return cleanupError;
   };
 
-  // ESP32-C3 isolates ordinary GPIOs in light sleep. Keep the X3 SD rail
-  // actively driven instead of allowing GPIO13 to float.
+  // ESP32-C3 isolates ordinary GPIOs in light sleep. Keep the X3 SD rail or
+  // X4 battery latch actively driven instead of allowing GPIO13 to float.
   esp_err_t error = gpio_set_level(retentionPin, retention.activeLevel);
   if (error == ESP_OK) error = gpio_set_direction(retentionPin, GPIO_MODE_OUTPUT);
   if (error == ESP_OK) error = gpio_sleep_sel_dis(retentionPin);

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -25,6 +25,8 @@ class HalPowerManager {
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
 
  public:
+  enum class LightSleepWakeReason : uint8_t { Timer, PowerButton, Failed };
+
 #if BOARD_HAS_PSRAM
   static constexpr int LOW_POWER_FREQ = 80;  // MHz
 #else
@@ -41,6 +43,12 @@ class HalPowerManager {
   // Setup wake up GPIO and enter deep sleep
   // Should be called inside main loop() to handle the currentLockMode
   void startDeepSleep(HalGPIO& gpio) const;
+
+  // Only the runtime-selected X3 profiles have validated standby wake wiring.
+  bool canStandbyLightSleep(const HalGPIO& gpio) const;
+
+  // Enter one light-sleep cycle. GPIO and timer wake sources are removed before returning.
+  LightSleepWakeReason lightSleepFor(uint32_t seconds) const;
 
   // Get battery percentage (range 0-100)
   uint16_t getBatteryPercentage() const;

--- a/lib/hal/HalTiltSensor.cpp
+++ b/lib/hal/HalTiltSensor.cpp
@@ -67,17 +67,17 @@ void HalTiltSensor::update(const uint8_t mode, const uint8_t orientation, const 
     return;
   }
 
-  // State machine: wake up or sleep based on the enabled flag
-  if ((mode != CrossPointTiltPageTurn::TILT_OFF) && !_isAwake) {
+  const bool shouldBeAwake = mode != CrossPointTiltPageTurn::TILT_OFF && inReader;
+  if (shouldBeAwake && !_isAwake) {
     _isAwake = wake();
     return;
-  } else if ((mode == CrossPointTiltPageTurn::TILT_OFF) && _isAwake) {
+  }
+  if (!shouldBeAwake && _isAwake) {
     _isAwake = !deepSleep();
     return;
   }
 
-  // If disabled, skip the rest of the polling logic and avoid unnecessary I2C traffic in non-reader activities
-  if ((mode == CrossPointTiltPageTurn::TILT_OFF) || !inReader) {
+  if (!shouldBeAwake) {
     return;
   }
 

--- a/src/activities/apps/standby/ChineseCalendarFace.cpp
+++ b/src/activities/apps/standby/ChineseCalendarFace.cpp
@@ -378,23 +378,23 @@ void ChineseCalendarFace::onPageNext() {
   }
 }
 
-bool ChineseCalendarFace::tick() {
+StandbyFace::TickResult ChineseCalendarFace::tick() {
   // If user is parked on today (offset 0) and the wall clock has crossed
   // midnight, recompute. Otherwise stay put.
-  if (dayOffset_ != 0) return false;
+  if (dayOffset_ != 0) return TickResult::None;
   struct tm today;
-  if (!getTodayLocal(today)) return false;
+  if (!getTodayLocal(today)) return TickResult::None;
   const int32_t key = today.tm_year * 512 + today.tm_yday;
-  if (key == cachedBaseDayKey_) return false;
+  if (key == cachedBaseDayKey_) return TickResult::None;
   refreshCachedDay();
-  return true;
+  return TickResult::Redraw;
 }
 
 StrId ChineseCalendarFace::titleId() const { return StrId::STR_FACE_CHINESE_CALENDAR; }
 
 uint32_t ChineseCalendarFace::secondsUntilNextWake() const {
   // No time-dependent UI inside the page (we only repaint at day crossover).
-  // Return a large value; StandbyActivity's loop is event-driven anyway.
+  // StandbyActivity bounds this interval so USB state is still polled regularly.
   return 3600u;
 }
 

--- a/src/activities/apps/standby/ChineseCalendarFace.h
+++ b/src/activities/apps/standby/ChineseCalendarFace.h
@@ -22,7 +22,7 @@ class ChineseCalendarFace final : public StandbyFace {
  public:
   void onEnter() override;
   void onExit() override;
-  bool tick() override;
+  TickResult tick() override;
   void render(GfxRenderer& renderer, const Rect& viewport) override;
   StrId titleId() const override;
   uint32_t secondsUntilNextWake() const override;

--- a/src/activities/apps/standby/SloppyClockFace.cpp
+++ b/src/activities/apps/standby/SloppyClockFace.cpp
@@ -43,12 +43,16 @@ void SloppyClockFace::regenerate(uint32_t seed) {
   lastMin_ = -1;
 }
 
-bool SloppyClockFace::tick() {
-  if (!style_ || !seeds_) return false;
+StandbyFace::TickResult SloppyClockFace::tick() {
+  if (!style_ || !seeds_) return TickResult::None;
   const uint32_t nowMin = standby_time::getMinuteTick(startMs_);
-  if (static_cast<int32_t>(nowMin) == lastMin_) return false;
+  if (static_cast<int32_t>(nowMin) == lastMin_) return TickResult::None;
   lastMin_ = static_cast<int32_t>(nowMin);
-  return true;
+
+  const uint8_t currentBucket = standby_time::getTenMinuteBucket(startMs_);
+  const bool cleanGhosting = standby_time::didTenMinuteBucketChange(lastTenMinuteBucket_, currentBucket);
+  lastTenMinuteBucket_ = currentBucket;
+  return cleanGhosting ? TickResult::RedrawWithGhostCleanup : TickResult::Redraw;
 }
 
 void SloppyClockFace::render(GfxRenderer& renderer, const Rect& viewport) {

--- a/src/activities/apps/standby/SloppyClockFace.h
+++ b/src/activities/apps/standby/SloppyClockFace.h
@@ -18,7 +18,7 @@ class SloppyClockFace final : public StandbyFace {
   // existing shake-reroll behaviour so the gesture keeps doing something.
   void onPagePrev() override;
   void onPageNext() override;
-  bool tick() override;
+  TickResult tick() override;
   void render(GfxRenderer& renderer, const Rect& viewport) override;
   StrId titleId() const override { return StrId::STR_FACE_SLOPPY_CLOCK; }
   uint32_t secondsUntilNextWake() const override;
@@ -28,6 +28,7 @@ class SloppyClockFace final : public StandbyFace {
   std::unique_ptr<sloppy::Seeds> seeds_;
   uint32_t startMs_ = 0;  // millis() anchor for the pre-sync fallback display
   int32_t lastMin_ = -1;  // last rendered minute tick, for "did the minute change?" gating
+  int16_t lastTenMinuteBucket_ = -1;
 
   void regenerate(uint32_t seed);
 };

--- a/src/activities/apps/standby/StandbyActivity.cpp
+++ b/src/activities/apps/standby/StandbyActivity.cpp
@@ -9,6 +9,12 @@
 #include <esp_system.h>
 #include <esp_wifi.h>
 
+#if CROSSPOINT_EMULATED == 0
+#include <HalDisplay.h>
+#include <HalGPIO.h>
+#include <HalPowerManager.h>
+#endif
+
 #include <algorithm>
 #include <string>
 
@@ -32,6 +38,9 @@ namespace {
 constexpr uint32_t kWifiTimeoutMs = 15000u;  // Same as WifiSelectionActivity
 constexpr uint32_t kNtpTimeoutMs = 12000u;
 constexpr uint32_t kSyncDelayMs = 1500u;
+#if CROSSPOINT_EMULATED == 0
+constexpr uint32_t kMaxLightSleepSeconds = 60u;
+#endif
 
 // Face factory table. Add new faces by appending a row here and including the
 // corresponding header above. Each entry also declares an isAvailable()
@@ -135,9 +144,7 @@ void StandbyActivity::onExit() {
       break;
     case SyncState::WifiConnecting:
     case SyncState::ClockSyncing:
-      WiFi.disconnect(false);
-      delay(100);
-      WiFi.mode(WIFI_OFF);
+      stopTimeSyncWifi();
       break;
   }
   syncState_ = SyncState::Idle;
@@ -257,11 +264,13 @@ void StandbyActivity::promptForWifi() {
 void StandbyActivity::onWifiResult(const ActivityResult& result) {
   if (result.isCancelled) {
     LOG_DBG("STANDBY", "WiFi UI cancelled; clock remains unavailable");
+    stopTimeSyncWifi();
+    syncState_ = SyncState::Idle;
     return;
   }
   if (TimeUtils::isClockValid()) {
     LOG_DBG("STANDBY", "WiFi UI returned with a trustworthy clock");
-    finishTimeSync();
+    completeTimeSync();
     return;
   }
 
@@ -273,7 +282,8 @@ void StandbyActivity::onWifiResult(const ActivityResult& result) {
 void StandbyActivity::beginClockSync() {
   if (!halClock.requestSync()) {
     LOG_ERR("STANDBY", "Clock sync could not start");
-    finishTimeSync();
+    stopTimeSyncWifi();
+    syncState_ = SyncState::Idle;
     return;
   }
   syncState_ = SyncState::ClockSyncing;
@@ -303,9 +313,7 @@ void StandbyActivity::pumpTimeSync() {
 
       LOG_DBG("STANDBY", "Silent WiFi sync failed (status=%d, t=%ums)", static_cast<int>(status),
               static_cast<unsigned>(elapsed));
-      WiFi.disconnect(false);
-      delay(100);
-      WiFi.mode(WIFI_OFF);
+      stopTimeSyncWifi();
       syncState_ = SyncState::Idle;
       if (!g_promptedForWifiThisSession)
         promptForWifi();
@@ -318,28 +326,31 @@ void StandbyActivity::pumpTimeSync() {
         case ClockSyncState::Succeeded:
           g_promptedForWifiThisSession = false;
           LOG_DBG("STANDBY", "Clock synchronized");
-          finishTimeSync();
+          completeTimeSync();
           return;
         case ClockSyncState::Failed:
           LOG_DBG("STANDBY", "Clock sync failed");
-          finishTimeSync();
+          stopTimeSyncWifi();
+          syncState_ = SyncState::Idle;
           return;
         case ClockSyncState::Idle:
           if (elapsed < kNtpTimeoutMs) return;
           LOG_DBG("STANDBY", "Clock sync stopped");
-          finishTimeSync();
+          stopTimeSyncWifi();
+          syncState_ = SyncState::Idle;
           return;
         case ClockSyncState::Syncing:
           if (elapsed < kNtpTimeoutMs) return;
           LOG_DBG("STANDBY", "Clock sync timed out");
-          finishTimeSync();
+          stopTimeSyncWifi();
+          syncState_ = SyncState::Idle;
           return;
       }
       break;
   }
 }
 
-void StandbyActivity::finishTimeSync() {
+void StandbyActivity::stopTimeSyncWifi() {
   WiFi.disconnect(false);
   delay(100);
   WiFi.mode(WIFI_OFF);
@@ -348,8 +359,70 @@ void StandbyActivity::finishTimeSync() {
   // active (see HalPowerManager.cpp). Return value is ignored;
   // ESP_ERR_WIFI_NOT_INIT is fine if we never connected.
   esp_wifi_deinit();
+}
+
+void StandbyActivity::completeTimeSync() {
+  stopTimeSyncWifi();
   syncState_ = SyncState::Idle;
+  lastInputMs_ = millis();
   requestUpdate();
+}
+
+void StandbyActivity::processFaceTick(const bool waitForUpdate) {
+  if (!currentFace_) return;
+
+  switch (currentFace_->tick()) {
+    case StandbyFace::TickResult::None:
+      return;
+    case StandbyFace::TickResult::Redraw:
+      break;
+    case StandbyFace::TickResult::RedrawWithGhostCleanup:
+#if CROSSPOINT_EMULATED == 0
+      if (gpio.isXteinkDevice()) renderer.requestNextRefresh(HalDisplay::HALF_REFRESH);
+#endif
+      break;
+  }
+
+  if (waitForUpdate)
+    requestUpdateAndWait();
+  else
+    requestUpdate();
+}
+
+bool StandbyActivity::tryLightSleep(const uint32_t idleMs) {
+#if CROSSPOINT_EMULATED == 0
+  if (mode_ != DisplayMode::Immersive || !currentFace_) return false;
+
+  const bool syncActive = syncState_ != SyncState::Idle;
+  const bool wifiActive = WiFi.getMode() != WIFI_MODE_NULL;
+  const bool hardwareAllowed = powerManager.canStandbyLightSleep(gpio);
+  if (!standby_time::shouldLightSleep(idleMs, syncActive, wifiActive, gpio.isUsbConnected(), hardwareAllowed)) {
+    return false;
+  }
+
+  const uint32_t seconds = std::clamp<uint32_t>(currentFace_->secondsUntilNextWake(), 1, kMaxLightSleepSeconds);
+  HalPowerManager::LightSleepWakeReason wakeReason;
+  {
+    RenderLock lock;
+    wakeReason = powerManager.lightSleepFor(seconds);
+  }
+  switch (wakeReason) {
+    case HalPowerManager::LightSleepWakeReason::Timer:
+      processFaceTick(true);
+      return true;
+    case HalPowerManager::LightSleepWakeReason::PowerButton:
+      mode_ = DisplayMode::Normal;
+      lastInputMs_ = millis();
+      requestUpdate();
+      return true;
+    case HalPowerManager::LightSleepWakeReason::Failed:
+      lastInputMs_ = millis();
+      return true;
+  }
+#else
+  (void)idleMs;
+#endif
+  return false;
 }
 
 void StandbyActivity::loop() {
@@ -453,22 +526,16 @@ void StandbyActivity::loop() {
 
   pumpTimeSync();
 
-  // After 5 s of idle, hide chrome and let the face fill the screen. From
-  // there the framework's idle-3 s auto-downclock kicks in (HalPowerManager →
-  // LOW_POWER_FREQ, 10 MHz). We keep preventAutoSleep() returning true so the
-  // device will NOT auto-deep-sleep — standby is a clock and must keep showing
-  // the time. The deep-sleep timer is short-circuited in main.cpp via
-  // preventAutoSleep(); downclocking is unaffected because main.cpp only
-  // resets lastActivityTime on real user input, not on preventAutoSleep().
   const uint32_t idle = millis() - lastInputMs_;
   if (mode_ == DisplayMode::Normal && idle >= 5000u) {
     mode_ = DisplayMode::Immersive;
     requestUpdate();
+    return;
   }
 
-  if (currentFace_ && currentFace_->tick()) {
-    requestUpdate();
-  }
+  if (tryLightSleep(idle)) return;
+
+  processFaceTick(false);
 }
 
 void StandbyActivity::render(RenderLock&&) {

--- a/src/activities/apps/standby/StandbyActivity.h
+++ b/src/activities/apps/standby/StandbyActivity.h
@@ -18,10 +18,8 @@ class StandbyActivity final : public Activity {
   void render(RenderLock&&) override;
   void onExit() override;
 
-  // Standby is a clock — keep the framework's deep-sleep timer (main.cpp:422,
-  // default 10 min) paused for the entire lifetime of this activity. Exiting
-  // back to Apps restores the default sleep behaviour. Tight-loop polling is
-  // still only used during WiFi/clock sync.
+  // Standby manages its own timer/GPIO light-sleep cycles, so the framework's
+  // generic deep-sleep timer stays paused for the activity's lifetime.
   bool preventAutoSleep() override { return true; }
   bool skipLoopDelay() override {
     return syncState_ == SyncState::WifiConnecting || syncState_ == SyncState::ClockSyncing;
@@ -37,10 +35,7 @@ class StandbyActivity final : public Activity {
 
   enum class DisplayMode : uint8_t {
     Normal,     // Header + battery + face dots + face content
-    Immersive,  // Face content only (after 5s idle). On battery the framework
-                // engages CPU low-freq after 3s idle and full deep sleep after
-                // SETTINGS.getSleepTimeoutMs() — Standby just needs to stay out
-                // of the way.
+    Immersive,  // Face content only; supported boards light-sleep after 35s idle.
   };
 
   std::unique_ptr<StandbyFace> currentFace_;
@@ -58,7 +53,10 @@ class StandbyActivity final : public Activity {
   void onWifiResult(const ActivityResult& result);
   void beginClockSync();
   void pumpTimeSync();
-  void finishTimeSync();
+  void stopTimeSyncWifi();
+  void completeTimeSync();
+  void processFaceTick(bool waitForUpdate);
+  bool tryLightSleep(uint32_t idleMs);
 
   // Layer a 4-level grayscale refresh on top of the BW image just committed by
   // displayBuffer(): re-render the LSB then MSB planes and composite via the

--- a/src/activities/apps/standby/StandbyFace.h
+++ b/src/activities/apps/standby/StandbyFace.h
@@ -17,6 +17,8 @@ class GfxRenderer;
 // StandbyActivity.
 class StandbyFace {
  public:
+  enum class TickResult : uint8_t { None, Redraw, RedrawWithGhostCleanup };
+
   virtual ~StandbyFace() = default;
 
   // Allocate per-face state. Called once when this face becomes active.
@@ -38,10 +40,9 @@ class StandbyFace {
   virtual void onPagePrev() {}
   virtual void onPageNext() {}
 
-  // Called once per StandbyActivity::loop() tick. Returns true if the screen
-  // needs to be redrawn (e.g. the minute boundary moved). Face owns the
-  // "did anything change since last render" decision.
-  virtual bool tick() = 0;
+  // Called once per StandbyActivity::loop() tick. Face owns both the redraw
+  // decision and whether that frame needs the stronger ghost-cleanup waveform.
+  virtual TickResult tick() = 0;
 
   // Render the face content within the provided viewport. The activity has
   // already drawn the header / button hints (or cleared the screen in Immersive

--- a/src/activities/apps/standby/StandbyTime.cpp
+++ b/src/activities/apps/standby/StandbyTime.cpp
@@ -14,6 +14,11 @@ constexpr unsigned kFallbackStartMM = 38;
 
 bool isSynced() { return TimeUtils::isClockValid(); }
 
+bool shouldLightSleep(const uint32_t idleMs, const bool syncActive, const bool wifiActive, const bool usbConnected,
+                      const bool hardwareAllowed) {
+  return hardwareAllowed && idleMs >= kLightSleepIdleMs && !syncActive && !wifiActive && !usbConnected;
+}
+
 void getNowHHMM(const uint32_t fallbackStartMs, unsigned& hh, unsigned& mm) {
   std::tm localTime{};
   const uint32_t now = TimeUtils::getCurrentValidTimestamp();
@@ -32,6 +37,17 @@ void getNowHHMM(const uint32_t fallbackStartMs, unsigned& hh, unsigned& mm) {
 uint32_t getMinuteTick(const uint32_t fallbackStartMs) {
   const uint32_t now = TimeUtils::getCurrentValidTimestamp();
   return now ? now / 60 : (millis() - fallbackStartMs) / 60000u;
+}
+
+uint8_t getTenMinuteBucket(const uint32_t fallbackStartMs) {
+  unsigned hh = 0;
+  unsigned mm = 0;
+  getNowHHMM(fallbackStartMs, hh, mm);
+  return static_cast<uint8_t>(hh * 6u + mm / 10u);
+}
+
+bool didTenMinuteBucketChange(const int16_t previousBucket, const uint8_t currentBucket) {
+  return previousBucket >= 0 && previousBucket != currentBucket;
 }
 
 }  // namespace standby_time

--- a/src/activities/apps/standby/StandbyTime.h
+++ b/src/activities/apps/standby/StandbyTime.h
@@ -5,12 +5,20 @@
 // Shared time helpers used by Standby and its faces.
 namespace standby_time {
 
+constexpr uint32_t kLightSleepIdleMs = 35000u;
+
 bool isSynced();
+
+bool shouldLightSleep(uint32_t idleMs, bool syncActive, bool wifiActive, bool usbConnected, bool hardwareAllowed);
 
 // Use the trustworthy wall clock when available. Before sync, tick forward
 // from a plausible fallback time anchored at fallbackStartMs.
 void getNowHHMM(uint32_t fallbackStartMs, unsigned& hh, unsigned& mm);
 
 uint32_t getMinuteTick(uint32_t fallbackStartMs);
+
+uint8_t getTenMinuteBucket(uint32_t fallbackStartMs);
+
+bool didTenMinuteBucketChange(int16_t previousBucket, uint8_t currentBucket);
 
 }  // namespace standby_time

--- a/test/time_utils/TimeUtilsTest.cpp
+++ b/test/time_utils/TimeUtilsTest.cpp
@@ -139,3 +139,45 @@ TEST(StandbyTime, UsesTickingFallbackUntilClockBecomesValid) {
   EXPECT_EQ(hour, 11u);
   EXPECT_EQ(minute, 4u);
 }
+
+TEST(StandbyTime, LightSleepRequiresIdleAndInactivePeripherals) {
+  EXPECT_FALSE(standby_time::shouldLightSleep(34999u, false, false, false, true));
+  EXPECT_TRUE(standby_time::shouldLightSleep(35000u, false, false, false, true));
+  EXPECT_FALSE(standby_time::shouldLightSleep(35000u, true, false, false, true));
+  EXPECT_FALSE(standby_time::shouldLightSleep(35000u, false, true, false, true));
+  EXPECT_FALSE(standby_time::shouldLightSleep(35000u, false, false, true, true));
+  EXPECT_FALSE(standby_time::shouldLightSleep(35000u, false, false, false, false));
+}
+
+TEST(StandbyTime, DetectsTenMinuteDisplayBucketChanges) {
+  halClock.now = 0;
+  constexpr uint32_t startMs = 100000u;
+  arduinoTestMillis = startMs;
+  const auto bucketAtMinute = [](const uint32_t elapsedMinutes) {
+    arduinoTestMillis = startMs + elapsedMinutes * 60000u;
+    return standby_time::getTenMinuteBucket(startMs);
+  };
+
+  const uint8_t bucket38 = bucketAtMinute(0);
+
+  EXPECT_FALSE(standby_time::didTenMinuteBucketChange(-1, bucket38));
+
+  const uint8_t bucket39 = bucketAtMinute(1);
+  EXPECT_EQ(bucket39, bucket38);
+  EXPECT_FALSE(standby_time::didTenMinuteBucketChange(bucket38, bucket39));
+
+  const uint8_t bucket40 = bucketAtMinute(2);
+  EXPECT_NE(bucket40, bucket39);
+  EXPECT_TRUE(standby_time::didTenMinuteBucketChange(bucket39, bucket40));
+
+  const uint8_t bucket19 = bucketAtMinute(41);
+  const uint8_t bucket20 = bucketAtMinute(42);
+  EXPECT_TRUE(standby_time::didTenMinuteBucketChange(bucket19, bucket20));
+
+  const uint8_t bucket59 = bucketAtMinute(21);
+  const uint8_t bucket00 = bucketAtMinute(22);
+  EXPECT_TRUE(standby_time::didTenMinuteBucketChange(bucket59, bucket00));
+
+  const uint8_t delayedBucket = bucketAtMinute(55);
+  EXPECT_TRUE(standby_time::didTenMinuteBucketChange(bucket20, delayedBucket));
+}


### PR DESCRIPTION
## Summary
- add validated X3 and X4 standby light sleep with timer/power-button wake and GPIO13 retention for the X3 SD rail or X4 battery latch
- clear the GPIO3 wake interrupt type before returning to normal input handling
- fully stop standby WiFi, suspend the X3 IMU outside the reader, and use HALF_REFRESH every ten minutes to clear clock ghosting

## Validation
- formatting, cppcheck, and patch checks passed
- the X4 follow-up passed the default firmware build
- 399/399 host tests passed
- default, Sticky, X4 Pro, Murphy M4, Waveshare 3.97, and Paper Mono builds passed on latest main
- simulator and all Chinese hardware builds passed before rebasing; the source patch was unchanged by the rebase
- X3 and X4 hardware: repeated timer wake, at least ten power-button wakes, and button, display, and SD recovery after wake passed
- X4 sleep current has not yet been quantified; no measured power reduction is claimed

## Known validation issue
- EEGO A4 local build is blocked by the latest main/SDK environment reinstall path: the generated build references removed `esp_insights`, then a retry reports a missing Arduino BLE source file. This is outside the PR diff; keep the PR draft until CI or a clean runner confirms that environment.
