### PR TITLE
feat: identify device model in HTTP user agent

### DIFF
--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -1,6 +1,7 @@
 #include "HttpDownloader.h"
 
 #include <Arduino.h>
+#include <HalSystem.h>
 #include <Logging.h>
 #include <Memory.h>
 #include <Stream.h>
@@ -8,6 +9,7 @@
 #include <esp_crt_bundle.h>
 #include <esp_http_client.h>
 
+#include <cstdio>
 #include <functional>
 #include <string>
 
@@ -32,6 +34,8 @@ constexpr int HTTP_TX_BUF = 512;
 constexpr int HTTP_TIMEOUT_MS = 60000;
 constexpr size_t READ_CHUNK = 1024;
 constexpr int MAX_REDIRECTS = 5;
+constexpr size_t DEVICE_MODEL_LENGTH_MAX = 32;
+constexpr size_t USER_AGENT_CAPACITY = sizeof("CrossMux--" CROSSPOINT_VERSION) + DEVICE_MODEL_LENGTH_MAX;
 
 struct Sink {
   std::function<bool(const uint8_t*, size_t)> write;  // returns false to abort the transfer
@@ -47,7 +51,7 @@ bool isRedirect(int status) {
 
 #if defined(FREEINK_NET_WOLFSSL)
 HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std::string& username,
-                                         const std::string& password, Sink& sink) {
+                                         const std::string& password, const char* userAgent, Sink& sink) {
   std::string url = startUrl;
 
   for (int hop = 0; hop <= MAX_REDIRECTS; ++hop) {
@@ -61,7 +65,7 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
     // setUserAgent replaces SecureHttpClient's built-in UA; addHeader would
     // append a second User-Agent header, which strict servers reject (aiohttp
     // answers 400 "Duplicate 'User-Agent' header found").
-    http.setUserAgent("CrossPoint-ESP32-" CROSSPOINT_VERSION);
+    http.setUserAgent(userAgent);
     if (!username.empty() && !password.empty()) {
       const std::string credentials = username + ":" + password;
       const String encoded = base64::encode(credentials.c_str());
@@ -116,7 +120,7 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
 // that ends early as ESP_ERR_HTTP_INCOMPLETE_DATA, whereas the read loop streams
 // large/slow files and surfaces a short read directly.
 HttpDownloader::DownloadError runGet(const std::string& url, const std::string& username, const std::string& password,
-                                     Sink& sink) {
+                                     const char* userAgent, Sink& sink) {
   esp_http_client_config_t config = {};
   config.url = url.c_str();
   config.buffer_size = HTTP_RX_BUF;
@@ -137,7 +141,7 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
     return HttpDownloader::HTTP_ERROR;
   }
 
-  esp_http_client_set_header(client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  esp_http_client_set_header(client, "User-Agent", userAgent);
   if (!username.empty() && !password.empty()) {
     // Preemptive Basic auth, like the prior addHeader; don't wait for a 401.
     const std::string credentials = username + ":" + password;
@@ -221,10 +225,17 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
 // WiFiClient inside runGetWolf, so this is safe for non-TLS targets too.
 HttpDownloader::DownloadError runGetSecure(const std::string& url, const std::string& username,
                                            const std::string& password, Sink& sink) {
+  char userAgent[USER_AGENT_CAPACITY];
+  const int userAgentLength =
+      snprintf(userAgent, sizeof(userAgent), "CrossMux-%s-" CROSSPOINT_VERSION, HalSystem::getDeviceModel());
+  if (userAgentLength < 0 || static_cast<size_t>(userAgentLength) >= sizeof(userAgent)) {
+    LOG_ERR("HTTP", "User-Agent exceeds %zu bytes", sizeof(userAgent));
+    return HttpDownloader::HTTP_ERROR;
+  }
 #if defined(FREEINK_NET_WOLFSSL)
-  return runGetWolf(url, username, password, sink);
+  return runGetWolf(url, username, password, userAgent, sink);
 #else
-  return runGet(url, username, password, sink);
+  return runGet(url, username, password, userAgent, sink);
 #endif
 }
 }  // namespace


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Identify the active device model in generic HTTP requests used by downloads, OTA, and OPDS.
* **What changes are included?**
  - change the generic User-Agent from `CrossPoint-ESP32-{version}` to `CrossMux-{deviceModel}-{version}`
  - reuse `HalSystem::getDeviceModel()` for both wolfSSL and ESP HTTP paths
  - format the value in a fixed stack buffer and fail the request if formatting is truncated
  - preserve the single-header `setUserAgent()` behavior and leave WeRead's browser User-Agent unchanged

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/main/SCOPE.md) and [ROADMAP.md](../blob/main/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this multi-device request identification requirement well.
- [x] The relevant maintainer requested and coordinated this HTTP/OTA behavior change.

## Testing

- [x] `git diff --check`
- [x] `./bin/clang-format-fix --check`
- [x] `pio run -e default`
- [x] `pio run -e x4pro`
- [x] Confirmed compiled strings contain the generic and x4pro User-Agent formats
- [ ] Capture X3/X4/S3 request headers on hardware and confirm exactly one `User-Agent`

## Additional Context

* No new heap allocation or public API is introduced; the User-Agent uses a fixed stack buffer.
* This complements #212, which identifies the device in OTA manifest query parameters; it does not duplicate that change.
* Draft pending hardware request-header verification.

---

### AI Usage

Did you use AI tools to help write this code? **YES**