### PR TITLE
fix: auto-connect AirPage live mode

### DIFF
--- a/src/activities/apps/airpage/AirPageActivity.cpp
+++ b/src/activities/apps/airpage/AirPageActivity.cpp
@@ -473,7 +473,7 @@ void AirPageActivity::applySettingsSelection() {
       const auto event = connection_.setRealtime(enabled);
       if (enabled) {
         applyConnectionEvent(event);
-        if (!connection_.wifiConnected()) openWifiSelection(false);
+        if (event == airpage::AirPageConnection::Event::WifiRequired) openWifiSelection(false);
       } else {
         clearConnectionNotice();
         requestUpdate();
@@ -557,6 +557,17 @@ void AirPageActivity::handleWallpaperResult(const ActivityResult& result) {
 
 void AirPageActivity::handleRefresh() {
   if (phase_ != Phase::Idle) return;
+  switch (connection_.state()) {
+    case airpage::AirPageConnection::State::WifiConnecting:
+    case airpage::AirPageConnection::State::BrokerConnecting:
+      return;
+    case airpage::AirPageConnection::State::Off:
+    case airpage::AirPageConnection::State::WifiOnline:
+    case airpage::AirPageConnection::State::Online:
+    case airpage::AirPageConnection::State::Backoff:
+    case airpage::AirPageConnection::State::Paused:
+      break;
+  }
   if (!connection_.wifiConnected()) {
     openWifiSelection(true);
     return;
@@ -841,15 +852,14 @@ const char* AirPageActivity::connectionText() const {
 const char* AirPageActivity::refreshActionText() const {
   switch (connection_.state()) {
     case airpage::AirPageConnection::State::Paused:
-      return connection_.wifiConnected() ? tr(STR_RETRY) : tr(STR_CONNECT);
     case airpage::AirPageConnection::State::Backoff:
       return tr(STR_RETRY);
     case airpage::AirPageConnection::State::Off:
       return connection_.wifiConnected() ? tr(STR_AIRPAGE_REFRESH) : tr(STR_CONNECT);
     case airpage::AirPageConnection::State::WifiConnecting:
-      return tr(STR_CONNECT);
-    case airpage::AirPageConnection::State::WifiOnline:
     case airpage::AirPageConnection::State::BrokerConnecting:
+      return tr(STR_CONNECTING);
+    case airpage::AirPageConnection::State::WifiOnline:
     case airpage::AirPageConnection::State::Online:
       return tr(STR_AIRPAGE_REFRESH);
   }

--- a/src/activities/apps/airpage/AirPageConnection.cpp
+++ b/src/activities/apps/airpage/AirPageConnection.cpp
@@ -56,8 +56,8 @@ AirPageConnection::Event AirPageConnection::begin(const bool realtime) {
     state_ = realtime_ ? State::BrokerConnecting : State::WifiOnline;
     return Event::StateChanged;
   }
-  state_ = State::Off;
-  return Event::WifiRequired;
+  if (!realtime_) return Event::None;
+  return startWifiAssociation() ? Event::StateChanged : Event::WifiRequired;
 }
 
 void AirPageConnection::stop() {
@@ -89,11 +89,16 @@ AirPageConnection::Event AirPageConnection::setRealtime(const bool enabled) {
   retryCount_ = 0;
 
   if (!realtime_) {
+    const bool wifiAssociationPending = state_ == State::WifiConnecting;
     disconnectBroker();
-    if (wifiConnected()) {
+    if (wifiAssociationPending) {
+      state_ = State::Off;
+      teardownWifi();
+    } else if (wifiConnected()) {
       state_ = State::WifiOnline;
     } else {
       state_ = State::Off;
+      teardownWifi();
     }
     return Event::StateChanged;
   }
@@ -104,7 +109,7 @@ AirPageConnection::Event AirPageConnection::setRealtime(const bool enabled) {
     state_ = State::BrokerConnecting;
     return Event::StateChanged;
   }
-  return pause(Event::WifiRequired);
+  return startWifiAssociation() ? Event::StateChanged : pause(Event::WifiRequired);
 }
 
 void AirPageConnection::prepareRefresh() {

--- a/test/airpage/AirPageConnectionTest.cpp
+++ b/test/airpage/AirPageConnectionTest.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+class GfxRenderer {};
+
+#include "AirPageConnection.h"
+#include "WifiCredentialStore.h"
+#include "esp_wifi.h"
+
+namespace airpage {
+
+const std::string& deviceId() {
+  static const std::string id = "test-device";
+  return id;
+}
+
+}  // namespace airpage
+
+namespace {
+
+void resetFakes() {
+  WiFi.reset();
+  WIFI_STORE.reset();
+  espWifiDeinitCalls = 0;
+}
+
+TEST(AirPageConnectionTest, ManualModeDoesNotStartWifiAssociation) {
+  resetFakes();
+  WIFI_STORE.setCredential("saved", "secret");
+  GfxRenderer renderer;
+  airpage::AirPageConnection connection(renderer);
+
+  EXPECT_EQ(connection.begin(false), airpage::AirPageConnection::Event::None);
+  EXPECT_EQ(connection.state(), airpage::AirPageConnection::State::Off);
+  EXPECT_EQ(WiFi.beginCalls, 0);
+}
+
+TEST(AirPageConnectionTest, LiveModeSilentlyUsesSavedCredential) {
+  resetFakes();
+  WIFI_STORE.setCredential("saved", "secret");
+  GfxRenderer renderer;
+  airpage::AirPageConnection connection(renderer);
+
+  EXPECT_EQ(connection.begin(true), airpage::AirPageConnection::Event::StateChanged);
+  EXPECT_EQ(connection.state(), airpage::AirPageConnection::State::WifiConnecting);
+  EXPECT_EQ(WiFi.beginCalls, 1);
+  EXPECT_EQ(WiFi.lastSsid, "saved");
+  EXPECT_EQ(WiFi.lastPassword, "secret");
+}
+
+TEST(AirPageConnectionTest, LiveModeRequestsWifiWithoutSavedCredential) {
+  resetFakes();
+  GfxRenderer renderer;
+  airpage::AirPageConnection connection(renderer);
+
+  EXPECT_EQ(connection.begin(true), airpage::AirPageConnection::Event::WifiRequired);
+  EXPECT_EQ(connection.state(), airpage::AirPageConnection::State::Off);
+  EXPECT_EQ(WiFi.beginCalls, 0);
+}
+
+TEST(AirPageConnectionTest, DisablingLiveModeStopsOwnedWifiAssociation) {
+  resetFakes();
+  WIFI_STORE.setCredential("saved", "secret");
+  GfxRenderer renderer;
+  airpage::AirPageConnection connection(renderer);
+  ASSERT_EQ(connection.begin(true), airpage::AirPageConnection::Event::StateChanged);
+  WiFi.statusValue = WL_CONNECTED;
+
+  EXPECT_EQ(connection.setRealtime(false), airpage::AirPageConnection::Event::StateChanged);
+  EXPECT_EQ(connection.state(), airpage::AirPageConnection::State::Off);
+  EXPECT_EQ(WiFi.modeValue, WIFI_OFF);
+  EXPECT_EQ(espWifiDeinitCalls, 1);
+}
+
+TEST(AirPageConnectionTest, EnablingLiveModeUsesSameSilentAssociationPath) {
+  resetFakes();
+  WIFI_STORE.setCredential("saved", "secret");
+  GfxRenderer renderer;
+  airpage::AirPageConnection connection(renderer);
+  ASSERT_EQ(connection.begin(false), airpage::AirPageConnection::Event::None);
+
+  EXPECT_EQ(connection.setRealtime(true), airpage::AirPageConnection::Event::StateChanged);
+  EXPECT_EQ(connection.state(), airpage::AirPageConnection::State::WifiConnecting);
+  EXPECT_EQ(WiFi.beginCalls, 1);
+}
+
+}  // namespace

--- a/test/airpage/CMakeLists.txt
+++ b/test/airpage/CMakeLists.txt
@@ -27,3 +27,20 @@ target_link_libraries(AirPageImageStoreTest PRIVATE
 )
 
 gtest_discover_tests(AirPageImageStoreTest PROPERTIES RUN_SERIAL TRUE)
+
+add_executable(AirPageConnectionTest
+  AirPageConnectionTest.cpp
+  ${REPO_ROOT}/src/activities/apps/airpage/AirPageConnection.cpp
+)
+
+target_include_directories(AirPageConnectionTest BEFORE PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+  ${REPO_ROOT}/src/activities/apps/airpage
+)
+
+target_link_libraries(AirPageConnectionTest PRIVATE
+  crosspoint_test_common
+  GTest::gtest_main
+)
+
+gtest_discover_tests(AirPageConnectionTest)

--- a/test/airpage/stubs/Arduino.h
+++ b/test/airpage/stubs/Arduino.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+
+inline uint32_t arduinoTestMillis = 0;
+
+inline unsigned long millis() { return arduinoTestMillis; }
+inline void delay(const unsigned long duration) { arduinoTestMillis += duration; }

--- a/test/airpage/stubs/HalGPIO.h
+++ b/test/airpage/stubs/HalGPIO.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class HalGPIO {
+ public:
+  bool deviceIsX3() const { return false; }
+};
+
+inline HalGPIO gpio;

--- a/test/airpage/stubs/NetworkStartup.h
+++ b/test/airpage/stubs/NetworkStartup.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <WiFi.h>
+
+class GfxRenderer;
+
+namespace NetworkStartup {
+
+inline void prepare(GfxRenderer&) {}
+inline bool setMode(GfxRenderer&, const wifi_mode_t mode) { return WiFi.mode(mode); }
+
+}  // namespace NetworkStartup

--- a/test/airpage/stubs/PubSubClient.h
+++ b/test/airpage/stubs/PubSubClient.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+class WiFiClient;
+
+class PubSubClient {
+ public:
+  explicit PubSubClient(WiFiClient&) {}
+
+  PubSubClient& setServer(const char*, uint16_t) { return *this; }
+  PubSubClient& setCallback(void (*)(char*, uint8_t*, unsigned int)) { return *this; }
+  PubSubClient& setSocketTimeout(uint16_t) { return *this; }
+  PubSubClient& setKeepAlive(uint16_t) { return *this; }
+  bool connect(const char*, const char*, uint8_t, bool, const char*) { return false; }
+  bool subscribe(const char*) { return false; }
+  bool publish(const char*, const char*, bool) { return false; }
+  bool connected() const { return false; }
+  void disconnect() {}
+  bool loop() { return false; }
+  int state() const { return -1; }
+};

--- a/test/airpage/stubs/WiFi.h
+++ b/test/airpage/stubs/WiFi.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <string>
+
+enum wl_status_t {
+  WL_IDLE_STATUS = 0,
+  WL_NO_SSID_AVAIL = 1,
+  WL_CONNECTED = 3,
+  WL_CONNECT_FAILED = 4,
+  WL_DISCONNECTED = 6,
+};
+
+using wifi_mode_t = int;
+constexpr wifi_mode_t WIFI_OFF = 0;
+constexpr wifi_mode_t WIFI_STA = 1;
+
+class WiFiClient {};
+
+class WiFiClass {
+ public:
+  wl_status_t status() const { return statusValue; }
+  bool persistent(bool) { return true; }
+  bool disconnect(bool = false, bool = false) {
+    ++disconnectCalls;
+    statusValue = WL_DISCONNECTED;
+    return true;
+  }
+  wl_status_t begin(const char* ssid) { return begin(ssid, ""); }
+  wl_status_t begin(const char* ssid, const char* password) {
+    ++beginCalls;
+    lastSsid = ssid;
+    lastPassword = password;
+    statusValue = WL_IDLE_STATUS;
+    return statusValue;
+  }
+  bool mode(const wifi_mode_t mode) {
+    modeValue = mode;
+    return true;
+  }
+  void reset() {
+    statusValue = WL_DISCONNECTED;
+    modeValue = WIFI_OFF;
+    beginCalls = 0;
+    disconnectCalls = 0;
+    lastSsid.clear();
+    lastPassword.clear();
+  }
+
+  wl_status_t statusValue = WL_DISCONNECTED;
+  wifi_mode_t modeValue = WIFI_OFF;
+  int beginCalls = 0;
+  int disconnectCalls = 0;
+  std::string lastSsid;
+  std::string lastPassword;
+};
+
+inline WiFiClass WiFi;

--- a/test/airpage/stubs/WifiCredentialStore.h
+++ b/test/airpage/stubs/WifiCredentialStore.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+
+struct WifiCredential {
+  std::string ssid;
+  std::string password;
+};
+
+class WifiCredentialStore {
+ public:
+  static WifiCredentialStore& getInstance() {
+    static WifiCredentialStore store;
+    return store;
+  }
+
+  size_t getCredentialCount() const { return credential_ ? 1 : 0; }
+  bool loadFromFile() { return true; }
+  std::string getLastConnectedSsid() const { return credential_ ? credential_->ssid : ""; }
+  std::optional<WifiCredential> findCredential(const std::string& ssid) const {
+    return credential_ && credential_->ssid == ssid ? credential_ : std::nullopt;
+  }
+  void setCredential(std::string ssid, std::string password) {
+    credential_ = WifiCredential{std::move(ssid), std::move(password)};
+  }
+  void reset() { credential_.reset(); }
+
+ private:
+  std::optional<WifiCredential> credential_;
+};
+
+#define WIFI_STORE WifiCredentialStore::getInstance()

--- a/test/airpage/stubs/esp_wifi.h
+++ b/test/airpage/stubs/esp_wifi.h
@@ -1,0 +1,8 @@
+#pragma once
+
+inline int espWifiDeinitCalls = 0;
+
+inline int esp_wifi_deinit() {
+  ++espWifiDeinitCalls;
+  return 0;
+}


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make AirPage live mode silently reconnect to the last saved Wi-Fi network while keeping the QR page visible, without changing manual mode or device button protocols.
* **What changes are included?**
  * Live mode now reuses the existing saved-credential association path on entry and when enabled from settings; Wi-Fi selection opens only when credentials are unavailable.
  * Manual mode remains offline when entered without an existing connection.
  * Repeated connect actions are ignored while Wi-Fi or MQTT is connecting, and the existing action labels now reflect Connect / Connecting / Refresh / Retry states.
  * Disabling live mode during an owned Wi-Fi association tears that association down, including the status-update race before the state machine observes it.
  * Adds five host regressions for manual entry, saved and missing credentials, disabling during association, and manual-to-live transition.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This is a focused correction to the existing AirPage connector. It adds no connector, public API, setting, cache format, translation key, dependency, or persistent allocation, and does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, recovery, or Waveshare Function-button handling. The saved-credential path also avoids allocating `WifiSelectionActivity` during normal live-mode entry.

## Additional Context

* `./bin/clang-format-fix --check` and `git diff --check`: passed.
* `pio check`: passed with no defects.
* Host tests: 412/412 passed, including the 5 new AirPage connection-state tests and existing Waveshare Function-button tests.
* Hardware builds passed: `default`, `x4pro`, `eego_a4`, and `waveshare_epaper_397`.
* Simulator builds passed: `simulator`, `simulator_x3`, `simulator_eego_a4`, and `simulator_murphy_m4`.
* Reported static RAM: default 55,612 B; x4pro 65,692 B; eego A4 64,708 B; Waveshare 3.97 65,404 B.
* Isolated-SD simulator smoke test verified that missing credentials open Wi-Fi selection and saved credentials keep AirPage on the QR page while connecting. The simulator MQTT endpoint was unavailable, so the online `Refresh` state and real-device heap stability remain to be verified on hardware.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
