### PR TITLE
ci: publish China Nightly from H2O

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  publish:
+  publish_github:
     if: always() && needs.prepare.result == 'success'
     needs: [prepare, build]
     runs-on: ubuntu-latest
@@ -101,17 +101,15 @@ jobs:
       - name: Require at least one complete target pair
         run: test -n "$(find artifacts -name '*-global-manifest.json' -print -quit)"
 
-      - name: Load previous indexes
+      - name: Load previous global index
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p previous/global
           gh release download nightly --repo "$GITHUB_REPOSITORY" \
             --pattern release-index.json --dir previous/global || true
-          curl -fsSL https://assets.crossmux.cn/firmware/releases/nightly/index.json \
-            -o previous/cn.json || true
 
-      - name: Build regional indexes
+      - name: Build global index
         run: |
           updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python3 scripts/build_nightly_index.py \
@@ -122,14 +120,6 @@ jobs:
             --updated-at "$updated_at" \
             --build-id "$BUILD_ID" \
             --output release-index.json
-          python3 scripts/build_nightly_index.py \
-            --manifests artifacts \
-            --previous previous/cn.json \
-            --region cn \
-            --base-url "https://assets.crossmux.cn/firmware/builds/${BUILD_ID}/" \
-            --updated-at "$updated_at" \
-            --build-id "$BUILD_ID" \
-            --output release-index-cn.json
 
       - name: Build release notes
         env:
@@ -146,16 +136,6 @@ jobs:
             cat ota-notes.md >> nightly-body.md
           fi
 
-      - name: Install COS CLI
-        run: |
-          curl -fsSL \
-            https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64 \
-            -o "$RUNNER_TEMP/coscli"
-          echo "7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91  $RUNNER_TEMP/coscli" \
-            | sha256sum --check -
-          sudo install -m 0755 "$RUNNER_TEMP/coscli" /usr/local/bin/coscli
-          coscli --version
-
       - name: Publish immutable GitHub build
         env:
           GH_TOKEN: ${{ github.token }}
@@ -167,6 +147,75 @@ jobs:
             --title "CrossMux Nightly ${GITHUB_SHA::7} #${GITHUB_RUN_NUMBER}" \
             --notes-file nightly-body.md \
             --prerelease
+
+      - name: Publish rolling global index last
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit nightly --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" --title "CrossMux Nightly (${GITHUB_SHA::7})" \
+              --notes-file nightly-body.md --prerelease
+          else
+            gh release create nightly --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" \
+              --title "CrossMux Nightly (${GITHUB_SHA::7})" --notes-file nightly-body.md --prerelease
+          fi
+          gh release upload nightly release-index.json --repo "$GITHUB_REPOSITORY" --clobber
+
+          c3_artifact=artifacts/nightly-xteink_x4
+          if [ -d "$c3_artifact" ]; then
+            cp "$c3_artifact/global/xteink-global-firmware.bin" firmware.bin
+            cp "$c3_artifact/cn/xteink-cn-firmware.bin" firmware-cn.bin
+            gh release upload nightly firmware.bin firmware-cn.bin --repo "$GITHUB_REPOSITORY" --clobber
+          fi
+
+  publish_cn:
+    if: always() && needs.prepare.result == 'success'
+    needs: [prepare, build]
+    runs-on: [self-hosted, Linux, X64, h2o]
+    permissions:
+      contents: read
+    env:
+      BUILD_ID: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-*
+          path: artifacts
+
+      - name: Require at least one complete target pair
+        run: test -n "$(find artifacts -name '*-global-manifest.json' -print -quit)"
+
+      - name: Load previous China index
+        run: |
+          mkdir -p previous
+          curl -fsSL https://assets.crossmux.cn/firmware/releases/nightly/index.json \
+            -o previous/cn.json || true
+
+      - name: Build China index
+        run: |
+          python3 scripts/build_nightly_index.py \
+            --manifests artifacts \
+            --previous previous/cn.json \
+            --region cn \
+            --base-url "https://assets.crossmux.cn/firmware/builds/${BUILD_ID}/" \
+            --updated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --build-id "$BUILD_ID" \
+            --output release-index-cn.json
+
+      - name: Install COS CLI
+        run: |
+          curl -fsSL \
+            https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64 \
+            -o "$RUNNER_TEMP/coscli"
+          echo "7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91  $RUNNER_TEMP/coscli" \
+            | sha256sum --check -
+          chmod 0755 "$RUNNER_TEMP/coscli"
+          "$RUNNER_TEMP/coscli" --version
 
       - name: Publish immutable COS objects
         env:
