### PR TITLE
fix: pass COS credentials to publish commands

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,6 @@ jobs:
     env:
       BUILD_ID: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
       BUILD_TAG: nightly-build-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
-      COS_ALIAS: crossmux-firmware
     steps:
       - uses: actions/checkout@v6
         with:
@@ -164,7 +163,7 @@ jobs:
             --notes-file nightly-body.md \
             --prerelease
 
-      - name: Configure COS
+      - name: Publish immutable COS objects
         env:
           COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
           COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
@@ -172,23 +171,18 @@ jobs:
           COS_BUCKET: ${{ secrets.COS_BUCKET }}
           COS_REGION: ${{ secrets.COS_REGION }}
         run: |
-          token_args=()
-          if [ -n "$COS_SESSION_TOKEN" ]; then
-            token_args=(--session-token "$COS_SESSION_TOKEN")
-          fi
-          coscli config add --init-skip --disable-log \
-            -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" "${token_args[@]}" \
-            -a "$COS_ALIAS" -b "$COS_BUCKET" -r "$COS_REGION"
-
-      - name: Publish immutable COS objects
-        run: |
           set -euo pipefail
+          cos_args=(--init-skip --disable-log -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
+            -e "cos.${COS_REGION}.myqcloud.com")
+          if [ -n "$COS_SESSION_TOKEN" ]; then
+            cos_args+=(--token "$COS_SESSION_TOKEN")
+          fi
           for artifact in artifacts/nightly-*; do
             target="${artifact##*/nightly-}"
             for flavor in global cn; do
               [ -d "$artifact/$flavor" ] || continue
-              coscli cp "$artifact/$flavor/" \
-                "cos://${COS_ALIAS}/firmware/builds/${BUILD_ID}/${target}/${flavor}/" \
+              coscli cp "${cos_args[@]}" "$artifact/$flavor/" \
+                "cos://${COS_BUCKET}/firmware/builds/${BUILD_ID}/${target}/${flavor}/" \
                 --recursive --forbid-overwrite \
                 --meta 'Cache-Control:public,max-age=31536000,immutable'
             done
@@ -197,9 +191,19 @@ jobs:
       - name: Publish rolling indexes last
         env:
           GH_TOKEN: ${{ github.token }}
+          COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+          COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+          COS_SESSION_TOKEN: ${{ secrets.COS_SESSION_TOKEN }}
+          COS_BUCKET: ${{ secrets.COS_BUCKET }}
+          COS_REGION: ${{ secrets.COS_REGION }}
         run: |
-          coscli cp release-index-cn.json \
-            "cos://${COS_ALIAS}/firmware/releases/nightly/index.json" \
+          cos_args=(--init-skip --disable-log -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
+            -e "cos.${COS_REGION}.myqcloud.com")
+          if [ -n "$COS_SESSION_TOKEN" ]; then
+            cos_args+=(--token "$COS_SESSION_TOKEN")
+          fi
+          coscli cp "${cos_args[@]}" release-index-cn.json \
+            "cos://${COS_BUCKET}/firmware/releases/nightly/index.json" \
             --meta 'Cache-Control:no-cache'
           if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit nightly --repo "$GITHUB_REPOSITORY" \

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -38,10 +38,11 @@ GitHub Release. Both variants and their manifests live in an immutable
 does not.
 
 COS publishing uses a version-pinned, SHA-256-verified COSCLI binary. The
-workflow verifies release tooling before writing any immutable release. Required
-repository secrets are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and
-`COS_REGION`; `COS_SESSION_TOKEN` is optional. Gitee is not a firmware release
-destination.
+workflow verifies release tooling before writing any immutable release and
+passes credentials directly to each COS command instead of persisting a CLI
+config file. Required repository secrets are `COS_SECRET_ID`, `COS_SECRET_KEY`,
+`COS_BUCKET`, and `COS_REGION`; `COS_SESSION_TOKEN` is optional. Gitee is not a
+firmware release destination.
 
 ## Index contract and failure behavior
 

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -61,6 +61,9 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertLess(
             workflow.index('Install COS CLI'), workflow.index('Publish immutable GitHub build')
         )
+        self.assertNotIn('coscli config add', workflow)
+        self.assertIn('cos://${COS_BUCKET}/firmware/builds/', workflow)
+        self.assertIn('cos_args+=(--token "$COS_SESSION_TOKEN")', workflow)
 
     def write_image(self, chip_id=0x0009, board='eego_a4'):
         image = bytearray(24)


### PR DESCRIPTION
## Summary
- remove the stateful COSCLI config step that persisted bucket data without credentials
- pass SecretId, SecretKey, optional token, endpoint, and full bucket name directly to each COS upload
- keep COS secrets scoped to COS-writing steps
- lock stateless authentication behavior in the existing Nightly test

## Root cause
COSCLI v1.0.8 config add stores bucket configuration, but the root -i/-k flags are process parameters and are not persisted. The following cp process therefore loaded a config without SecretId.

## Validation
- python3 -m unittest scripts.tests.test_nightly_release
- parsed .github/workflows/nightly.yml with PyYAML
- git diff --check

## Failed release safety
Run 33034563534 built all 7 targets successfully but failed on the first COS upload. The rolling global and China indexes were not updated.