### PR TITLE
fix: expose COS upload failures in Nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -186,10 +186,15 @@ jobs:
             target="${artifact##*/nightly-}"
             for flavor in global cn; do
               [ -d "$artifact/$flavor" ] || continue
-              coscli cp "${cos_args[@]}" "$artifact/$flavor/" \
+              if ! coscli cp "${cos_args[@]}" "$artifact/$flavor/" \
                 "cos://${COS_BUCKET}/firmware/builds/${BUILD_ID}/${target}/${flavor}/" \
                 --recursive --forbid-overwrite \
-                --meta 'Cache-Control:public,max-age=31536000,immutable'
+                --meta 'Cache-Control:public,max-age=31536000,immutable' \
+                --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
+                find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
+                  2>/dev/null || true
+                exit 1
+              fi
             done
           done
 
@@ -207,9 +212,14 @@ jobs:
           if [ -n "$COS_SESSION_TOKEN" ]; then
             cos_args+=(--token "$COS_SESSION_TOKEN")
           fi
-          coscli cp "${cos_args[@]}" release-index-cn.json \
+          if ! coscli cp "${cos_args[@]}" release-index-cn.json \
             "cos://${COS_BUCKET}/firmware/releases/nightly/index.json" \
-            --meta 'Cache-Control:no-cache'
+            --meta 'Cache-Control:no-cache' \
+            --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
+            find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
+              2>/dev/null || true
+            exit 1
+          fi
           if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit nightly --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" --title "CrossMux Nightly (${GITHUB_SHA::7})" \

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -64,6 +64,8 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertNotIn('coscli config add', workflow)
         self.assertIn('cos://${COS_BUCKET}/firmware/builds/', workflow)
         self.assertIn('cos_args+=(--token "$COS_SESSION_TOKEN")', workflow)
+        self.assertIn('--fail-output-path "$RUNNER_TEMP/coscli-errors"', workflow)
+        self.assertIn('-name error.report -exec cat {} +', workflow)
 
     def write_image(self, chip_id=0x0009, board='eego_a4'):
         image = bytearray(24)


### PR DESCRIPTION
## Summary

- persist COSCLI transfer failures under the runner temporary directory
- print `error.report` before stopping immutable uploads or rolling-index publication
- keep credentials out of the emitted report

## Local verification

- `python3 -m unittest scripts.tests.test_nightly_release`
- workflow YAML parse
- Bash syntax checks for both COS publication steps
- `git diff --check origin/main...HEAD`
- official COSCLI v1.0.8 ARM64 SHA/version verification
- real COSCLI against a local 403 COS-style response: report included `AccessDenied`, message, and request ID; dummy credentials were absent

## Boundary

This makes the next Tencent failure actionable; it does not guess at IAM, bucket, or region changes. Do not merge automatically. A real Nightly run is still required after merge to validate GitHub runner credentials and Tencent COS access.