### PR TITLE
fix: build Paper Mono recovery guard in simulators

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,7 +630,8 @@ void setup() {
   // Recovery firmware mode: hold a side button together with power at boot. X4 Pro uses
   // BTN_DOWN/GPIO7 because BTN_UP/GPIO0 is an ESP32-S3 boot strap; other boards keep BTN_UP.
   bool recoveryFirmwareMode = false;
-  if (wakeupReason == HalGPIO::WakeupReason::PowerButton && !BoardConfig::isPaperMono()) {
+#if !FREEINK_DEVICE_PAPERMONO
+  if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
     // Refresh the cached button state a few times — isPressed() needs ~half a second to settle
     // after boot per the HalGPIO contract. Use a millis-based deadline so we always wait the full
     // settle window even if the loop body takes longer than expected on slow boots.
@@ -645,6 +646,7 @@ void setup() {
       LOG_INF("MAIN", "Recovery firmware mode (%s + POWER held at boot)", BoardConfig::isX4Pro() ? "DOWN" : "UP");
     }
   }
+#endif
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);


### PR DESCRIPTION
## Summary

Follow-up to #230 after its `Hardware CI` run exposed a native simulator compatibility failure.

The pinned simulator BoardConfig stub does not provide `BoardConfig::isPaperMono()`. Compile the Paper Mono recovery-chord exclusion with the existing `FREEINK_DEVICE_PAPERMONO` target macro instead. Runtime behavior is unchanged: Paper Mono still skips recovery-chord detection, while every other target retains the existing path.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/main/SCOPE.md) and [ROADMAP.md](../blob/main/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a build-compatibility correction for the Paper Mono recovery behavior merged in #230.
- [x] Recovery-path coordination is covered by the repository owner's Paper Mono hardware validation on #230.

## Verification

- `./bin/clang-format-fix -g`
- `git diff --check`
- `pio run -e simulator`
- `pio run -e papermono`
- Paper Mono matrix from #230 remains applicable because the same recovery path is excluded at compile time instead of by the previous runtime predicate.

Resource impact compared with #230:

- RAM: 82,068 bytes (unchanged)
- Flash: 6,075,622 bytes (-560 bytes)
- No new allocation, public API, or persistence-format change

---

### AI Usage

Did you use AI tools to help write this code? **YES**