### PR TITLE
fix(eego-a4): clean refresh when leaving the AirPage full-screen image

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -140,6 +140,12 @@ void AirPageActivity::onExit() {
   LOG_DBG("AIRP", "onExit free=%u largest=%u", static_cast<unsigned>(ESP.getFreeHeap()),
           static_cast<unsigned>(ESP.getMaxAllocHeap()));
   Activity::onExit();
+#if FREEINK_DEVICE_EEGO_A4
+  // EEGO can render the AirPage image as a grayscale full-screen frame; force
+  // a clean first frame after exit so its pixels do not ghost into the next
+  // activity (same A4-only treatment as the EPUB reader).
+  renderer.requestNextFullRefresh();
+#endif
 }
 
 bool AirPageActivity::preventAutoSleep() { return phase_ != Phase::Idle || connection_.preventsAutoSleep(); }
@@ -371,6 +377,12 @@ void AirPageActivity::loop() {
 void AirPageActivity::setAirPageScreen(const Screen screen) {
   if (screen_ == screen) return;
   closeRouting();
+#if FREEINK_DEVICE_EEGO_A4
+  // Leaving the full-screen image for a normal UI page (QR/settings/history):
+  // the image may have been driven as a grayscale frame whose residue a plain
+  // FAST diff won't scrub. Force a clean first frame on the A4.
+  if (screen_ == Screen::Image && screen != Screen::Image) renderer.requestNextFullRefresh();
+#endif
   screen_ = screen;
 }
 


### PR DESCRIPTION
## 背景

EEGO A4（eego_a4_cn）基于最新 `main`（`33477350 feat: enable AirPage on all devices`）的修复。

### AirPage 全屏图片退出后画面残留（eego 限定）

- **现象**：AirPage 加载一张彩色/灰度图片全屏显示后，**按 Back 从图片退回 QR/设置/历史界面**，或退出 AirPage 应用时，图片像素残留在新界面上，短时间不消失。
- **根因**：A4 上用 `AirPageImageRenderer::render()` 把图片以**灰度双平面波形**（`displayGrayBuffer`）整屏驱动。从 `Screen::Image` 切到普通 UI 页（或退出应用）时，目标帧只用 `FAST` 差分刷新——在 A4 的灰度残留上做纯 FAST 差分清不干净，于是图片残影叠进下一个界面。
- **修复**（仅 `#if FREEINK_DEVICE_EEGO_A4` 生效，其他设备行为不变）：
  - `AirPageActivity::setAirPageScreen()`：当 `screen_` 从 `Screen::Image` 切到其他页面时，调用 `renderer.requestNextFullRefresh()`，让目标页首帧全刷。
  - `AirPageActivity::onExit()`：退出 AirPage 应用时同样请求一次干净首帧。
  - 与 EPUB 阅读器 `onExit()` 的 A4 干净帧处理一致。

## 变更文件

- `src/activities/apps/airpage/AirPageActivity.cpp` — 从图片退出/退出应用时 A4 全刷

## 验证

- 真机 COM14（EEGO A4，eego_a4_cn）烧录验证：
  - 图片显示 → Back 退回 QR：无残留
  - 图片 → 设置/历史：无残留
  - 图片直接退出回 Apps/Home：无残影
- 仅 A4 限定，X4 Pro 等其他设备不受影响