@@ -186,7 +235,7 @@ jobs:
             target="${artifact##*/nightly-}"
             for flavor in global cn; do
               [ -d "$artifact/$flavor" ] || continue
-              if ! coscli cp "${cos_args[@]}" "$artifact/$flavor/" \
+              if ! "$RUNNER_TEMP/coscli" cp "${cos_args[@]}" "$artifact/$flavor/" \
                 "cos://${COS_BUCKET}/firmware/builds/${BUILD_ID}/${target}/${flavor}/" \
                 --recursive --forbid-overwrite \
                 --meta 'Cache-Control:public,max-age=31536000,immutable' \
@@ -198,41 +247,25 @@ jobs:
             done
           done
 
-      - name: Publish rolling indexes last
+      - name: Publish rolling China index last
         env:
-          GH_TOKEN: ${{ github.token }}
           COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
           COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
           COS_SESSION_TOKEN: ${{ secrets.COS_SESSION_TOKEN }}
           COS_BUCKET: ${{ secrets.COS_BUCKET }}
           COS_REGION: ${{ secrets.COS_REGION }}
         run: |
+          set -euo pipefail
           cos_args=(--init-skip --disable-log -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
             -e "cos.${COS_REGION}.myqcloud.com")
           if [ -n "$COS_SESSION_TOKEN" ]; then
             cos_args+=(--token "$COS_SESSION_TOKEN")
           fi
-          if ! coscli cp "${cos_args[@]}" release-index-cn.json \
+          if ! "$RUNNER_TEMP/coscli" cp "${cos_args[@]}" release-index-cn.json \
             "cos://${COS_BUCKET}/firmware/releases/nightly/index.json" \
             --meta 'Cache-Control:no-cache' \
             --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
             find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
               2>/dev/null || true
             exit 1
-          fi
-          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit nightly --repo "$GITHUB_REPOSITORY" \
-              --target "$GITHUB_SHA" --title "CrossMux Nightly (${GITHUB_SHA::7})" \
-              --notes-file nightly-body.md --prerelease
-          else
-            gh release create nightly --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" \
-              --title "CrossMux Nightly (${GITHUB_SHA::7})" --notes-file nightly-body.md --prerelease
-          fi
-          gh release upload nightly release-index.json --repo "$GITHUB_REPOSITORY" --clobber
-
-          c3_artifact=artifacts/nightly-xteink_x4
-          if [ -d "$c3_artifact" ]; then
-            cp "$c3_artifact/global/xteink-global-firmware.bin" firmware.bin
-            cp "$c3_artifact/cn/xteink-cn-firmware.bin" firmware-cn.bin
-            gh release upload nightly firmware.bin firmware-cn.bin --repo "$GITHUB_REPOSITORY" --clobber
           fi

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -23,7 +23,7 @@ Each target job builds and verifies both variants. Packaging checks the ESP
 image chip ID, required board tag, partition layout, app-slot size, and SHA-256
 before emitting an immutable target manifest.
 
-The publish job writes in this order:
+The global and China publish jobs run independently. Each writes in this order:
 
 1. immutable binaries and checksum files;
 2. immutable target manifests;
@@ -37,12 +37,13 @@ GitHub Release. Both variants and their manifests live in an immutable
 `assets.crossmux.cn`. Region chooses the storage provider; firmware language
 does not.
 
