### PR TITLE
ci: prefer idle H2O for firmware builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   UV_HTTP_RETRIES: 10
 
 jobs:
+  select_runner:
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
   clang-format:
     runs-on: ubuntu-latest
     steps:
@@ -73,7 +78,8 @@ jobs:
 
   build-default:
     name: Build X4 and X4 Pro
-    runs-on: ubuntu-latest
+    needs: select_runner
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,6 +99,7 @@ jobs:
         run: uv pip install --system -U pioarduino==6.1.19
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio/.cache
@@ -166,6 +173,7 @@ jobs:
       - build-default
       - clang-format
       - cppcheck
+      - select_runner
       - unit-tests
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/hardware-ci.yml
+++ b/.github/workflows/hardware-ci.yml
@@ -71,9 +71,15 @@ env:
   UV_HTTP_RETRIES: 10
 
 jobs:
+  select_runner:
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
   build:
     name: Build simulators and S3 hardware
-    runs-on: ubuntu-latest
+    needs: select_runner
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,6 +90,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install simulator build tools
+        if: runner.environment == 'github-hosted'
         run: |
           sudo apt-get update
           sudo apt-get install -y libsdl2-dev libssl-dev
@@ -98,6 +105,7 @@ jobs:
         run: uv pip install --system -U pioarduino==6.1.19
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio/.cache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,11 @@ permissions:
   contents: read
 
 jobs:
+  select_runner:
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -28,12 +33,12 @@ jobs:
         run: echo "matrix=$(python3 scripts/package_nightly_target.py --matrix)" >> "$GITHUB_OUTPUT"
 
   build:
-    needs: prepare
+    needs: [prepare, select_runner]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     name: ${{ matrix.targetId }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  select_runner:
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
   build-release:
-    runs-on: ubuntu-latest
+    needs: select_runner
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,6 +35,7 @@ jobs:
         run: uv pip install --system -U pioarduino==6.1.19
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio/.cache

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,9 +4,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-release-candidate:
+  select_runner:
     if: startsWith(github.ref_name, 'release/')
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
+  build-release-candidate:
+    needs: select_runner
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -26,6 +32,7 @@ jobs:
         run: uv pip install --system -U pioarduino==6.1.19
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio/.cache

--- a/.github/workflows/select-build-runner.yml
+++ b/.github/workflows/select-build-runner.yml
@@ -1,0 +1,57 @@
+name: Select build runner
+
+on:
+  workflow_call:
+    secrets:
+      runner_status_token:
+        required: false
+    outputs:
+      runs-on:
+        description: JSON runner labels for fromJSON()
+        value: ${{ jobs.select.outputs.runner }}
+      reason:
+        description: Human-readable selection reason
+        value: ${{ jobs.select.outputs.reason }}
+
+permissions:
+  contents: read
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.choose.outputs.runner }}
+      reason: ${{ steps.choose.outputs.reason }}
+    steps:
+      - id: choose
+        name: Prefer idle H2O for trusted builds
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.runner_status_token }}
+          TRUSTED_SOURCE: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          runner='"ubuntu-latest"'
+
+          if [[ "$TRUSTED_SOURCE" != "true" ]]; then
+            reason="untrusted pull request"
+          elif [[ -z "$GH_TOKEN" ]]; then
+            reason="runner status token unavailable"
+          elif h2o_name="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runners" \
+              --jq '.runners[] | select(.name == "H2O" and .status == "online" and .busy == false and ([.labels[].name] | index("h2o") != null)) | .name' \
+              2>/dev/null
+          )"; then
+            if [[ -n "$h2o_name" ]]; then
+              runner='["self-hosted","Linux","X64","h2o"]'
+              reason="H2O is online and idle"
+            else
+              reason="H2O is offline or busy"
+            fi
+          else
+            reason="runner status API unavailable"
+          fi
+
+          echo "runner=$runner" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "### Build runner selection" >> "$GITHUB_STEP_SUMMARY"
+          echo "- $reason" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-build.yml
+++ b/.github/workflows/sync-build.yml
@@ -25,12 +25,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  select_runner:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/chore/sync-upstream') ||
       (github.event_name == 'pull_request' && github.head_ref == 'chore/sync-upstream')
+    uses: ./.github/workflows/select-build-runner.yml
+    secrets:
+      runner_status_token: ${{ secrets.H2O_RUNNER_TOKEN }}
+
+  build:
+    needs: select_runner
+    runs-on: ${{ fromJSON(needs.select_runner.outputs['runs-on']) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,6 +56,7 @@ jobs:
         run: uv pip install --system -U pioarduino==6.1.19
 
       - name: Cache PlatformIO packages
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.platformio/.cache

--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -166,6 +166,16 @@ pio run -t upload && pio device monitor
 - Format check fails → Run clang-format locally
 - Build check fails → Fix compile errors
 
+Firmware build jobs call `select-build-runner.yml` before they start. Trusted
+same-repository PRs, pushes, tags, schedules, and manual runs use the H2O
+self-hosted runner only when it is online and idle; fork PRs, Dependabot, a
+missing `H2O_RUNNER_TOKEN`, API errors, and an unavailable H2O fall back to
+`ubuntu-latest`. The token must be repository-scoped with read-only
+Administration permission. Selection is best effort: a runner that disconnects
+after selection can still leave the selected job queued. Formatting, static
+analysis, unit tests, and all publishing jobs remain GitHub-hosted so persistent
+runner jobs never receive release credentials.
+
 ---
 
 ## Serial Monitoring and Live Debugging


### PR DESCRIPTION
## Summary
- select the H2O self-hosted runner only for trusted builds when it is online and idle
- fall back to ubuntu-latest for fork PRs, busy or offline H2O, missing credentials, and API errors
- keep formatting, static analysis, unit tests, and publishing on GitHub-hosted runners

## Test plan
- validate four runner-status fixtures and all workflow YAML
- validate selector shell syntax and runner wiring for six build workflows
- run python3 -m unittest discover -v -s scripts/tests
- run git diff --check

## Operational notes
- selection is best effort; concurrent selectors can race for the single H2O slot
- Nightly and Release publishing are not triggered by this PR