### PR TITLE
feat: emphasize Chinese settings categories

### DIFF
--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -280,8 +280,8 @@ repository.
 
 ## Known limitations
 
-- **No bold/italic CJK glyphs**: the bitmaps come from a single NotoSansSC-Regular subset. UI elements that pass `EpdFontFamily::Style::Bold` render the regular weight under CN.
-- **Offline reader fallback is 12pt only**: install an SD `.cpfont` family for other reading sizes and styles.
+- **No bold/italic CJK glyphs**: the bitmaps come from a single NotoSansSC-Regular subset. The Settings page gives its four top-level Chinese category labels a fixed one-pixel synthetic bold; other UI elements that pass `EpdFontFamily::Style::Bold` render the regular weight under CN.
+- **Offline reader fallback is 12pt only**: install an SD `.cpfont` family for other reading sizes and styles. The INX Settings categories also remain at the theme-defined 12pt because the unified firmware has no resident 16pt CJK UI face.
 - **Rare characters render as □ in reader at SMALL until an SD font is installed**: the 12pt bitmap uses the complete 3500-char pool plus required glyphs. It omits classical/scientific rarities, Traditional Chinese variants, and uncommon names outside that set; for example, `璟` is intentionally absent. The reader offers the complete-font downloader on the first detected missing glyph.
 - **No Traditional Chinese UI locale**: only `ZH_CN` is present; broader CJK book coverage depends on the selected SD font.
 

--- a/src/activities/UiTabListActivity.cpp
+++ b/src/activities/UiTabListActivity.cpp
@@ -103,7 +103,7 @@ void UiTabListActivity::syncTabListViewport(UiScreen& screen, fui::ListProps& pr
   props.selectedIndex = static_cast<int16_t>(n.selected - 1);  // -1 = tab band focused
 }
 
-void UiTabListActivity::buildTabBar(UiScreen& screen) {
+void UiTabListActivity::buildTabBar(UiScreen& screen, const bool boldLabels) {
   const auto& metrics = UITheme::getInstance().getMetrics();
 
   // Tabs. The selected pill dims to a dither when the selection is down in
@@ -162,6 +162,7 @@ void UiTabListActivity::buildTabBar(UiScreen& screen) {
     tabProps.tabInset = tabsFocused ? fui::Insets{2, 0, 4, 0} : fui::Insets{2, 0, 0, 0};
     tabProps.contentInset = fui::Insets{2, 8, 2, 8};
   }
+  if (boldLabels) tabProps.text.bold = true;
   const int16_t tabLineHeight = screen.target().lineHeight(tabProps.text.font);
   const int16_t tabBand =
       static_cast<int16_t>(metrics.tabBarHeight > tabLineHeight + 10 ? metrics.tabBarHeight : tabLineHeight + 10);

--- a/src/activities/UiTabListActivity.h
+++ b/src/activities/UiTabListActivity.h
@@ -56,7 +56,7 @@ class UiTabListActivity : public UiListActivity {
   // --- screen helpers --------------------------------------------------------
   // The shared tab band: theme-driven pill treatment (label-hugging Lyra vs
   // full-slot RoundedRaff), Lyra focused band wash, always-on divider.
-  void buildTabBar(UiScreen& screen);
+  void buildTabBar(UiScreen& screen, bool boldLabels = false);
   // Ring-aware counterpart of syncListViewport: measures rows, applies the
   // one-shot follow to the remembered row, clamps, and writes
   // props.selectedIndex = ring - 1. hasSubtitle: see syncListViewport().

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -863,6 +863,7 @@ std::string SettingsActivity::settingValueText(const SettingInfo& setting) {
 
 void SettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
+  const bool boldChineseCategories = I18N.getLanguage() == Language::ZH_CN;
   // Content below the GUI.drawHeader band, above the button hints.
   screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
                                       static_cast<int16_t>(metrics.buttonHintsHeight), 0});
@@ -884,11 +885,23 @@ void SettingsActivity::buildScreen(UiScreen& screen) {
     props.valueText = screen.theme().bodyText;
     syncListViewport(screen, props);
     if (!showMainTabContentSelection()) props.selectedIndex = -1;
+    if (boldChineseCategories) {
+      props.labelText.bold = false;
+      props.valueText.bold = false;
+    }
+    GfxRenderer::SyntheticBoldScope syntheticBold(renderer, boldChineseCategories
+                                                                ? CrossPointSettings::SYNTHETIC_BOLD_STANDARD
+                                                                : CrossPointSettings::SYNTHETIC_BOLD_OFF);
     screen.list(props);
     return;
   }
 
-  buildTabBar(screen);
+  {
+    GfxRenderer::SyntheticBoldScope syntheticBold(renderer, boldChineseCategories
+                                                                ? CrossPointSettings::SYNTHETIC_BOLD_STANDARD
+                                                                : CrossPointSettings::SYNTHETIC_BOLD_OFF);
+    buildTabBar(screen, boldChineseCategories);
+  }
 
   // rowItems_ (label/actionValue) was built by rebuildRowItems() when the
   // category was last selected/rebuilt; only the live value text needs


### PR DESCRIPTION
## Summary
- apply fixed one-pixel synthetic bold only to the four top-level Chinese Settings categories
- preserve child labels, values, headers, hints, English UI, and reader fake-bold preferences
- remove the obsolete INX 16pt font rebinding after the unified-font main change

## Validation
- `pio run -e simulator`
- `pio run -e gh_release`
- `./bin/clang-format-fix -g`
- `git diff --check`

## Notes
- latest main uses one unified firmware and no longer defines a `gh_release_cn` environment
- INX category text remains at the theme-defined 12pt because unified firmware has no resident 16pt CJK UI face