### PR TITLE
fix: validate COSCLI before Nightly publication

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -142,6 +142,16 @@ jobs:
             cat ota-notes.md >> nightly-body.md
           fi
 
+      - name: Install COS CLI
+        run: |
+          curl -fsSL \
+            https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64 \
+            -o "$RUNNER_TEMP/coscli"
+          echo "7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91  $RUNNER_TEMP/coscli" \
+            | sha256sum --check -
+          sudo install -m 0755 "$RUNNER_TEMP/coscli" /usr/local/bin/coscli
+          coscli --version
+
       - name: Publish immutable GitHub build
         env:
           GH_TOKEN: ${{ github.token }}
@@ -153,14 +163,6 @@ jobs:
             --title "CrossMux Nightly ${GITHUB_SHA::7} #${GITHUB_RUN_NUMBER}" \
             --notes-file nightly-body.md \
             --prerelease
-
-      - name: Install COS CLI
-        run: |
-          curl -fsSL \
-            https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-linux-amd64 \
-            -o "$RUNNER_TEMP/coscli"
-          sudo install -m 0755 "$RUNNER_TEMP/coscli" /usr/local/bin/coscli
-          coscli --version
 
       - name: Configure COS
         env:

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -37,9 +37,11 @@ GitHub Release. Both variants and their manifests live in an immutable
 `assets.crossmux.cn`. Region chooses the storage provider; firmware language
 does not.
 
-COS publishing uses the version-pinned COSCLI binary. Required repository
-secrets are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and `COS_REGION`;
-`COS_SESSION_TOKEN` is optional. Gitee is not a firmware release destination.
+COS publishing uses a version-pinned, SHA-256-verified COSCLI binary. The
+workflow verifies release tooling before writing any immutable release. Required
+repository secrets are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and
+`COS_REGION`; `COS_SESSION_TOKEN` is optional. Gitee is not a firmware release
+destination.
 
 ## Index contract and failure behavior
 

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -52,6 +52,16 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertIn("find artifacts -type f -print", workflow)
         self.assertNotIn("find artifacts -path '*/global/*'", workflow)
 
+    def test_coscli_is_verified_before_publishing(self):
+        workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        self.assertIn('coscli-v1.0.8-linux-amd64', workflow)
+        self.assertIn(
+            '7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91', workflow
+        )
+        self.assertLess(
+            workflow.index('Install COS CLI'), workflow.index('Publish immutable GitHub build')
+        )
+
     def write_image(self, chip_id=0x0009, board='eego_a4'):
         image = bytearray(24)
         image[0] = 0xE9


### PR DESCRIPTION
## Summary
- use the official pinned COSCLI v1.0.8 Linux asset
- verify its published SHA-256 before installation
- validate COSCLI before creating the immutable GitHub Release
- lock the asset, checksum, and ordering in the existing Nightly test

## Validation
- python3 -m unittest scripts.tests.test_nightly_release
- parsed .github/workflows/nightly.yml with PyYAML
- git diff --check
- downloaded the official asset and verified SHA-256

## Release follow-up
After this PR merges, trigger a fresh Nightly workflow_dispatch. Do not rerun the failed workflow because it retains the old workflow definition.