### PR TITLE
fix: align Paper Mono power and wake behavior

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,9 +260,9 @@ enum class SilentRebootTarget : uint32_t {
 // flows suppress the splash and leave the panel holding its pre-boot frame; a
 // plain boot shows the splash. See setup() for the resolution.
 enum class BootResume : uint8_t {
-  Splash,       // cold boot, flash, panic, or plain reboot
-  Silent,       // heap-defrag ESP.restart() (RTC flag; lost on power loss)
-  QuickResume,  // wake from a quick-resume deep sleep (SD flag; survives power loss)
+  Splash,          // cold boot, flash, panic, or plain reboot
+  Silent,          // heap-defrag ESP.restart() (RTC flag; lost on power loss)
+  SplashlessWake,  // wake from deep sleep with the splash suppressed by the SD flag
 };
 
 // Latched true once enterDeepSleep() commits to sleeping, before it tears down
@@ -351,7 +351,9 @@ void enterDeepSleep(bool fromTimeout = false) {
       SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::QUICK_RESUME ||
       (fromTimeout &&
        SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT);
-  APP_STATE.showBootScreen = !isQuickResumeSleep;
+  // Every sleep mode leaves a complete retained frame on the e-ink panel. Keep
+  // it visible until the first useful reader or home paint replaces it.
+  APP_STATE.showBootScreen = false;
 
   APP_STATE.saveToFile();
 
@@ -369,6 +371,9 @@ void enterDeepSleep(bool fromTimeout = false) {
 
   if (isQuickResumeSleep) {
     saveSleepFrameBuffer();
+  } else if (Storage.exists(SLEEP_FRAME_FILE)) {
+    // A stale Quick Resume frame must not replace the selected sleep screen during wake.
+    Storage.remove(SLEEP_FRAME_FILE);
   }
 
   // Tear down WiFi so the modem power domain isn't held alive across deep sleep.
@@ -607,8 +612,14 @@ void setup() {
     case HalGPIO::WakeupReason::AfterUSBPower:
       // If USB power caused a cold boot, go back to sleep
       LOG_DBG("MAIN", "Wakeup reason: After USB Power");
+#if FREEINK_DEVICE_PAPERMONO
+      // There is no armable GPIO wake because the button is behind the PMIC.
+      // Sleeping here would strand the device in a USB-replug boot loop.
+      break;
+#else
       powerManager.startDeepSleep(gpio);
       break;
+#endif
     case HalGPIO::WakeupReason::AfterFlash:
       // After flashing, just proceed to boot
     case HalGPIO::WakeupReason::Other:
@@ -619,7 +630,7 @@ void setup() {
   // Recovery firmware mode: hold a side button together with power at boot. X4 Pro uses
   // BTN_DOWN/GPIO7 because BTN_UP/GPIO0 is an ESP32-S3 boot strap; other boards keep BTN_UP.
   bool recoveryFirmwareMode = false;
-  if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
+  if (wakeupReason == HalGPIO::WakeupReason::PowerButton && !BoardConfig::isPaperMono()) {
     // Refresh the cached button state a few times — isPressed() needs ~half a second to settle
     // after boot per the HalGPIO contract. Use a millis-based deadline so we always wait the full
     // settle window even if the loop body takes longer than expected on slow boots.
@@ -642,9 +653,12 @@ void setup() {
   // skips the panel-clearing pass and the X3 initial-full-sync arming (see
   // HalDisplay::begin), so the first paint is FAST_REFRESH (~500ms) over the
   // retained frame and input dispatches against a visible UI.
-  const BootResume resume = isSilentReboot              ? BootResume::Silent
-                            : !APP_STATE.showBootScreen ? BootResume::QuickResume
-                                                        : BootResume::Splash;
+  // Only a verified deep-sleep wake may use the one-shot persisted flag.
+  // Otherwise a stale flag could suppress the splash on a cold boot.
+  const bool isSleepWake = wakeupReason == HalGPIO::WakeupReason::PowerButton;
+  const BootResume resume = isSilentReboot                             ? BootResume::Silent
+                            : isSleepWake && !APP_STATE.showBootScreen ? BootResume::SplashlessWake
+                                                                       : BootResume::Splash;
   bool allowFastInitialReaderRefresh = false;
 
   const bool fontsReady = setupDisplayAndFonts(resume != BootResume::Splash,
@@ -657,13 +671,13 @@ void setup() {
         // Splash skipped: the routing block below picks the target activity; the
         // panel keeps showing the pre-reboot popup until that first paint lands.
         break;
-      case BootResume::QuickResume:
-        // One-shot flag: re-arm the splash for the next non-quick-resume boot. Save
+      case BootResume::SplashlessWake:
+        // One-shot flag: re-arm the splash for the next ordinary boot. Save
         // before any painting so a hang in the blocking paint path can't strand
-        // us in a quick-resume-with-no-frame loop on the next boot.
+        // us in a splashless-with-no-frame loop on the next boot.
         APP_STATE.showBootScreen = true;
         APP_STATE.saveToFile();
-        if (loadSleepFrameBuffer()) {
+        if (Storage.exists(SLEEP_FRAME_FILE) && loadSleepFrameBuffer()) {
           const bool useDifferentialRefresh = gpio.deviceIsX3();
           if (useDifferentialRefresh) {
             // begin() clears the X3 controller RAM, so restore the saved frame as
@@ -679,8 +693,6 @@ void setup() {
           } else {
             renderer.displayBuffer(HalDisplay::HALF_REFRESH);
           }
-        } else {
-          activityManager.goToBoot();  // frame file missing, fall back to the splash
         }
         break;
       case BootResume::Splash:
@@ -841,6 +853,18 @@ void loop() {
     // This should never be hit as `enterDeepSleep` calls esp_deep_sleep_start
     return;
   }
+
+#if FREEINK_DEVICE_PAPERMONO
+  // Paper Mono reports the PMIC power button as a one-tick click, so the held
+  // path above cannot fire. With the default Ignore action, retain the normal
+  // power-button meaning and shut down; explicit alternate bindings still win.
+  if ((SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP ||
+       SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::IGNORE) &&
+      millis() >= allowSleepAt && mappedInputManager.wasReleased(MappedInputManager::Button::Power)) {
+    enterDeepSleep();
+    return;
+  }
+#endif
 
   // Refresh screen when power button is short-pressed with FORCE_REFRESH setting.
   if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::FORCE_REFRESH &&


### PR DESCRIPTION
## Summary

* **Goal:** Align CrossMux Paper Mono power-button and sleep/wake behavior with current upstream CrossPoint.
* **Changes included:**
  * Treat the PMIC's one-tick power click as a sleep request for the default `IGNORE` and explicit `SLEEP` actions.
  * Keep Paper Mono awake after a USB-powered cold boot because it has no armable ESP GPIO wake source.
  * Exclude Paper Mono from the side-button recovery chord.
  * Use the upstream splashless deep-sleep wake flow and discard stale Quick Resume frames.

The input SDK already emits the PMIC click as a one-tick `BTN_POWER` pulse, so no SDK or HAL change is needed.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/main/SCOPE.md) and [ROADMAP.md](../blob/main/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This fixes a device-input gap already handled by upstream CrossPoint; CrossMux needs the same behavior for its Paper Mono target.
- [x] Recovery-path coordination is covered: this change was requested and hardware-validated by the repository owner.

## Verification

- `./bin/clang-format-fix -g`
- `git diff --check`
- `pio run -e papermono`
- Paper Mono hardware matrix reported passing by the repository owner:
  * `IGNORE` and `SLEEP` shut down and wake splashlessly.
  * `FORCE_REFRESH` and `PAGE_TURN` retain their configured actions.
  * USB cold boot stays awake.
  * Side button + power does not enter recovery mode.
  * Normal sleep and Quick Resume retain the expected sleep frame.

Resource impact:

- RAM: 82,068 bytes (unchanged)
- Flash: 6,076,302 bytes (+120 bytes)
- No new allocation, public API, or persistence-format change

Upstream behavior adapted from `bbca4886`, `e970abae`, and `cdd89b1d`.

---

### AI Usage

Did you use AI tools to help write this code? **YES**