### PR TITLE
fix: deduplicate device time settings

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -223,6 +223,13 @@ void SettingsActivity::rebuildSettingsLists() {
       }
       controlsSettings.push_back(setting);
     } else if (setting.category == StrId::STR_CAT_SYSTEM) {
+      // These stay in the shared list for persistence and the web API, but the
+      // device UI owns them in the Date & Time submenu.
+      if (setting.valuePtr == &CrossPointSettings::clockAutoSync ||
+          setting.valuePtr == &CrossPointSettings::clockUtcOffsetQ ||
+          setting.valuePtr == &CrossPointSettings::clockFormat) {
+        continue;
+      }
       systemSettings.push_back(setting);
     }
   }

--- a/src/activities/settings/StatusBarSettingsActivity.cpp
+++ b/src/activities/settings/StatusBarSettingsActivity.cpp
@@ -1,14 +1,8 @@
 #include "StatusBarSettingsActivity.h"
 
 #include <GfxRenderer.h>
-#include <HalClock.h>
 #include <I18n.h>
 
-#include <cstring>
-#include <memory>
-
-#include "ClockOffsetActivity.h"
-#include "ClockSyncActivity.h"
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
@@ -17,8 +11,6 @@
 namespace fui = freeink::ui;
 
 namespace {
-// CrossMux keeps time in the system clock on every board; an external RTC only
-// improves persistence across power loss.
 enum MenuItem {
   ITEM_CHAPTER_PAGE_COUNT = 0,
   ITEM_BOOK_PROGRESS_PERCENTAGE,
@@ -28,9 +20,6 @@ enum MenuItem {
   ITEM_BATTERY,
   ITEM_XTC_STATUS_BAR,
   ITEM_CLOCK,
-  ITEM_CLOCK_FORMAT,
-  ITEM_CLOCK_UTC_OFFSET,
-  ITEM_CLOCK_SYNC,
   ITEM_COUNT
 };
 
@@ -47,26 +36,8 @@ const StrId menuNames[FULL_MENU_ITEMS] = {
     StrId::STR_BATTERY,
     StrId::STR_XTC_STATUS_BAR,
     StrId::STR_CLOCK,
-    StrId::STR_CLOCK_FORMAT,
-    StrId::STR_CLOCK_UTC_OFFSET,
-    StrId::STR_CLOCK_SYNC_NOW,
 };
 
-constexpr int CLOCK_FORMAT_ITEMS = 2;
-const StrId clockFormatNames[CLOCK_FORMAT_ITEMS] = {StrId::STR_CLOCK_FORMAT_24H, StrId::STR_CLOCK_FORMAT_12H};
-
-std::string formatUtcOffset(uint8_t biasedQ) {
-  // biasedQ is in quarter-hour steps, biased by 48 (so 48 = UTC+0).
-  if (biasedQ > 104) biasedQ = 48;
-  int totalMinutes = (static_cast<int>(biasedQ) - 48) * 15;
-  bool neg = totalMinutes < 0;
-  int absMinutes = neg ? -totalMinutes : totalMinutes;
-  int hours = absMinutes / 60;
-  int mins = absMinutes % 60;
-  char buf[16];
-  snprintf(buf, sizeof(buf), "UTC%c%d:%02d", neg ? '-' : '+', hours, mins);
-  return buf;
-}
 constexpr int PROGRESS_BAR_ITEMS = 3;
 const StrId progressBarNames[PROGRESS_BAR_ITEMS] = {StrId::STR_BOOK, StrId::STR_CHAPTER, StrId::STR_HIDE};
 
@@ -109,14 +80,6 @@ void StatusBarSettingsActivity::onEnter() {
 
   if (SETTINGS.xtcStatusBarMode >= XTC_STATUS_BAR_ITEMS) {
     SETTINGS.xtcStatusBarMode = CrossPointSettings::XTC_STATUS_BAR_MODE::XTC_STATUS_BAR_HIDE;
-  }
-
-  if (SETTINGS.clockUtcOffsetQ > 104) {
-    SETTINGS.clockUtcOffsetQ = 48;  // Default to UTC+0
-  }
-
-  if (SETTINGS.clockFormat >= CLOCK_FORMAT_ITEMS) {
-    SETTINGS.clockFormat = 0;
   }
 
   if (SETTINGS.statusBarClock >= STATUS_BAR_CLOCK_ITEMS) {
@@ -186,16 +149,6 @@ void StatusBarSettingsActivity::handleSelection() {
     case ITEM_CLOCK:
       SETTINGS.statusBarClock = (SETTINGS.statusBarClock + 1) % STATUS_BAR_CLOCK_ITEMS;
       break;
-    case ITEM_CLOCK_FORMAT:
-      SETTINGS.clockFormat = (SETTINGS.clockFormat + 1) % CLOCK_FORMAT_ITEMS;
-      break;
-    case ITEM_CLOCK_UTC_OFFSET:
-      // Launch the dedicated offset picker. It saves on exit, no result handler needed.
-      startActivityForResultWith<ClockOffsetActivity>(nullptr);
-      return;
-    case ITEM_CLOCK_SYNC:
-      startActivityForResultWith<ClockSyncActivity>(nullptr);
-      return;
     default:
       return;
   }
@@ -220,14 +173,6 @@ std::string StatusBarSettingsActivity::rowValueText(const int index) {
       return I18N.get(xtcStatusBarNames[SETTINGS.xtcStatusBarMode]);
     case ITEM_CLOCK:
       return I18N.get(statusBarClockNames[SETTINGS.statusBarClock]);
-    case ITEM_CLOCK_FORMAT: {
-      const uint8_t fmt = SETTINGS.clockFormat < CLOCK_FORMAT_ITEMS ? SETTINGS.clockFormat : 0;
-      return std::string(I18N.get(clockFormatNames[fmt]));
-    }
-    case ITEM_CLOCK_UTC_OFFSET:
-      return formatUtcOffset(SETTINGS.clockUtcOffsetQ);
-    case ITEM_CLOCK_SYNC:
-      return halClock.hasValidTime() ? tr(STR_CLOCK_SYNCED) : tr(STR_NOT_SET);
     default:
       return tr(STR_HIDE);
   }

--- a/src/activities/settings/StatusBarSettingsActivity.h
+++ b/src/activities/settings/StatusBarSettingsActivity.h
@@ -10,7 +10,7 @@ class StatusBarSettingsActivity final : public UiListActivity {
   explicit StatusBarSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput);
 
   // Must equal ITEM_COUNT in the .cpp (static_assert'd there).
-  static constexpr int MAX_STATUS_BAR_ITEMS = 11;
+  static constexpr int MAX_STATUS_BAR_ITEMS = 8;
 
   void onEnter() override;
   void render(RenderLock&&) override;


### PR DESCRIPTION
## Summary

- keep Date & Time as the only device-side entry for automatic sync, UTC offset, and clock format
- remove clock format, UTC offset, and immediate sync from Status Bar settings while retaining clock placement
- preserve the shared settings fields, persistence format, and Web settings keys

## Testing

- `./bin/clang-format-fix --check`
- `pio run -e simulator`
- `./bin/ci-check` (all supported firmware environments and 397/397 host tests)

## Validation still required

- physical-device validation was not run
- interactive navigation under INX and a non-INX theme was not run
- live Web settings GET/POST validation was not run; the shared keys and handlers remain unchanged
