### PR TITLE
fix: shorten Waveshare PMIC hard-off hold

### DIFF
--- a/docs/engineering/waveshare-epaper-397.md
+++ b/docs/engineering/waveshare-epaper-397.md
@@ -31,7 +31,7 @@ Power action and hold-to-sleep behavior. Hold it for about one second to power
 on; the boot gesture is ignored until its first release, so it may remain held
 until the first screen is visible. A new runtime hold uses the existing 400 ms
 software shutdown threshold (about 10 ms when short Power is set to Sleep),
-while a continuous 10-second hold remains the PMIC hard-power-off fallback.
+while a continuous 4-second hold remains the PMIC hard-power-off fallback.
 Audio, QMI8658, and SHTC3 are deliberately not initialized by this target.
 
 GPIO4/GPIO6 short presses emit Left/Right on release. Holding either key for

--- a/lib/hal/Waveshare397Power.cpp
+++ b/lib/hal/Waveshare397Power.cpp
@@ -51,7 +51,7 @@ enum class Register : uint8_t {
 constexpr uint8_t CHIP_ID = 0x4A;
 constexpr uint8_t ALDO_AUDIO = 0x03;
 constexpr uint8_t ALDO_DISPLAY = 0x04;
-constexpr uint8_t PKEY_TIMING_1S_ON_10S_OFF = 0x0E;
+constexpr uint8_t PKEY_TIMING_1S_ON_4S_OFF = 0x02;
 constexpr uint8_t PKEY_IRQ_MASK = 0x0F;
 constexpr uint8_t PKEY_EDGE_IRQS = PowerKeyState::PRESS_IRQ | PowerKeyState::RELEASE_IRQ;
 bool ready = false;
@@ -81,7 +81,7 @@ bool updateBits(Register reg, uint8_t mask, uint8_t value) {
 
 bool configure() {
   return updateBits(Register::VbusVoltage, 0x0F, 0x06) && updateBits(Register::VbusCurrent, 0x07, 0x04) &&
-         updateBits(Register::Voff, 0x07, 0x00) && updateBits(Register::Key, 0x0F, PKEY_TIMING_1S_ON_10S_OFF) &&
+         updateBits(Register::Voff, 0x07, 0x00) && updateBits(Register::Key, 0x0F, PKEY_TIMING_1S_ON_4S_OFF) &&
          updateBits(Register::Precharge, 0x03, 0x02) && updateBits(Register::ChargeCurrent, 0x1F, 0x08) &&
          updateBits(Register::Termination, 0x0F, 0x01) && updateBits(Register::TargetVoltage, 0x07, 0x03) &&
          updateBits(Register::Backup, 0x07, 0x04) && updateBits(Register::LowBattery, 0xFF, 0x55) &&


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Shorten the AXP2101 hard-power-off fallback on Waveshare ESP32-S3 ePaper 3.97 from 10 seconds to 4 seconds, so a device accidentally left in ROM download mode can be recovered with a shorter hold.
* **What changes are included?** Configure register `0x27` for the official 1-second power-on / 4-second hard-off timing and update the board documentation. The existing runtime 400 ms software sleep threshold and power-key interrupt handling are unchanged.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

* This improves recovery time but does not mask the separate GPIO0/BOOT hardware condition that can select ROM download mode during reset sampling.
* No settings, UI, public API, dependencies, or memory allocations are added.
* Verification:
  * `pio run -e waveshare_epaper_397`
  * `WaveshareFunctionButtonTest`: 14 tests passed
  * Hardware verified on battery power: the 4-second hard-off fallback recovers from ROM download mode and the following approximately 1-second power-on starts normally.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
