### PR TITLE
fix: update simulator HAL for device model

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -221,7 +221,7 @@ extra_scripts =
   pre:scripts/gen_i18n.py
   pre:scripts/git_branch.py
 lib_deps =
-  simulator=https://github.com/0x1abin/crosspoint-simulator.git#6f743c4d6a956bbb69ae3544e98168537b12ea1f
+  simulator=https://github.com/0x1abin/crosspoint-simulator.git#acf04ec5acc973e677691df853a3b29c8a49f2fe
   FreeInkUI=symlink://freeink-sdk/libs/ui/FreeInkUI
   Icons=symlink://freeink-sdk/libs/assets/Icons
   bblanchon/ArduinoJson @ 7.4.2


### PR DESCRIPTION
## Summary

* **Goal:** Restore the native simulator builds broken after #234 added `HalSystem::getDeviceModel()` to shared HTTP code.
* **Change:** Pin the simulator dependency to `acf04ec5acc973e677691df853a3b29c8a49f2fe`, which mirrors that HAL API and tests every simulator device profile.

Prerequisite simulator PR: https://github.com/0x1abin/crosspoint-simulator/pull/2

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a maintenance fix for the repository's existing native simulator matrix; no firmware feature is added.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Testing

- [x] Simulator host compatibility self-test: X4, X3, X4 Pro, eego A4, Mofei M4
- [x] `pio run -e simulator -e simulator_x3 -e simulator_eego_a4 -e simulator_murphy_m4`
- [x] `git diff --check`
- [ ] GitHub Hardware CI full matrix

## Additional Context

* Fixes the simulator failures in Hardware CI #45; all hardware targets were already successful there.
* Dependency pin only. `HttpDownloader.cpp` and firmware behavior are unchanged.
* No new heap allocation or firmware memory/flash impact.
* Hardware request-header capture remains covered by the original UA change, not this compatibility fix.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