-COS publishing uses a version-pinned, SHA-256-verified COSCLI binary. The
-workflow verifies release tooling before writing any immutable release and
-passes credentials directly to each COS command instead of persisting a CLI
-config file. Required repository secrets are `COS_SECRET_ID`, `COS_SECRET_KEY`,
-`COS_BUCKET`, and `COS_REGION`; `COS_SESSION_TOKEN` is optional. Gitee is not a
-firmware release destination.
+COS publishing runs only on the H2O self-hosted runner and does not fall back to
+a GitHub-hosted runner. It uses a version-pinned, SHA-256-verified COSCLI binary
+from the runner's temporary directory. The workflow verifies COSCLI before
+writing any immutable COS object and passes credentials directly to each COS
+command instead of persisting a CLI config file. Required repository secrets
+are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and `COS_REGION`;
+`COS_SESSION_TOKEN` is optional. Gitee is not a firmware release destination.
 
 ## Index contract and failure behavior
 

--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -173,8 +173,11 @@ missing `H2O_RUNNER_TOKEN`, API errors, and an unavailable H2O fall back to
 `ubuntu-latest`. The token must be repository-scoped with read-only
 Administration permission. Selection is best effort: a runner that disconnects
 after selection can still leave the selected job queued. Formatting, static
-analysis, unit tests, and all publishing jobs remain GitHub-hosted so persistent
-runner jobs never receive release credentials.
+analysis, unit tests, and GitHub publishing remain GitHub-hosted. Nightly COS
+publishing is the exception: it requires the H2O labels with no fallback, has
+read-only repository contents, and receives COS credentials but no GitHub write
+credential. If H2O is unavailable, that regional job waits while the independent
+GitHub publish job can continue.
 
 ---
 

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -52,16 +52,34 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertIn("find artifacts -type f -print", workflow)
         self.assertNotIn("find artifacts -path '*/global/*'", workflow)
 
+    def test_publish_jobs_keep_credentials_scoped(self):
+        workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        github_job, china_job = workflow.split('  publish_cn:\n')
+        github_job = github_job.split('  publish_github:\n')[1]
+        self.assertIn('runs-on: ubuntu-latest', github_job)
+        self.assertNotIn('COS_SECRET_', github_job)
+        self.assertIn('runs-on: [self-hosted, Linux, X64, h2o]', china_job)
+        self.assertIn('persist-credentials: false', china_job)
+        self.assertNotIn("select_runner.outputs['runs-on']", china_job)
+        self.assertNotIn('GH_TOKEN:', china_job)
+
     def test_coscli_is_verified_before_publishing(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        china_job = workflow.split('  publish_cn:\n')[1]
         self.assertIn('coscli-v1.0.8-linux-amd64', workflow)
         self.assertIn(
             '7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91', workflow
         )
         self.assertLess(
-            workflow.index('Install COS CLI'), workflow.index('Publish immutable GitHub build')
+            china_job.index('Install COS CLI'), china_job.index('Publish immutable COS objects')
+        )
+        self.assertLess(
+            china_job.index('Publish immutable COS objects'),
+            china_job.index('Publish rolling China index last'),
         )
         self.assertNotIn('coscli config add', workflow)
+        self.assertNotIn('/usr/local/bin/coscli', china_job)
+        self.assertIn('"$RUNNER_TEMP/coscli" cp', china_job)
         self.assertIn('cos://${COS_BUCKET}/firmware/builds/', workflow)
         self.assertIn('cos_args+=(--token "$COS_SESSION_TOKEN")', workflow)
         self.assertIn('--fail-output-path "$RUNNER_TEMP/coscli-errors"', workflow)


### PR DESCRIPTION
## Summary
- Split GitHub and China COS publishing into independent Nightly jobs.
- Pin China publishing to the H2O runner with no fallback.
- Keep GitHub write access on the GitHub-hosted job; H2O receives read-only repository access and COS credentials only for upload steps.
- Download and verify COSCLI in the runner temporary directory.

## Validation
- `python3 scripts/tests/test_nightly_release.py` (10 tests)
- Nightly workflow YAML parsed successfully
- All 17 workflow shell blocks passed `bash -n`
- `git diff --check`

## Rollout
- Keep this PR in draft for review.
- After merge, manually run Nightly from `main` with release notes and compare COS upload throughput against the previous roughly 35 KB/s baseline.