### PR TITLE
feat: add touch pagination to multipage lists

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -69,6 +69,8 @@ void AirPageActivity::onEnter() {
 
   resetUi();
   app.on(ACTION_TOUCH, &AirPageActivity::onTouchAction, this);
+  app.on(ACTION_SETTINGS_ROW, &AirPageActivity::onSettingsRow, this);
+  app.on(ACTION_HISTORY_ROW, &AirPageActivity::onHistoryRow, this);
   app.setScreen(&AirPageActivity::touchScreen, this);
 
   phase_ = Phase::Idle;
@@ -83,6 +85,12 @@ void AirPageActivity::onEnter() {
   displayedScreenHeight_ = 0;
   settingsSelection_ = 0;
   historySelection_ = 0;
+  settingsNav_.reset();
+  historyNav_.reset();
+  settingsRows_[0].label = tr(STR_AIRPAGE_MODE_SETTING);
+  settingsRows_[0].actionValue = 0;
+  settingsRows_[1].label = tr(STR_AIRPAGE_AUTO_WALLPAPER);
+  settingsRows_[1].actionValue = 1;
   airpage::AirPageImageRenderer::resetSessionFailures();
 
   switch (imageStore_.initialize(currentArchiveDateKey())) {
@@ -96,6 +104,7 @@ void AirPageActivity::onEnter() {
       notice_ = Notice::InvalidImage;
       break;
   }
+  rebuildHistoryRows();
   autoSleepWallpaper_ = airpage::loadAutoSleepWallpaper();
   airpage::AirPageWallpaper::recoverInterruptedTransaction();
 
@@ -155,6 +164,7 @@ bool AirPageActivity::processImageDisplayResult() {
       if (newlyDownloaded) {
         imageStore_.commitDisplayedDownload(currentArchiveDateKey());
         imageStore_.selectCurrent(selectedImage_);
+        rebuildHistoryRows();
         if (autoSleepWallpaper_ && !airpage::AirPageWallpaper::install(selectedImage_)) {
           notice_ = Notice::WallpaperFailed;
           wallpaperResult_ = WallpaperResult::Failed;
@@ -178,6 +188,7 @@ bool AirPageActivity::processImageDisplayResult() {
           setAirPageScreen(Screen::History);
           break;
       }
+      rebuildHistoryRows();
       notice_ = Notice::InvalidImage;
       imageNeedsDisplay_ = true;
       requestUpdate();
@@ -247,10 +258,26 @@ void AirPageActivity::loop() {
     return;
   }
 
-  if (phase_ == Phase::Idle && (screen_ == Screen::Qr || screen_ == Screen::Image)) {
+  if (phase_ == Phase::Idle) {
     const auto touch = routeTouch(mappedInput);
     if (touch.routed && app.invalidated()) requestUpdate();
     if (touch) return;
+
+    if (screen_ == Screen::Settings || screen_ == Screen::History) {
+      const auto swipe = mappedInput.wasSwipe();
+      if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
+        const int count = screen_ == Screen::Settings ? kSettingsRows : static_cast<int>(imageStore_.historyCount());
+        bool moved = false;
+        {
+          RenderLock lock(*this);
+          fui::ListNav& nav = screen_ == Screen::Settings ? settingsNav_ : historyNav_;
+          const int delta = swipe == MappedInputManager::SwipeDir::Up ? nav.pageRows() : -nav.pageRows();
+          moved = nav.scrollBy(delta, count);
+        }
+        if (moved) requestUpdate();
+        return;
+      }
+    }
   }
 
   switch (screen_) {
@@ -280,31 +307,28 @@ void AirPageActivity::loop() {
         requestUpdate();
         return;
       }
-      if (mappedInput.wasReleased(MappedInputManager::Button::NavPrevious)) {
-        settingsSelection_ = (settingsSelection_ + kSettingsRows - 1) % kSettingsRows;
-        requestUpdate();
-        return;
-      }
-      if (mappedInput.wasReleased(MappedInputManager::Button::NavNext)) {
-        settingsSelection_ = (settingsSelection_ + 1) % kSettingsRows;
-        requestUpdate();
-        return;
-      }
       if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
         applySettingsSelection();
         return;
       }
 
-      const Rect content = contentViewport();
-      switch (handleListTouch(settingsSelection_, kSettingsRows, content.y, content.height, false)) {
-        case ListTouchResult::Activated:
-          applySettingsSelection();
-          return;
-        case ListTouchResult::Consumed:
-          return;
-        case ListTouchResult::None:
-          break;
-      }
+      bool navigated = false;
+      const auto moveSelection = [this, &navigated](const int index) {
+        navigated = true;
+        moveSettingsSelection(index);
+      };
+      buttonNavigator_.onNextRelease(
+          [this, &moveSelection] { moveSelection(ButtonNavigator::nextIndex(settingsSelection_, kSettingsRows)); });
+      buttonNavigator_.onPreviousRelease(
+          [this, &moveSelection] { moveSelection(ButtonNavigator::previousIndex(settingsSelection_, kSettingsRows)); });
+      buttonNavigator_.onNextContinuous([this, &moveSelection] {
+        moveSelection(ButtonNavigator::nextPageIndex(settingsSelection_, kSettingsRows, settingsNav_.pageRows()));
+      });
+      buttonNavigator_.onPreviousContinuous([this, &moveSelection] {
+        moveSelection(ButtonNavigator::previousPageIndex(settingsSelection_, kSettingsRows, settingsNav_.pageRows()));
+      });
+      if (navigated) return;
+
       break;
     }
 
@@ -316,31 +340,32 @@ void AirPageActivity::loop() {
         return;
       }
       const size_t historyCount = imageStore_.historyCount();
-      if (historyCount > 0 && mappedInput.wasReleased(MappedInputManager::Button::NavPrevious)) {
-        historySelection_ = (historySelection_ + static_cast<int>(historyCount) - 1) % static_cast<int>(historyCount);
-        requestUpdate();
-        return;
-      }
-      if (historyCount > 0 && mappedInput.wasReleased(MappedInputManager::Button::NavNext)) {
-        historySelection_ = (historySelection_ + 1) % static_cast<int>(historyCount);
-        requestUpdate();
-        return;
-      }
       if (historyCount > 0 && mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
         openSelectedHistoryImage();
         return;
       }
+      if (historyCount == 0) break;
 
-      const Rect content = contentViewport();
-      switch (handleListTouch(historySelection_, static_cast<int>(historyCount), content.y, content.height, true)) {
-        case ListTouchResult::Activated:
-          openSelectedHistoryImage();
-          return;
-        case ListTouchResult::Consumed:
-          return;
-        case ListTouchResult::None:
-          break;
-      }
+      bool navigated = false;
+      const auto moveSelection = [this, &navigated](const int index) {
+        navigated = true;
+        moveHistorySelection(index);
+      };
+      buttonNavigator_.onNextRelease([this, historyCount, &moveSelection] {
+        moveSelection(ButtonNavigator::nextIndex(historySelection_, static_cast<int>(historyCount)));
+      });
+      buttonNavigator_.onPreviousRelease([this, historyCount, &moveSelection] {
+        moveSelection(ButtonNavigator::previousIndex(historySelection_, static_cast<int>(historyCount)));
+      });
+      buttonNavigator_.onNextContinuous([this, historyCount, &moveSelection] {
+        moveSelection(
+            ButtonNavigator::nextPageIndex(historySelection_, static_cast<int>(historyCount), historyNav_.pageRows()));
+      });
+      buttonNavigator_.onPreviousContinuous([this, historyCount, &moveSelection] {
+        moveSelection(ButtonNavigator::previousPageIndex(historySelection_, static_cast<int>(historyCount),
+                                                         historyNav_.pageRows()));
+      });
+      if (navigated) return;
       break;
     }
 
@@ -379,10 +404,11 @@ void AirPageActivity::touchScreen(UiScreen& screen, void* user) {
 }
 
 void AirPageActivity::buildTouchScreen(UiScreen& screen) {
-  if (!mappedInput.hasTouch() || phase_ != Phase::Idle || wallpaperResult_ != WallpaperResult::None) return;
+  if (phase_ != Phase::Idle || wallpaperResult_ != WallpaperResult::None) return;
 
   switch (screen_) {
     case Screen::Qr: {
+      if (!mappedInput.hasTouch()) return;
       const fui::FooterAction actions[] = {
           {tr(STR_BACK), ACTION_TOUCH, static_cast<int16_t>(TouchAction::BackToApps)},
           {tr(STR_AIRPAGE_SETTINGS_ACTION), ACTION_TOUCH, static_cast<int16_t>(TouchAction::Settings)},
@@ -393,6 +419,7 @@ void AirPageActivity::buildTouchScreen(UiScreen& screen) {
       return;
     }
     case Screen::Image: {
+      if (!mappedInput.hasTouch()) return;
       const fui::TapZone zone{screen.frame().screen(), ACTION_TOUCH, static_cast<int16_t>(TouchAction::OpenImageMenu)};
       fui::TapZonesProps props;
       props.zones = &zone;
@@ -400,9 +427,56 @@ void AirPageActivity::buildTouchScreen(UiScreen& screen) {
       fui::tapZones(screen.frame(), screen.frame().screen(), props);
       return;
     }
-    case Screen::Settings:
-    case Screen::History:
+    case Screen::Settings: {
+      const Rect content = contentViewport();
+      screen.setContentMargin(fui::Insets{static_cast<int16_t>(content.y),
+                                          static_cast<int16_t>(renderer.getScreenWidth() - content.x - content.width),
+                                          static_cast<int16_t>(renderer.getScreenHeight() - content.y - content.height),
+                                          static_cast<int16_t>(content.x)});
+      settingsRows_[0].value = connection_.realtime() ? tr(STR_AIRPAGE_MODE_REALTIME) : tr(STR_AIRPAGE_MODE_MANUAL);
+      settingsRows_[1].value = autoSleepWallpaper_ ? tr(STR_AIRPAGE_SETTING_ON) : tr(STR_AIRPAGE_SETTING_OFF);
+      fui::ListProps props;
+      props.items = settingsRows_;
+      props.count = kSettingsRows;
+      props.action = ACTION_SETTINGS_ROW;
+      props.inputMask = fui::InputTouch;
+      props.valueInset = 8;
+      int16_t rowHeight = screen.theme().rowHeight;
+      if (!mappedInput.hasTouch()) {
+        rowHeight = static_cast<int16_t>(UITheme::getInstance().getMetrics().listRowHeight);
+        props.rowHeight = rowHeight;
+      }
+      settingsNav_.selected = settingsSelection_;
+      settingsNav_.syncToProps(screen.body(), rowHeight, screen.theme().listRowGap, kSettingsRows, props);
+      screen.list(props);
       return;
+    }
+    case Screen::History: {
+      const Rect content = contentViewport();
+      screen.setContentMargin(fui::Insets{static_cast<int16_t>(content.y),
+                                          static_cast<int16_t>(renderer.getScreenWidth() - content.x - content.width),
+                                          static_cast<int16_t>(renderer.getScreenHeight() - content.y - content.height),
+                                          static_cast<int16_t>(content.x)});
+      const int count = static_cast<int>(imageStore_.historyCount());
+      if (count == 0) {
+        screen.centeredText(tr(STR_AIRPAGE_NO_IMAGE), screen.theme().bodyText);
+        return;
+      }
+      fui::ListProps props;
+      props.items = historyRows_;
+      props.count = static_cast<uint16_t>(count);
+      props.action = ACTION_HISTORY_ROW;
+      props.inputMask = fui::InputTouch;
+      int16_t rowHeight = screen.theme().rowHeight;
+      if (!mappedInput.hasTouch()) {
+        rowHeight = static_cast<int16_t>(UITheme::getInstance().getMetrics().listWithSubtitleRowHeight);
+        props.rowHeight = rowHeight;
+      }
+      historyNav_.selected = historySelection_;
+      historyNav_.syncToProps(screen.body(), rowHeight, screen.theme().listRowGap, count, props);
+      screen.list(props);
+      return;
+    }
   }
 }
 
@@ -410,6 +484,25 @@ void AirPageActivity::onTouchAction(const fui::ActionEvent& event, void* user) {
   auto* self = static_cast<AirPageActivity*>(user);
   self->app.clearTapFlash();
   self->applyTouchAction(static_cast<TouchAction>(event.value));
+}
+
+void AirPageActivity::onSettingsRow(const fui::ActionEvent& event, void* user) {
+  auto* self = static_cast<AirPageActivity*>(user);
+  if (self->screen_ != Screen::Settings || event.value < 0 || event.value >= kSettingsRows) return;
+  self->app.clearTapFlash();
+  self->moveSettingsSelection(event.value);
+  self->applySettingsSelection();
+}
+
+void AirPageActivity::onHistoryRow(const fui::ActionEvent& event, void* user) {
+  auto* self = static_cast<AirPageActivity*>(user);
+  if (self->screen_ != Screen::History || event.value < 0 ||
+      event.value >= static_cast<int>(self->imageStore_.historyCount())) {
+    return;
+  }
+  self->app.clearTapFlash();
+  self->moveHistorySelection(event.value);
+  self->openSelectedHistoryImage();
 }
 
 void AirPageActivity::applyTouchAction(const TouchAction action) {
@@ -457,7 +550,18 @@ void AirPageActivity::openImageMenu() {
 void AirPageActivity::openSettings() {
   if (phase_ != Phase::Idle) return;
   setAirPageScreen(Screen::Settings);
-  settingsSelection_ = 0;
+  settingsNav_.reset();
+  moveSettingsSelection(0);
+  requestUpdate();
+}
+
+void AirPageActivity::moveSettingsSelection(const int index) {
+  {
+    RenderLock lock(*this);
+    settingsSelection_ = index;
+    settingsNav_.selected = index;
+    settingsNav_.follow(kSettingsRows);
+  }
   requestUpdate();
 }
 
@@ -498,9 +602,44 @@ void AirPageActivity::applySettingsSelection() {
 
 void AirPageActivity::openHistory() {
   if (phase_ != Phase::Idle) return;
+  historyNav_.reset();
   historySelection_ = 0;
+  rebuildHistoryRows();
   setAirPageScreen(Screen::History);
   requestUpdate();
+}
+
+void AirPageActivity::moveHistorySelection(const int index) {
+  {
+    RenderLock lock(*this);
+    historySelection_ = index;
+    historyNav_.selected = index;
+    historyNav_.follow(static_cast<int>(imageStore_.historyCount()));
+  }
+  requestUpdate();
+}
+
+void AirPageActivity::rebuildHistoryRows() {
+  RenderLock lock(*this);
+  const int count = static_cast<int>(imageStore_.historyCount());
+  historySelection_ = std::min(historySelection_, std::max(0, count - 1));
+  for (int i = 0; i < count; ++i) {
+    const auto& entry = imageStore_.historyEntry(static_cast<size_t>(i));
+    if (entry.isCurrent()) {
+      snprintf(historyLabels_[i], sizeof(historyLabels_[i]), "%s", tr(STR_AIRPAGE_CURRENT_IMAGE));
+    } else if (!formatArchiveDate(entry.archiveId, historyLabels_[i], sizeof(historyLabels_[i]))) {
+      snprintf(historyLabels_[i], sizeof(historyLabels_[i]), "%s %d", tr(STR_AIRPAGE_IMAGE_LABEL), i + 1);
+    }
+    const char* format = entry.image.format == airpage::ImageFormat::Jpeg ? "JPEG" : "BMP";
+    snprintf(historySubtitles_[i], sizeof(historySubtitles_[i]), "%s · %d×%d", format, entry.image.width,
+             entry.image.height);
+    historyRows_[i].label = historyLabels_[i];
+    historyRows_[i].subtitle = historySubtitles_[i];
+    historyRows_[i].actionValue = static_cast<int16_t>(i);
+  }
+  historyNav_.selected = historySelection_;
+  historyNav_.scrollBy(0, count);
+  historyNav_.follow(count);
 }
 
 void AirPageActivity::openSelectedHistoryImage() {
@@ -508,6 +647,7 @@ void AirPageActivity::openSelectedHistoryImage() {
     if (historySelection_ >= static_cast<int>(imageStore_.historyCount())) {
       historySelection_ = imageStore_.historyCount() == 0 ? 0 : static_cast<int>(imageStore_.historyCount() - 1);
     }
+    rebuildHistoryRows();
     notice_ = Notice::InvalidImage;
     requestUpdate();
     return;
@@ -750,10 +890,8 @@ void AirPageActivity::render(RenderLock&&) {
         renderQr(content);
         break;
       case Screen::Settings:
-        renderSettings(content);
         break;
       case Screen::History:
-        renderHistory(content);
         break;
       case Screen::Image:
         renderStatus(content, tr(STR_AIRPAGE_INVALID_IMAGE));
@@ -786,7 +924,7 @@ void AirPageActivity::render(RenderLock&&) {
       break;
   }
 
-  if (mappedInput.hasTouch()) renderUi();
+  if (mappedInput.hasTouch() || screen_ == Screen::Settings || screen_ == Screen::History) renderUi();
 
   renderer.displayBuffer();
   imageNeedsDisplay_ = true;
@@ -877,50 +1015,6 @@ void AirPageActivity::renderQr(const Rect& viewport) {
 
 void AirPageActivity::renderStatus(const Rect& viewport, const char* msg) {
   UITheme::drawCenteredWrappedText(renderer, viewport, UI_12_FONT_ID, msg, 2);
-}
-
-void AirPageActivity::renderSettings(const Rect& viewport) {
-  GUI.drawList(
-      renderer, viewport, kSettingsRows, settingsSelection_,
-      [](int index) {
-        const StrId id = index == 0 ? StrId::STR_AIRPAGE_MODE_SETTING : StrId::STR_AIRPAGE_AUTO_WALLPAPER;
-        return std::string(I18N.get(id));
-      },
-      nullptr, nullptr,
-      [this](int index) {
-        if (index == 0) {
-          const StrId id = connection_.realtime() ? StrId::STR_AIRPAGE_MODE_REALTIME : StrId::STR_AIRPAGE_MODE_MANUAL;
-          return std::string(I18N.get(id));
-        }
-        const StrId id = autoSleepWallpaper_ ? StrId::STR_AIRPAGE_SETTING_ON : StrId::STR_AIRPAGE_SETTING_OFF;
-        return std::string(I18N.get(id));
-      });
-}
-
-void AirPageActivity::renderHistory(const Rect& viewport) {
-  const size_t historyCount = imageStore_.historyCount();
-  if (historyCount == 0) {
-    renderStatus(viewport, tr(STR_AIRPAGE_NO_IMAGE));
-    return;
-  }
-
-  GUI.drawList(
-      renderer, viewport, static_cast<int>(historyCount), historySelection_,
-      [this](int index) {
-        const auto& entry = imageStore_.historyEntry(static_cast<size_t>(index));
-        if (entry.isCurrent()) return std::string(tr(STR_AIRPAGE_CURRENT_IMAGE));
-        char label[32];
-        if (formatArchiveDate(entry.archiveId, label, sizeof(label))) return std::string(label);
-        snprintf(label, sizeof(label), "%s %d", tr(STR_AIRPAGE_IMAGE_LABEL), index + 1);
-        return std::string(label);
-      },
-      [this](int index) {
-        const airpage::ImageInfo& image = imageStore_.historyEntry(static_cast<size_t>(index)).image;
-        const char* format = image.format == airpage::ImageFormat::Jpeg ? "JPEG" : "BMP";
-        char subtitle[40];
-        snprintf(subtitle, sizeof(subtitle), "%s · %d×%d", format, image.width, image.height);
-        return std::string(subtitle);
-      });
 }
 
 const char* AirPageActivity::screenTitle() const {

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -9,6 +9,7 @@
 #include "AirPageImageStore.h"
 #include "components/OptionPopup.h"
 #include "components/UiAppHost.h"
+#include "util/ButtonNavigator.h"
 
 struct Rect;
 
@@ -70,16 +71,21 @@ class AirPageActivity final : public Activity, private UiAppHost {
   void setAirPageScreen(Screen screen);
   void openImageMenu();
   void applyTouchAction(TouchAction action);
+  void rebuildHistoryRows();
+  void moveSettingsSelection(int index);
+  void moveHistorySelection(int index);
 
   static constexpr freeink::ui::ActionId ACTION_TOUCH = 1;
+  static constexpr freeink::ui::ActionId ACTION_SETTINGS_ROW = 2;
+  static constexpr freeink::ui::ActionId ACTION_HISTORY_ROW = 3;
   static void touchScreen(UiScreen& screen, void* user);
   static void onTouchAction(const freeink::ui::ActionEvent& event, void* user);
+  static void onSettingsRow(const freeink::ui::ActionEvent& event, void* user);
+  static void onHistoryRow(const freeink::ui::ActionEvent& event, void* user);
   void buildTouchScreen(UiScreen& screen);
 
   void renderQr(const Rect& viewport);
   void renderStatus(const Rect& viewport, const char* msg);
-  void renderSettings(const Rect& viewport);
-  void renderHistory(const Rect& viewport);
   Rect contentViewport() const;
   const char* noticeText() const;
   const char* connectionText() const;
@@ -98,6 +104,14 @@ class AirPageActivity final : public Activity, private UiAppHost {
   airpage::AirPageConnection connection_;
   airpage::SelectedImage selectedImage_;
   OptionPopup imageMenu_;
+  ButtonNavigator buttonNavigator_;
+
+  freeink::ui::ListNav settingsNav_;
+  freeink::ui::ListNav historyNav_;
+  freeink::ui::ListItem settingsRows_[kSettingsRows]{};
+  freeink::ui::ListItem historyRows_[airpage::AirPageImageStore::kMaxHistoryEntries]{};
+  char historyLabels_[airpage::AirPageImageStore::kMaxHistoryEntries][48]{};
+  char historySubtitles_[airpage::AirPageImageStore::kMaxHistoryEntries][40]{};
 
   bool imageNeedsDisplay_ = true;
   bool waitForInputRelease_ = false;

--- a/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
@@ -8,8 +8,11 @@
 #include "AppMetricCard.h"
 #include "ReadingStatsDetailActivity.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 #include "util/HeaderDateUtils.h"
+
+namespace fui = freeink::ui;
 
 namespace {
 constexpr int SUMMARY_CARD_HEIGHT = 70;
@@ -22,128 +25,111 @@ void drawMetricCard(const GfxRenderer& renderer, const Rect& rect, const char* l
 }
 }  // namespace
 
+ReadingDayDetailActivity::ReadingDayDetailActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                                                   const uint32_t dayOrdinal)
+    : UiListActivity("ReadingDayDetail", renderer, mappedInput), dayOrdinal(dayOrdinal) {}
+
 void ReadingDayDetailActivity::refreshEntries() {
   entries = ReadingStatsAnalytics::getBooksReadOnDay(dayOrdinal);
-  if (selectedIndex >= static_cast<int>(entries.size())) {
-    selectedIndex = std::max(0, static_cast<int>(entries.size()) - 1);
+  nav.selected = std::min(nav.selected, std::max(0, listCount() - 1));
+  nav.scrollBy(0, listCount());
+  nav.follow(listCount());
+
+  rowValues.clear();
+  rowValues.reserve(entries.size());
+  for (const auto& entry : entries) rowValues.push_back(ReadingStatsAnalytics::formatDurationHm(entry.readingMs));
+
+  rowItems.clear();
+  rowItems.reserve(entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const ReadingBookStats* book = entries[i].book;
+    fui::ListItem item;
+    item.label = book ? (book->title.empty() ? book->path.c_str() : book->title.c_str()) : tr(STR_NOT_SET);
+    item.subtitle = book ? (book->author.empty() ? tr(STR_IN_PROGRESS) : book->author.c_str()) : tr(STR_NOT_SET);
+    item.icon = listIconFor(UIIcon::Book, 32);
+    item.value = rowValues[i].c_str();
+    item.actionValue = static_cast<int16_t>(i);
+    rowItems.push_back(item);
   }
+
+  dateLabel = ReadingStatsAnalytics::formatDayOrdinalLabel(dayOrdinal);
+  const auto timeline = ReadingStatsAnalytics::buildTimelineDayEntry(dayOrdinal);
+  totalReadingText = ReadingStatsAnalytics::formatDurationHm(entries.empty() ? 0 : timeline.totalReadingMs);
+  bookCountText = std::to_string(entries.size());
+  topBookTitle = !entries.empty() && entries.front().book != nullptr ? getBookTitle(*entries.front().book)
+                                                                     : std::string(tr(STR_NOT_SET));
 }
 
 void ReadingDayDetailActivity::openSelectedBook() {
-  if (selectedIndex < 0 || selectedIndex >= static_cast<int>(entries.size()) ||
-      entries[selectedIndex].book == nullptr) {
+  if (nav.selected < 0 || nav.selected >= listCount() || entries[nav.selected].book == nullptr) {
     return;
   }
 
+  app.clearTapFlash();
   startActivityForResultWith<ReadingStatsDetailActivity>(
       [this](const ActivityResult&) {
         refreshEntries();
         requestUpdate();
       },
-      entries[selectedIndex].book->path);
+      entries[nav.selected].book->path);
 }
 
 void ReadingDayDetailActivity::onEnter() {
-  Activity::onEnter();
+  UiListActivity::onEnter();
   refreshEntries();
-  waitForConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
-  requestUpdate();
 }
 
-void ReadingDayDetailActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    finish();
-    return;
-  }
-
-  if (waitForConfirmRelease) {
-    if (!mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      waitForConfirmRelease = false;
-    }
-    return;
-  }
-
-  const auto& metrics = UITheme::getInstance().getMetrics();
-  const int listTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing + SUMMARY_CARD_HEIGHT +
-                      metrics.verticalSpacing + 34 + 10;
-  const int listHeight = renderer.getScreenHeight() - listTop - metrics.buttonHintsHeight - metrics.verticalSpacing;
-  if (handleListTouch(selectedIndex, static_cast<int>(entries.size()), listTop, listHeight, false) ==
-      ListTouchResult::Activated) {
-    openSelectedBook();
-    return;
-  }
-
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    openSelectedBook();
-    return;
-  }
-
-  buttonNavigator.onNextRelease([this] {
-    if (entries.empty()) {
-      return;
-    }
-    selectedIndex = ButtonNavigator::nextIndex(selectedIndex, static_cast<int>(entries.size()));
-    requestUpdate();
-  });
-
-  buttonNavigator.onPreviousRelease([this] {
-    if (entries.empty()) {
-      return;
-    }
-    selectedIndex = ButtonNavigator::previousIndex(selectedIndex, static_cast<int>(entries.size()));
-    requestUpdate();
-  });
+void ReadingDayDetailActivity::activateIndex(const int index) {
+  if (index < 0 || index >= listCount()) return;
+  nav.selected = index;
+  openSelectedBook();
 }
 
-void ReadingDayDetailActivity::render(RenderLock&&) {
-  renderer.clearScreen();
-
+void ReadingDayDetailActivity::drawChrome() {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int pageWidth = renderer.getScreenWidth();
-  const int pageHeight = renderer.getScreenHeight();
   const int sidePadding = metrics.contentSidePadding;
   const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
   const int cardWidth = (pageWidth - sidePadding * 2 - SUMMARY_GAP) / 2;
-  const std::string dateLabel = ReadingStatsAnalytics::formatDayOrdinalLabel(dayOrdinal);
-  const uint64_t totalReadingMs =
-      !entries.empty() ? ReadingStatsAnalytics::buildTimelineDayEntry(dayOrdinal).totalReadingMs : 0;
 
   HeaderDateUtils::drawHeaderWithDate(renderer, tr(STR_READING_DAY), dateLabel.c_str());
 
   drawMetricCard(renderer, Rect{sidePadding, contentTop, cardWidth, SUMMARY_CARD_HEIGHT}, tr(STR_TOTAL_TIME),
-                 ReadingStatsAnalytics::formatDurationHm(totalReadingMs));
+                 totalReadingText);
   drawMetricCard(renderer, Rect{sidePadding + cardWidth + SUMMARY_GAP, contentTop, cardWidth, SUMMARY_CARD_HEIGHT},
-                 tr(STR_BOOKS_READ), std::to_string(entries.size()));
+                 tr(STR_BOOKS_READ), bookCountText);
 
-  const char* topBookLabel = tr(STR_TOP_BOOK);
-  const std::string topBookTitle = !entries.empty() && entries.front().book != nullptr
-                                       ? getBookTitle(*entries.front().book)
-                                       : std::string(tr(STR_NOT_SET));
   const int listTop = contentTop + SUMMARY_CARD_HEIGHT + metrics.verticalSpacing;
-  GUI.drawSubHeader(renderer, Rect{0, listTop, pageWidth, 34}, topBookLabel, topBookTitle.c_str());
+  GUI.drawSubHeader(renderer, Rect{0, listTop, pageWidth, 34}, tr(STR_TOP_BOOK), topBookTitle.c_str());
+}
 
+void ReadingDayDetailActivity::buildScreen(UiScreen& screen) {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+  const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
+  const int listTop = contentTop + SUMMARY_CARD_HEIGHT + metrics.verticalSpacing;
   const int listContentTop = listTop + 34 + 10;
-  const int listHeight = pageHeight - listContentTop - metrics.buttonHintsHeight - metrics.verticalSpacing;
+  screen.setContentMargin(fui::Insets{
+      static_cast<int16_t>(listContentTop), static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(metrics.buttonHintsHeight + metrics.verticalSpacing), static_cast<int16_t>(safe.x)});
+
   if (entries.empty()) {
-    renderer.drawText(UI_10_FONT_ID, sidePadding, listContentTop + 20, tr(STR_NO_READING_DAY));
-  } else {
-    GUI.drawList(
-        renderer, Rect{0, listContentTop, pageWidth, listHeight}, static_cast<int>(entries.size()), selectedIndex,
-        [this](const int index) {
-          return entries[index].book ? getBookTitle(*entries[index].book) : std::string(tr(STR_NOT_SET));
-        },
-        [this](const int index) {
-          if (!entries[index].book) {
-            return std::string(tr(STR_NOT_SET));
-          }
-          return entries[index].book->author.empty() ? std::string(tr(STR_IN_PROGRESS)) : entries[index].book->author;
-        },
-        [](const int) { return UIIcon::Book; },
-        [this](const int index) { return ReadingStatsAnalytics::formatDurationHm(entries[index].readingMs); });
+    screen.centeredText(tr(STR_NO_READING_DAY), screen.theme().bodyText);
+    return;
   }
 
+  fui::ListProps props;
+  props.items = rowItems.data();
+  props.count = static_cast<uint16_t>(rowItems.size());
+  props.action = ACTION_ROW;
+  props.inputMask = fui::InputTouch;
+  props.valueInset = 8;
+  syncListViewport(screen, props, /*hasSubtitle=*/true);
+  screen.list(props);
+}
+
+void ReadingDayDetailActivity::drawFooter() {
   const auto labels =
       mappedInput.mapLabels(tr(STR_BACK), entries.empty() ? "" : tr(STR_OPEN), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-  renderer.displayBuffer();
 }

--- a/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingDayDetailActivity.cpp
@@ -3,6 +3,8 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
+#include <algorithm>
+#include <iterator>
 #include <string>
 
 #include "AppMetricCard.h"
@@ -37,7 +39,8 @@ void ReadingDayDetailActivity::refreshEntries() {
 
   rowValues.clear();
   rowValues.reserve(entries.size());
-  for (const auto& entry : entries) rowValues.push_back(ReadingStatsAnalytics::formatDurationHm(entry.readingMs));
+  std::transform(entries.begin(), entries.end(), std::back_inserter(rowValues),
+                 [](const auto& entry) { return ReadingStatsAnalytics::formatDurationHm(entry.readingMs); });
 
   rowItems.clear();
   rowItems.reserve(entries.size());

--- a/src/activities/apps/reading-stats/ReadingDayDetailActivity.h
+++ b/src/activities/apps/reading-stats/ReadingDayDetailActivity.h
@@ -1,26 +1,33 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
-#include "../../Activity.h"
-#include "util/ButtonNavigator.h"
+#include "activities/UiListActivity.h"
 #include "util/ReadingStatsAnalytics.h"
 
-class ReadingDayDetailActivity final : public Activity {
-  ButtonNavigator buttonNavigator;
-  uint32_t dayOrdinal = 0;
-  int selectedIndex = 0;
-  std::vector<ReadingStatsAnalytics::DayBookEntry> entries;
-  bool waitForConfirmRelease = false;
+class ReadingDayDetailActivity final : public UiListActivity {
+ public:
+  explicit ReadingDayDetailActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, uint32_t dayOrdinal);
+
+  void onEnter() override;
+
+ private:
+  int listCount() const override { return static_cast<int>(entries.size()); }
+  void buildScreen(UiScreen& screen) override;
+  void activateIndex(int index) override;
+  void drawChrome() override;
+  void drawFooter() override;
 
   void refreshEntries();
   void openSelectedBook();
 
- public:
-  explicit ReadingDayDetailActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, uint32_t dayOrdinal)
-      : Activity("ReadingDayDetail", renderer, mappedInput), dayOrdinal(dayOrdinal) {}
-
-  void onEnter() override;
-  void loop() override;
-  void render(RenderLock&&) override;
+  uint32_t dayOrdinal = 0;
+  std::vector<ReadingStatsAnalytics::DayBookEntry> entries;
+  std::vector<std::string> rowValues;
+  std::vector<freeink::ui::ListItem> rowItems;
+  std::string dateLabel;
+  std::string totalReadingText;
+  std::string bookCountText;
+  std::string topBookTitle;
 };

--- a/src/activities/settings/AppVisibilitySettingsActivity.cpp
+++ b/src/activities/settings/AppVisibilitySettingsActivity.cpp
@@ -3,19 +3,29 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
-#include <string>
-
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "activities/apps/AppsMenuActivity.h"
 #include "components/UITheme.h"
 
+namespace fui = freeink::ui;
+
+AppVisibilitySettingsActivity::AppVisibilitySettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
+    : UiListActivity("AppVisibilitySettings", renderer, mappedInput) {}
+
 void AppVisibilitySettingsActivity::onEnter() {
-  Activity::onEnter();
-  selectedIndex = 0;
+  UiListActivity::onEnter();
   dirty = false;
   waitForConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
-  requestUpdate();
+
+  rowItems.clear();
+  rowItems.reserve(static_cast<size_t>(listCount()));
+  for (int i = 0; i < listCount(); ++i) {
+    fui::ListItem item;
+    item.label = I18N.get(AppsMenuActivity::getAppTitleId(i));
+    item.actionValue = static_cast<int16_t>(i);
+    rowItems.push_back(item);
+  }
 }
 
 void AppVisibilitySettingsActivity::onExit() {
@@ -23,79 +33,48 @@ void AppVisibilitySettingsActivity::onExit() {
   Activity::onExit();
 }
 
-void AppVisibilitySettingsActivity::loop() {
-  if (waitForConfirmRelease) {
-    if (!mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      waitForConfirmRelease = false;
-    }
-    return;
-  }
+int AppVisibilitySettingsActivity::listCount() const { return AppsMenuActivity::getAppCount(); }
 
-  const int appCount = AppsMenuActivity::getAppCount();
-  const auto& metrics = UITheme::getInstance().getMetrics();
-  const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
-  const int contentHeight =
-      renderer.getScreenHeight() - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing * 2;
-
-  switch (handleListTouch(selectedIndex, appCount, contentTop, contentHeight, false)) {
-    case ListTouchResult::Activated:
-      toggleSelected();
-      return;
-    case ListTouchResult::Consumed:
-      return;
-    case ListTouchResult::None:
-      break;
-  }
-
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    finish();
-    return;
-  }
-
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-    toggleSelected();
-    return;
-  }
-
-  buttonNavigator.onNext([this, appCount] {
-    selectedIndex = ButtonNavigator::nextIndex(selectedIndex, appCount);
-    requestUpdate();
-  });
-  buttonNavigator.onPrevious([this, appCount] {
-    selectedIndex = ButtonNavigator::previousIndex(selectedIndex, appCount);
-    requestUpdate();
-  });
+bool AppVisibilitySettingsActivity::handleCustomInput() {
+  if (!waitForConfirmRelease) return false;
+  if (!mappedInput.isPressed(MappedInputManager::Button::Confirm)) waitForConfirmRelease = false;
+  return true;
 }
 
-void AppVisibilitySettingsActivity::toggleSelected() {
-  const bool visible = AppsMenuActivity::isAppVisible(selectedIndex);
-  if (AppsMenuActivity::setAppVisible(selectedIndex, !visible)) {
+void AppVisibilitySettingsActivity::activateIndex(const int index) {
+  if (index < 0 || index >= listCount()) return;
+  nav.selected = index;
+  app.clearTapFlash();
+  const bool visible = AppsMenuActivity::isAppVisible(index);
+  if (AppsMenuActivity::setAppVisible(index, !visible)) {
     dirty = true;
     requestUpdate();
   }
 }
 
-void AppVisibilitySettingsActivity::render(RenderLock&&) {
-  renderer.clearScreen();
+const char* AppVisibilitySettingsActivity::headerTitle() const { return tr(STR_APP_VISIBILITY); }
 
+void AppVisibilitySettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  const int pageWidth = renderer.getScreenWidth();
-  const int pageHeight = renderer.getScreenHeight();
-  const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
-  const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing * 2;
-  const int appCount = AppsMenuActivity::getAppCount();
+  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
-  GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_APP_VISIBILITY));
-  GUI.drawList(
-      renderer, Rect{0, contentTop, pageWidth, contentHeight}, appCount, selectedIndex,
-      [](int index) { return std::string(I18N.get(AppsMenuActivity::getAppTitleId(index))); }, nullptr, nullptr,
-      [](int index) {
-        return AppsMenuActivity::isAppVisible(index) ? std::string(tr(STR_STATE_ON)) : std::string(tr(STR_STATE_OFF));
-      },
-      true);
+  for (int i = 0; i < listCount(); ++i) {
+    rowItems[static_cast<size_t>(i)].value = AppsMenuActivity::isAppVisible(i) ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
+  }
 
+  fui::ListProps props;
+  props.items = rowItems.data();
+  props.count = static_cast<uint16_t>(rowItems.size());
+  props.action = ACTION_ROW;
+  props.inputMask = fui::InputTouch;
+  props.valueInset = 8;
+  syncListViewport(screen, props);
+  screen.list(props);
+}
+
+void AppVisibilitySettingsActivity::drawFooter() {
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_TOGGLE), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-
-  renderer.displayBuffer();
 }

--- a/src/activities/settings/AppVisibilitySettingsActivity.h
+++ b/src/activities/settings/AppVisibilitySettingsActivity.h
@@ -1,23 +1,25 @@
 #pragma once
 
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
+#include <vector>
 
-class AppVisibilitySettingsActivity final : public Activity {
+#include "activities/UiListActivity.h"
+
+class AppVisibilitySettingsActivity final : public UiListActivity {
  public:
-  explicit AppVisibilitySettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("AppVisibilitySettings", renderer, mappedInput) {}
+  explicit AppVisibilitySettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput);
 
   void onEnter() override;
   void onExit() override;
-  void loop() override;
-  void render(RenderLock&&) override;
 
  private:
-  void toggleSelected();
+  int listCount() const override;
+  void buildScreen(UiScreen& screen) override;
+  void activateIndex(int index) override;
+  bool handleCustomInput() override;
+  const char* headerTitle() const override;
+  void drawFooter() override;
 
-  ButtonNavigator buttonNavigator;
-  int selectedIndex = 0;
+  std::vector<freeink::ui::ListItem> rowItems;
   bool waitForConfirmRelease = false;
   bool dirty = false;
 };

--- a/test/inx_navigation/InxNavigationTest.cpp
+++ b/test/inx_navigation/InxNavigationTest.cpp
@@ -1,4 +1,5 @@
 #include <FreeInkUICore.h>
+#include <components/lists/list.h>
 #include <gtest/gtest.h>
 
 #include <type_traits>
@@ -59,6 +60,26 @@ TEST(InxNavigation, WrapsAcrossFiveTabs) {
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::First, 10), 0);
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::Last, 1), 0);
   EXPECT_EQ(MainTabs::contentEdgeIndex(MainTabContentEdge::Last, 10), 9);
+}
+
+TEST(InxNavigation, ScrollsListPagesWithoutMovingSelection) {
+  freeink::ui::ListNav nav;
+  nav.selected = 2;
+  nav.visibleRows = 4;
+
+  EXPECT_TRUE(nav.scrollBy(nav.pageRows(), 10));
+  EXPECT_EQ(nav.top, 4);
+  EXPECT_EQ(nav.selected, 2);
+  EXPECT_TRUE(nav.scrollBy(nav.pageRows(), 10));
+  EXPECT_EQ(nav.top, 6);
+  EXPECT_FALSE(nav.scrollBy(nav.pageRows(), 10));
+
+  EXPECT_TRUE(nav.scrollBy(-nav.pageRows(), 10));
+  EXPECT_EQ(nav.top, 2);
+  EXPECT_TRUE(nav.scrollBy(-nav.pageRows(), 10));
+  EXPECT_EQ(nav.top, 0);
+  EXPECT_FALSE(nav.scrollBy(-nav.pageRows(), 10));
+  EXPECT_EQ(nav.selected, 2);
 }
 
 TEST(InxNavigation, TracksLastInputWithTouchPriority) {


### PR DESCRIPTION
## Summary

- Add swipe pagination and direct row activation to the hidden-app list, AirPage history, and per-day reading-book list.
- Reuse the existing FreeInkUI `ListNav` semantics: swipes move the viewport without moving the button selection; button navigation keeps wrapping and brings the selection back into view.
- Keep list data allocation out of render paths: hidden apps reserve once, reading-day rows rebuild only on data refresh, and AirPage uses fixed storage for its maximum 20 history rows.
- Add a regression test covering page scrolling, boundary clamping, and selection preservation.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** a new interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle these multipage touch interactions well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Validation

- `./bin/clang-format-fix -g --check`
- `git diff --check`
- 28 relevant host tests: AirPage image-store and INX/navigation suites
- `pio run`: 55,716 B RAM (17.0%), 6,261,617 B flash (95.5%)
- `pio run -e x4pro`: 65,692 B RAM (20.0%), 6,066,782 B flash (92.6%)
- `pio run -e simulator_eego_a4`

## Additional Context

- No public API, setting, translation key, dependency, or cache-format changes.
- Dynamic row caches are built only on activity entry or data refresh. AirPage history storage is fixed at the store's existing 20-entry limit.
- Interactive simulator acceptance and repeated-entry real-device heap/largest-block monitoring are still pending; this PR is draft until those checks are complete.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
