### PR TITLE
fix: clear sleep image after splashless wake

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -662,6 +662,7 @@ void setup() {
                             : isSleepWake && !APP_STATE.showBootScreen ? BootResume::SplashlessWake
                                                                        : BootResume::Splash;
   bool allowFastInitialReaderRefresh = false;
+  bool needsWakeRefresh = false;
 
   const bool fontsReady = setupDisplayAndFonts(resume != BootResume::Splash,
                                                snapshotTarget == SilentRebootTarget::ReaderPreloadChineseFont);
@@ -695,6 +696,10 @@ void setup() {
           } else {
             renderer.displayBuffer(HalDisplay::HALF_REFRESH);
           }
+        } else {
+          // The panel still physically shows the sleep image, so clean the
+          // first Home paint without adding a separate refresh cycle.
+          needsWakeRefresh = true;
         }
         break;
       case BootResume::Splash:
@@ -731,6 +736,7 @@ void setup() {
              mappedInputManager.isPressed(MappedInputManager::Button::Back) || APP_STATE.readerActivityLoadCount > 0) {
     // Boot to home screen if no book is open, last sleep was not from reader, back button is held, or reader activity
     // crashed (indicated by readerActivityLoadCount > 0)
+    if (needsWakeRefresh) renderer.requestNextRefresh(HalDisplay::HALF_REFRESH);
     activityManager.goHome();
   } else {
     // Clear app state to avoid getting into a boot loop if the epub doesn't load


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Clear a retained sleep image that remains visible underneath the Home screen after a splashless wake without a saved Quick Resume frame.
* **What changes are included?**
  * Track when a splashless wake has no retained sleep frame.
  * Reuse CrossMux's existing one-shot refresh override so the first Home paint uses `HALF_REFRESH`.
  * Cover both RoundedRaff and INX Home routes without adding public API parameters.
  * Preserve Quick Resume, reader resume, cold boot, silent reboot, recovery, and OTA behavior.

This adapts [CrossPoint PR #3009](https://github.com/crosspoint-reader/crosspoint-reader/pull/3009) by Thiago Kenji Okada. CrossMux already has a renderer-level one-shot refresh override, so the upstream behavior is implemented in `src/main.cpp` only.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] CrossPoint upstream already handles this case; this PR brings that established wake behavior into CrossMux and extends it to the INX Home route.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

Automated verification:

- `./bin/clang-format-fix -g`
- `git diff --check`
- `pio run -e papermono`

Resource usage:

- RAM: 82,068 B
- Flash: 6,075,650 B
- No new allocation, public API, or persistence-format changes.

Paper Mono hardware verification is pending:

- Quick Resume disabled: wake to RoundedRaff and INX Home without a retained sleep-image ghost.
- Wake from the reader and preserve reader resume behavior.
- Quick Resume enabled: retain the saved-frame wake behavior.
- USB cold boot and normal boot splash remain unchanged.

---

### AI Usage

Did you use AI tools to help write this code? **YES**