### PR TITLE
ci: unify and harden Nightly firmware publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,15 +62,12 @@ jobs:
       - name: Build unified target
         run: pio run -e "${{ matrix.environment }}"
 
-      - name: Package and verify target pair
+      - name: Package and verify unified target
         run: |
           set -euo pipefail
-          python3 scripts/package_nightly_target.py "${{ matrix.targetId }}" --flavor global \
-            --output "dist/${{ matrix.targetId }}/global"
-          python3 scripts/package_nightly_target.py "${{ matrix.targetId }}" --flavor zh-CN \
-            --output "dist/${{ matrix.targetId }}/cn"
-          (cd "dist/${{ matrix.targetId }}/global" && sha256sum --check *-SHA256SUMS)
-          (cd "dist/${{ matrix.targetId }}/cn" && sha256sum --check *-SHA256SUMS)
+          python3 scripts/package_nightly_target.py "${{ matrix.targetId }}" \
+            --output "dist/${{ matrix.targetId }}"
+          (cd "dist/${{ matrix.targetId }}" && sha256sum --check *-SHA256SUMS)
 
       - uses: actions/upload-artifact@v4
         with:
@@ -164,9 +161,12 @@ jobs:
 
           c3_artifact=artifacts/nightly-xteink_x4
           if [ -d "$c3_artifact" ]; then
-            cp "$c3_artifact/global/xteink-global-firmware.bin" firmware.bin
-            cp "$c3_artifact/cn/xteink-cn-firmware.bin" firmware-cn.bin
-            gh release upload nightly firmware.bin firmware-cn.bin --repo "$GITHUB_REPOSITORY" --clobber
+            cp "$c3_artifact/xteink-firmware.bin" firmware.bin
+            gh release upload nightly firmware.bin --repo "$GITHUB_REPOSITORY" --clobber
+            if gh release view nightly --repo "$GITHUB_REPOSITORY" --json assets \
+              --jq '.assets[].name' | grep -Fxq firmware-cn.bin; then
+              gh release delete-asset nightly firmware-cn.bin --repo "$GITHUB_REPOSITORY" --yes
+            fi
           fi
 
   publish_cn:
@@ -233,18 +233,15 @@ jobs:
           fi
           for artifact in artifacts/nightly-*; do
             target="${artifact##*/nightly-}"
-            for flavor in global cn; do
-              [ -d "$artifact/$flavor" ] || continue
-              if ! "$RUNNER_TEMP/coscli" cp "${cos_args[@]}" "$artifact/$flavor/" \
-                "cos://${COS_BUCKET}/firmware/builds/${BUILD_ID}/${target}/${flavor}/" \
-                --recursive --forbid-overwrite \
-                --meta 'Cache-Control:public,max-age=31536000,immutable' \
-                --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
-                find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
-                  2>/dev/null || true
-                exit 1
-              fi
-            done
+            if ! "$RUNNER_TEMP/coscli" cp "${cos_args[@]}" "$artifact/" \
+              "cos://${COS_BUCKET}/firmware/builds/${BUILD_ID}/${target}/" \
+              --recursive --forbid-overwrite \
+              --meta 'Cache-Control:public,max-age=31536000,immutable' \
+              --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
+              find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
+                2>/dev/null || true
+              exit 1
+            fi
           done
 
       - name: Publish rolling China index last

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,7 +81,6 @@ jobs:
           retention-days: 14
 
   publish_github:
-    if: always() && needs.prepare.result == 'success'
     needs: [prepare, build]
     runs-on: ubuntu-latest
     permissions:
@@ -99,9 +98,6 @@ jobs:
           pattern: nightly-*
           path: artifacts
 
-      - name: Require at least one complete target pair
-        run: test -n "$(find artifacts -name '*-global-manifest.json' -print -quit)"
-
       - name: Load previous global index
         env:
           GH_TOKEN: ${{ github.token }}
@@ -110,12 +106,18 @@ jobs:
           gh release download nightly --repo "$GITHUB_REPOSITORY" \
             --pattern release-index.json --dir previous/global
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: previous-global-index
+          path: previous/global/release-index.json
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Build global index
         run: |
           updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python3 scripts/build_nightly_index.py \
             --manifests artifacts \
-            --previous previous/global/release-index.json \
             --region global \
             --base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${BUILD_TAG}/" \
             --updated-at "$updated_at" \
@@ -175,7 +177,6 @@ jobs:
           fi
 
   publish_cn:
-    if: always() && needs.prepare.result == 'success'
     needs: [prepare, build]
     runs-on: [self-hosted, Linux, X64, h2o]
     permissions:
@@ -192,20 +193,23 @@ jobs:
           pattern: nightly-*
           path: artifacts
 
-      - name: Require at least one complete target pair
-        run: test -n "$(find artifacts -name '*-global-manifest.json' -print -quit)"
-
       - name: Load previous China index
         run: |
           mkdir -p previous
           curl -fsSL https://assets.crossmux.cn/firmware/releases/nightly/index.json \
             -o previous/cn.json
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: previous-cn-index
+          path: previous/cn.json
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Build China index
         run: |
           python3 scripts/build_nightly_index.py \
             --manifests artifacts \
-            --previous previous/cn.json \
             --region cn \
             --base-url "https://assets.crossmux.cn/firmware/builds/${BUILD_ID}/" \
             --updated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -286,3 +290,104 @@ jobs:
           python3 scripts/verify_nightly_release.py \
             --index-url "https://assets.crossmux.cn/firmware/releases/nightly/index.json?run=${GITHUB_RUN_ID}" \
             --expected-sha "$GITHUB_SHA"
+
+  cleanup_github:
+    needs: verify_publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      BUILD_TAG: nightly-build-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: previous-global-index
+          path: previous/global
+
+      - name: Delete obsolete GitHub Nightly builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 1000 \
+            --json tagName --jq '.[].tagName' > github-releases.txt
+          python3 scripts/nightly_retention.py \
+            --storage github \
+            --current "$BUILD_TAG" \
+            --previous-index previous/global/release-index.json \
+            --candidates github-releases.txt \
+            > obsolete-github-builds.txt
+          while IFS= read -r build_tag; do
+            gh release delete "$build_tag" --repo "$GITHUB_REPOSITORY" \
+              --cleanup-tag --yes
+          done < obsolete-github-builds.txt
+
+  cleanup_cn:
+    needs: verify_publish
+    runs-on: [self-hosted, Linux, X64, h2o]
+    permissions:
+      contents: read
+    env:
+      BUILD_ID: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: previous-cn-index
+          path: previous
+
+      - name: Install COS CLI
+        run: |
+          curl -fsSL \
+            https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64 \
+            -o "$RUNNER_TEMP/coscli"
+          echo "7165f2ae16c5f7ac495864c963ca574a76e04ec72680d7bc8a8eee3234d8cf91  $RUNNER_TEMP/coscli" \
+            | sha256sum --check -
+          chmod 0755 "$RUNNER_TEMP/coscli"
+          "$RUNNER_TEMP/coscli" --version
+
+      - name: Delete obsolete COS Nightly builds
+        env:
+          COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+          COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+          COS_SESSION_TOKEN: ${{ secrets.COS_SESSION_TOKEN }}
+          COS_BUCKET: ${{ secrets.COS_BUCKET }}
+          COS_REGION: ${{ secrets.COS_REGION }}
+        run: |
+          set -euo pipefail
+          cos_args=(--init-skip --disable-log -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
+            -e "cos.${COS_REGION}.myqcloud.com")
+          if [ -n "$COS_SESSION_TOKEN" ]; then
+            cos_args+=(--token "$COS_SESSION_TOKEN")
+          fi
+          versioning="$("$RUNNER_TEMP/coscli" bucket-versioning --method get \
+            "${cos_args[@]}" "cos://${COS_BUCKET}")"
+          list_args=(--limit -1)
+          rm_args=(--recursive --force)
+          if grep -Eq 'Enabled|Suspended' <<< "$versioning"; then
+            list_args+=(--recursive --all-versions)
+            rm_args+=(--all-versions)
+          fi
+          "$RUNNER_TEMP/coscli" ls "${cos_args[@]}" \
+            "cos://${COS_BUCKET}/firmware/builds/" "${list_args[@]}" \
+            > cos-builds.txt
+          python3 scripts/nightly_retention.py \
+            --storage cos \
+            --current "$BUILD_ID" \
+            --previous-index previous/cn.json \
+            --candidates cos-builds.txt \
+            > obsolete-cos-builds.txt
+          while IFS= read -r build_id; do
+            if ! "$RUNNER_TEMP/coscli" rm "${cos_args[@]}" \
+              "cos://${COS_BUCKET}/firmware/builds/${build_id}/" "${rm_args[@]}" \
+              --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
+              find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \
+                2>/dev/null || true
+              exit 1
+            fi
+          done < obsolete-cos-builds.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: nightly-publish
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -104,7 +108,7 @@ jobs:
         run: |
           mkdir -p previous/global
           gh release download nightly --repo "$GITHUB_REPOSITORY" \
-            --pattern release-index.json --dir previous/global || true
+            --pattern release-index.json --dir previous/global
 
       - name: Build global index
         run: |
@@ -163,10 +167,11 @@ jobs:
           if [ -d "$c3_artifact" ]; then
             cp "$c3_artifact/xteink-firmware.bin" firmware.bin
             gh release upload nightly firmware.bin --repo "$GITHUB_REPOSITORY" --clobber
-            if gh release view nightly --repo "$GITHUB_REPOSITORY" --json assets \
-              --jq '.assets[].name' | grep -Fxq firmware-cn.bin; then
-              gh release delete-asset nightly firmware-cn.bin --repo "$GITHUB_REPOSITORY" --yes
-            fi
+          fi
+          legacy_assets="$(gh release view nightly --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name')"
+          if grep -Fxq firmware-cn.bin <<< "$legacy_assets"; then
+            gh release delete-asset nightly firmware-cn.bin --repo "$GITHUB_REPOSITORY" --yes
           fi
 
   publish_cn:
@@ -194,7 +199,7 @@ jobs:
         run: |
           mkdir -p previous
           curl -fsSL https://assets.crossmux.cn/firmware/releases/nightly/index.json \
-            -o previous/cn.json || true
+            -o previous/cn.json
 
       - name: Build China index
         run: |
@@ -266,3 +271,18 @@ jobs:
               2>/dev/null || true
             exit 1
           fi
+
+  verify_publish:
+    needs: [publish_github, publish_cn]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify published Nightly indexes and assets
+        run: |
+          python3 scripts/verify_nightly_release.py \
+            --index-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/release-index.json?run=${GITHUB_RUN_ID}" \
+            --expected-sha "$GITHUB_SHA"
+          python3 scripts/verify_nightly_release.py \
+            --index-url "https://assets.crossmux.cn/firmware/releases/nightly/index.json?run=${GITHUB_RUN_ID}" \
+            --expected-sha "$GITHUB_SHA"

--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -157,9 +157,9 @@ pio run -e sticky -e x4pro -e papermono -e eego_a4 \
   -e murphy_m4 -e waveshare_epaper_397
 ```
 
-Nightly builds each hardware target once, then publishes the identical firmware
-under the legacy `global` and `zh-CN` schema-v1 manifests. Publishing rejects a
-pair whose firmware SHA-256 differs.
+Nightly builds and stores one neutrally named binary set per hardware target.
+The legacy `global` and `zh-CN` schema-v1 manifests both reference that set;
+publishing rejects a pair whose asset names, sizes, or SHA-256 values differ.
 See [firmware-release.md](firmware-release.md) for the release and index contract.
 
 The committed headers were regenerated with source SHA-256

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -29,10 +29,11 @@ The global and China publish jobs run independently. Each writes in this order:
 2. immutable target manifests;
 3. rolling regional indexes.
 
-Publishing fails if the previous rolling index cannot be loaded; a transient
-read error must not turn a partial build into an index that drops targets. Once
-both regions publish, CI resolves every manifest and verifies each distinct
-asset's size and SHA-256 before declaring the run successful.
+All seven targets must build successfully before either region publishes.
+Publishing also fails if the previous rolling index cannot be loaded because
+that index protects the immediately preceding build during cleanup. Once both
+regions publish, CI resolves every manifest and verifies each distinct asset's
+size and SHA-256 before deleting obsolete builds.
 
 The global index is the `release-index.json` asset of the rolling `nightly`
 GitHub Release. The unified binaries and compatibility manifests live in an
@@ -43,6 +44,13 @@ served through `assets.crossmux.cn`. Region chooses the storage provider; both
 variant manifests reference the same neutral binary names and differing hashes
 fail publication.
 
+At steady state, GitHub and COS retain the current build and the build or builds
+referenced by the previous index. A scheduled successful Nightly therefore
+keeps roughly 24 hours of rollback data. Failed builds do not publish or clean
+up anything. The first complete run can temporarily retain more than two build
+names when the preceding index contains target-level fallbacks; the next
+complete run converges to exactly the current and previous build.
+
 COS publishing runs only on the H2O self-hosted runner and does not fall back to
 a GitHub-hosted runner. It uses a version-pinned, SHA-256-verified COSCLI binary
 from the runner's temporary directory. The workflow verifies COSCLI before
@@ -50,6 +58,11 @@ writing any immutable COS object and passes credentials directly to each COS
 command instead of persisting a CLI config file. Required repository secrets
 are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and `COS_REGION`;
 `COS_SESSION_TOKEN` is optional. Gitee is not a firmware release destination.
+The COS identity also needs `cos:GetBucketVersioning`,
+`cos:GetBucketObjectVersions`, `cos:DeleteObject`, and
+`cos:DeleteMultipleObjects`. Cleanup detects versioned buckets and removes
+every version of an obsolete build prefix rather than leaving hidden historical
+objects.
 
 ## Index contract and failure behavior
 
@@ -58,12 +71,11 @@ map. Each target repeats its identity and channel capabilities and contains
 global and `zh-CN` pointers with version, CrossMux SHA, SDK SHA, publish time,
 and immutable manifest URL.
 
-A target advances only when both compatibility manifests are valid and have the
-same CrossMux revision, SDK revision, version, and assets. A
-missing manifest retains that target's previous pointer; other targets may still
-advance. A malformed complete pair fails publishing. Unknown targets from an
-older index are discarded. Historical objects are never overwritten, so
-rollback changes only the rolling index pointer.
+Every target advances together only when both compatibility manifests are valid
+and have the same CrossMux revision, SDK revision, version, and assets. A
+missing or malformed manifest prevents the whole Nightly from publishing.
+Build objects are never overwritten; cleanup runs only after the new rolling
+indexes and their assets pass verification.
 
 ## Consumers and safety
 

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -19,9 +19,9 @@ total. Each image is later aliased by the legacy `global` and `zh-CN` pointers.
 
 ## Publishing
 
-Each target job builds once and packages two compatibility variants. Packaging checks the ESP
-image chip ID, required board tag, partition layout, app-slot size, and SHA-256
-before emitting an immutable target manifest.
+Each target job builds once and packages one binary set plus two compatibility
+manifests. Packaging checks the ESP image chip ID, required board tag, partition
+layout, app-slot size, and SHA-256 before emitting the manifests.
 
 The global and China publish jobs run independently. Each writes in this order:
 
@@ -30,12 +30,13 @@ The global and China publish jobs run independently. Each writes in this order:
 3. rolling regional indexes.
 
 The global index is the `release-index.json` asset of the rolling `nightly`
-GitHub Release. Both variants and their manifests live in an immutable
-`nightly-build-<sha>-<run>-<attempt>` GitHub Release. The China index is
-`/firmware/releases/nightly/index.json`; both variants live under
-`/firmware/builds/<build-id>/<target>/<variant>/` in COS and are served through
-`assets.crossmux.cn`. Region chooses the storage provider; both variant pointers
-reference identical firmware bytes and differing hashes fail publication.
+GitHub Release. The unified binaries and compatibility manifests live in an
+immutable `nightly-build-<sha>-<run>-<attempt>` GitHub Release. The China index
+is `/firmware/releases/nightly/index.json`; each target's single binary set and
+both manifests live under `/firmware/builds/<build-id>/<target>/` in COS and are
+served through `assets.crossmux.cn`. Region chooses the storage provider; both
+variant manifests reference the same neutral binary names and differing hashes
+fail publication.
 
 COS publishing runs only on the H2O self-hosted runner and does not fall back to
 a GitHub-hosted runner. It uses a version-pinned, SHA-256-verified COSCLI binary
@@ -52,11 +53,12 @@ map. Each target repeats its identity and channel capabilities and contains
 global and `zh-CN` pointers with version, CrossMux SHA, SDK SHA, publish time,
 and immutable manifest URL.
 
-A target advances only when both variants are valid and have the same CrossMux
-revision, SDK revision, version, and firmware SHA-256. A missing variant retains that target's previous pointer;
-other targets may still advance. A malformed complete pair fails publishing.
-Unknown targets from an older index are discarded. Historical objects are
-never overwritten, so rollback changes only the rolling index pointer.
+A target advances only when both compatibility manifests are valid and have the
+same CrossMux revision, SDK revision, version, and assets. A
+missing manifest retains that target's previous pointer; other targets may still
+advance. A malformed complete pair fails publishing. Unknown targets from an
+older index are discarded. Historical objects are never overwritten, so
+rollback changes only the rolling index pointer.
 
 ## Consumers and safety
 

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -29,6 +29,11 @@ The global and China publish jobs run independently. Each writes in this order:
 2. immutable target manifests;
 3. rolling regional indexes.
 
+Publishing fails if the previous rolling index cannot be loaded; a transient
+read error must not turn a partial build into an index that drops targets. Once
+both regions publish, CI resolves every manifest and verifies each distinct
+asset's size and SHA-256 before declaring the run successful.
+
 The global index is the `release-index.json` asset of the rolling `nightly`
 GitHub Release. The unified binaries and compatibility manifests live in an
 immutable `nightly-build-<sha>-<run>-<attempt>` GitHub Release. The China index

--- a/scripts/build_nightly_index.py
+++ b/scripts/build_nightly_index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Merge successful target pairs into a regional rolling Nightly index."""
+"""Build a complete regional rolling Nightly index."""
 
 import argparse
 import json
@@ -46,36 +46,32 @@ def manifest_url(base_url, region, target_id, flavor):
     return urljoin(base_url, f'{target_id}/{name}')
 
 
-def build_index(manifest_root, previous, region, base_url, updated_at, build_id):
-    previous_targets = previous.get('targets', {}) if previous else {}
-    targets = {
-        target_id: target
-        for target_id, target in previous_targets.items()
-        if target_id in TARGETS
-    }
+def build_index(manifest_root, region, base_url, updated_at, build_id):
+    targets = {}
+    crossmux_revisions = set()
+    sdk_revisions = set()
     for target_id, target in TARGETS.items():
         manifests = {}
         for flavor in FLAVOR_TOKENS:
             matches = list(manifest_root.rglob(manifest_name(target_id, flavor)))
             if len(matches) != 1:
-                manifests = {}
-                break
+                raise ValueError(f'expected one {target_id}/{flavor} manifest, found {len(matches)}')
             manifest = read_json(matches[0])
             if not valid_manifest(manifest, target_id, flavor):
                 raise ValueError(f'invalid {target_id}/{flavor} manifest')
             manifests[flavor] = manifest
-        if len(manifests) != len(FLAVOR_TOKENS):
-            continue
         revisions = {manifest['crossmuxSha'] for manifest in manifests.values()}
         if len(revisions) != 1:
             raise ValueError(f'{target_id} flavor revisions do not match')
-        sdk_revisions = {manifest['sdkSha'] for manifest in manifests.values()}
-        if len(sdk_revisions) != 1:
+        target_sdk_revisions = {manifest['sdkSha'] for manifest in manifests.values()}
+        if len(target_sdk_revisions) != 1:
             raise ValueError(f'{target_id} flavor SDK revisions do not match')
         if len({manifest['version'] for manifest in manifests.values()}) != 1:
             raise ValueError(f'{target_id} flavor versions do not match')
         if len({json.dumps(manifest['assets'], sort_keys=True) for manifest in manifests.values()}) != 1:
             raise ValueError(f'{target_id} flavor assets do not match')
+        crossmux_revisions.update(revisions)
+        sdk_revisions.update(target_sdk_revisions)
         targets[target_id] = {
             'targetId': target_id,
             'models': target['models'],
@@ -93,6 +89,10 @@ def build_index(manifest_root, previous, region, base_url, updated_at, build_id)
                 for flavor, manifest in manifests.items()
             },
         }
+    if len(crossmux_revisions) != 1:
+        raise ValueError('target CrossMux revisions do not match')
+    if len(sdk_revisions) != 1:
+        raise ValueError('target SDK revisions do not match')
     return {
         'schemaVersion': 1,
         'channel': 'nightly',
@@ -105,7 +105,6 @@ def build_index(manifest_root, previous, region, base_url, updated_at, build_id)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--manifests', type=Path, required=True)
-    parser.add_argument('--previous', type=Path)
     parser.add_argument('--region', choices=('global', 'cn'), required=True)
     parser.add_argument('--base-url', required=True)
     parser.add_argument('--updated-at', required=True)
@@ -113,12 +112,8 @@ def main():
     parser.add_argument('--output', type=Path, required=True)
     args = parser.parse_args()
 
-    previous = read_json(args.previous) if args.previous and args.previous.is_file() else None
-    if previous and (previous.get('schemaVersion') != 1 or previous.get('channel') != 'nightly'):
-        raise SystemExit('previous index has an unsupported schema')
     index = build_index(
         args.manifests,
-        previous,
         args.region,
         args.base_url.rstrip('/') + '/',
         args.updated_at,

--- a/scripts/build_nightly_index.py
+++ b/scripts/build_nightly_index.py
@@ -43,11 +43,7 @@ def manifest_url(base_url, region, target_id, flavor):
     name = manifest_name(target_id, flavor)
     if region == 'global':
         return urljoin(base_url, name)
-    return urljoin(base_url, f'{target_id}/{FLAVOR_TOKENS[flavor]}/{name}')
-
-
-def firmware_sha(manifest):
-    return next(asset.get('sha256') for asset in manifest['assets'] if asset.get('role') == 'firmware')
+    return urljoin(base_url, f'{target_id}/{name}')
 
 
 def build_index(manifest_root, previous, region, base_url, updated_at, build_id):
@@ -78,8 +74,8 @@ def build_index(manifest_root, previous, region, base_url, updated_at, build_id)
             raise ValueError(f'{target_id} flavor SDK revisions do not match')
         if len({manifest['version'] for manifest in manifests.values()}) != 1:
             raise ValueError(f'{target_id} flavor versions do not match')
-        if len({firmware_sha(manifest) for manifest in manifests.values()}) != 1:
-            raise ValueError(f'{target_id} flavor firmware hashes do not match')
+        if len({json.dumps(manifest['assets'], sort_keys=True) for manifest in manifests.values()}) != 1:
+            raise ValueError(f'{target_id} flavor assets do not match')
         targets[target_id] = {
             'targetId': target_id,
             'models': target['models'],

--- a/scripts/nightly_retention.py
+++ b/scripts/nightly_retention.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Plan deletion of Nightly builds not used by the current or previous index."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+from nightly_targets import FLAVOR_TOKENS, TARGETS
+
+
+BUILD_ID = r'[0-9a-f]{40}-[0-9]+-[0-9]+'
+NAMESPACE_TEXT = {'github': rf'nightly-build-{BUILD_ID}', 'cos': BUILD_ID}
+NAMESPACE = {storage: re.compile(rf'^{pattern}$') for storage, pattern in NAMESPACE_TEXT.items()}
+FIND_NAMESPACE = {
+    storage: re.compile(rf'(?<![a-z0-9-])({pattern})(?![a-z0-9-])')
+    for storage, pattern in NAMESPACE_TEXT.items()
+}
+MANIFEST_PATH = {
+    'github': re.compile(
+        rf'^/0x1abin/crossmux/releases/download/(nightly-build-{BUILD_ID})/[^/]+-manifest\.json$'
+    ),
+    'cos': re.compile(rf'^/firmware/builds/({BUILD_ID})/'),
+}
+HOST = {'github': 'github.com', 'cos': 'assets.crossmux.cn'}
+
+
+def referenced_builds(index, storage):
+    if not isinstance(index, dict) or index.get('schemaVersion') != 1 or index.get('channel') != 'nightly':
+        raise ValueError('invalid previous Nightly index envelope')
+    targets = index.get('targets')
+    if not isinstance(targets, dict) or set(targets) != set(TARGETS):
+        raise ValueError('previous Nightly index does not contain the canonical target set')
+
+    builds = set()
+    for target_id, entry in targets.items():
+        variants = entry.get('variants') if isinstance(entry, dict) else None
+        if not isinstance(entry, dict) or entry.get('targetId') != target_id or not isinstance(
+            variants, dict
+        ) or set(variants) != set(FLAVOR_TOKENS):
+            raise ValueError(f'invalid previous {target_id} variant set')
+        for flavor, pointer in variants.items():
+            manifest_url = pointer.get('manifestUrl') if isinstance(pointer, dict) else None
+            if not isinstance(manifest_url, str):
+                raise ValueError(f'invalid previous {target_id}/{flavor} manifest URL')
+            parsed = urlparse(manifest_url)
+            match = MANIFEST_PATH[storage].match(parsed.path)
+            if parsed.scheme != 'https' or parsed.hostname != HOST[storage] or parsed.query or not match:
+                raise ValueError(f'unexpected previous {target_id}/{flavor} manifest URL')
+            builds.add(match.group(1))
+    return builds
+
+
+def obsolete_builds(storage, current, previous_index, candidates):
+    if not NAMESPACE[storage].fullmatch(current):
+        raise ValueError(f'invalid current {storage} build name')
+    found = set(FIND_NAMESPACE[storage].findall(candidates))
+    if current not in found:
+        raise ValueError(f'current {storage} build is missing from the candidate list')
+    keep = referenced_builds(previous_index, storage) | {current}
+    return sorted(found - keep)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--storage', choices=NAMESPACE, required=True)
+    parser.add_argument('--current', required=True)
+    parser.add_argument('--previous-index', type=Path, required=True)
+    parser.add_argument('--candidates', type=Path, required=True)
+    args = parser.parse_args()
+    previous_index = json.loads(args.previous_index.read_text())
+    candidates = args.candidates.read_text()
+    for build in obsolete_builds(args.storage, args.current, previous_index, candidates):
+        print(build)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/nightly_targets.py
+++ b/scripts/nightly_targets.py
@@ -93,9 +93,9 @@ def version_for(base_version, target_id, flavor, short_sha):
     return f"{'-'.join(parts)}-rc+{short_sha[:7]}"
 
 
-def asset_name(target_id, flavor, source_name):
+def asset_name(target_id, source_name):
     target = TARGETS[target_id]
-    return f"{target['deviceSlug']}-{FLAVOR_TOKENS[flavor]}-{source_name}"
+    return f"{target['deviceSlug']}-{source_name}"
 
 
 def manifest_name(target_id, flavor):

--- a/scripts/package_nightly_target.py
+++ b/scripts/package_nightly_target.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Package one model-specific Nightly flavor and emit its verified manifest."""
+"""Package one model-specific Nightly target and emit compatibility manifests."""
 
 import argparse
 import configparser
@@ -92,9 +92,9 @@ def verify_firmware(path, chip_id, board_tag):
     raise SystemExit(f'{path.name} does not contain board tag {board_tag!r}')
 
 
-def package_target(root, target_id, flavor, output):
+def package_target(root, target_id, output):
     target = TARGETS[target_id]
-    environment = environment_for(target_id, flavor)
+    environment = environment_for(target_id, 'global')
     build = root / '.pio/build' / environment
     output.mkdir(parents=True, exist_ok=True)
     verify_partition_csv(root)
@@ -103,7 +103,7 @@ def package_target(root, target_id, flavor, output):
     assets = []
     for role, source_name, offset in segments:
         source = find_boot_app0() if role == 'boot_app0' else build / source_name
-        destination = output / asset_name(target_id, flavor, source_name)
+        destination = output / asset_name(target_id, source_name)
         copy_asset(source, destination)
         assets.append({
             'role': role,
@@ -131,8 +131,7 @@ def package_target(root, target_id, flavor, output):
         'supportedChannels': target['supportedChannels'],
         'environment': environment,
         'chip': target['chip'],
-        'flavor': flavor,
-        'version': version_for(config['crosspoint']['version'], target_id, flavor, short_sha),
+        'version': version_for(config['crosspoint']['version'], target_id, 'global', short_sha),
         'crossmuxSha': git_value(root, 'rev-parse', 'HEAD'),
         'sdkSha': git_value(root / 'freeink-sdk', 'rev-parse', 'HEAD'),
         'assets': assets,
@@ -141,20 +140,23 @@ def package_target(root, target_id, flavor, output):
         manifest['partitionProfile'] = 'crossmux-sticky-v1'
         manifest['flash'] = {'size': 0x1000000, 'mode': 'dio', 'frequency': '80m'}
 
-    manifest_path = output / manifest_name(target_id, flavor)
-    manifest_path.write_text(json.dumps(manifest, indent=2) + '\n')
-    checksum_paths = [output / asset['name'] for asset in assets] + [manifest_path]
-    checksum_name = f"{target['deviceSlug']}-{FLAVOR_TOKENS[flavor]}-SHA256SUMS"
+    manifest_paths = []
+    for flavor in FLAVOR_TOKENS:
+        manifest_path = output / manifest_name(target_id, flavor)
+        manifest_path.write_text(json.dumps({**manifest, 'flavor': flavor}, indent=2) + '\n')
+        manifest_paths.append(manifest_path)
+
+    checksum_paths = [output / asset['name'] for asset in assets] + manifest_paths
+    checksum_name = f"{target['deviceSlug']}-SHA256SUMS"
     (output / checksum_name).write_text(
         ''.join(f'{sha256(path)}  {path.name}\n' for path in checksum_paths)
     )
-    print(f"Packaged {target_id}/{flavor} {manifest['version']} in {output}")
+    print(f"Packaged {target_id} {manifest['version']} in {output}")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('target', nargs='?', choices=TARGETS)
-    parser.add_argument('--flavor', choices=FLAVOR_TOKENS, default='global')
     parser.add_argument('--output', type=Path)
     parser.add_argument('--matrix', action='store_true')
     args = parser.parse_args()
@@ -165,9 +167,8 @@ def main():
         parser.error('target is required unless --matrix is used')
 
     root = Path(__file__).resolve().parent.parent
-    token = FLAVOR_TOKENS[args.flavor]
-    output = (args.output or root / 'dist' / args.target / token).resolve()
-    package_target(root, args.target, args.flavor, output)
+    output = (args.output or root / 'dist' / args.target).resolve()
+    package_target(root, args.target, output)
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import sys
 import tempfile
@@ -13,6 +14,7 @@ sys.path.insert(0, str(SCRIPTS))
 import build_nightly_index
 import nightly_targets
 import package_nightly_target
+import verify_nightly_release
 
 
 class NightlyTargetTest(unittest.TestCase):
@@ -52,6 +54,19 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertNotIn('for flavor in global cn', workflow)
         self.assertIn('cp "$c3_artifact/xteink-firmware.bin" firmware.bin', workflow)
         self.assertIn('gh release delete-asset nightly firmware-cn.bin', workflow)
+
+    def test_workflow_fails_closed_and_verifies_both_regions(self):
+        workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        self.assertIn('group: nightly-publish', workflow)
+        self.assertNotIn('--dir previous/global || true', workflow)
+        self.assertNotIn('-o previous/cn.json || true', workflow)
+        rolling = workflow.split('- name: Publish rolling global index last', 1)[1].split('  publish_cn:', 1)[0]
+        c3_start = rolling.index('c3_artifact=')
+        c3_end = rolling.index('          fi\n', c3_start)
+        self.assertGreater(rolling.index('legacy_assets='), c3_end)
+        verify = workflow.split('  verify_publish:', 1)[1]
+        self.assertIn('needs: [publish_github, publish_cn]', verify)
+        self.assertEqual(verify.count('python3 scripts/verify_nightly_release.py'), 2)
 
     def test_package_contains_one_binary_set_and_two_compatible_manifests(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -255,6 +270,132 @@ class NightlyIndexTest(unittest.TestCase):
                 self.root, None, 'global', 'https://example.com/', 'now', 'test'
             )
 
+
+class PublishedNightlyTest(unittest.TestCase):
+    def setUp(self):
+        self.index_url = (
+            'https://github.com/0x1abin/crossmux/releases/download/nightly/release-index.json'
+        )
+        self.release_url = (
+            'https://github.com/0x1abin/crossmux/releases/download/nightly-build-test/'
+        )
+        self.current_sha = 'a' * 40
+        self.old_sha = 'c' * 40
+        self.sdk_sha = 'b' * 40
+        self.store = {}
+        self.fetches = {}
+        targets = {}
+        for index, (target_id, target) in enumerate(nightly_targets.TARGETS.items()):
+            revision = self.old_sha if index == 0 else self.current_sha
+            assets = []
+            for role, name, offset in verify_nightly_release.expected_assets(target_id):
+                data = f'{target_id}/{role}'.encode()
+                self.store[self.release_url + name] = data
+                assets.append({
+                    'role': role,
+                    'name': name,
+                    'offset': offset,
+                    'size': len(data),
+                    'sha256': hashlib.sha256(data).hexdigest(),
+                })
+            variants = {}
+            for flavor in nightly_targets.FLAVOR_TOKENS:
+                version = f'1.5.7-rc+{revision[:7]}'
+                manifest = {
+                    'schemaVersion': 1,
+                    'channel': 'nightly',
+                    'targetId': target_id,
+                    'models': target['models'],
+                    'deviceSlug': target['deviceSlug'],
+                    'boardTag': target['boardTag'],
+                    'supportedChannels': target['supportedChannels'],
+                    'environment': nightly_targets.environment_for(target_id, flavor),
+                    'flavor': flavor,
+                    'version': version,
+                    'crossmuxSha': revision,
+                    'sdkSha': self.sdk_sha,
+                    'assets': assets,
+                }
+                url = self.release_url + nightly_targets.manifest_name(target_id, flavor)
+                self.store[url] = json.dumps(manifest).encode()
+                variants[flavor] = {
+                    'version': version,
+                    'crossmuxSha': revision,
+                    'sdkSha': self.sdk_sha,
+                    'publishedAt': 'now',
+                    'manifestUrl': url,
+                }
+            targets[target_id] = {
+                'targetId': target_id,
+                'models': target['models'],
+                'deviceSlug': target['deviceSlug'],
+                'boardTag': target['boardTag'],
+                'supportedChannels': target['supportedChannels'],
+                'variants': variants,
+            }
+        self.index = {
+            'schemaVersion': 1,
+            'channel': 'nightly',
+            'updatedAt': 'now',
+            'buildId': 'test',
+            'targets': targets,
+        }
+        self.write_index()
+
+    def write_index(self):
+        self.store[self.index_url] = json.dumps(self.index).encode()
+
+    def fetch(self, url):
+        self.fetches[url] = self.fetches.get(url, 0) + 1
+        return self.store[url]
+
+    def test_verifies_current_and_retained_targets_with_one_asset_fetch(self):
+        result = verify_nightly_release.verify_release(
+            self.index_url, self.current_sha, self.fetch
+        )
+        self.assertEqual(result['targets'], len(nightly_targets.TARGETS))
+        self.assertEqual(result['currentTargets'], len(nightly_targets.TARGETS) - 1)
+        for url in self.store:
+            if url.endswith('.bin'):
+                self.assertEqual(self.fetches[url], 1)
+
+    def test_accepts_legacy_assets_for_retained_target(self):
+        target_id = 'xteink_x4'
+        cn_url = self.release_url + nightly_targets.manifest_name(target_id, 'zh-CN')
+        manifest = json.loads(self.store[cn_url])
+        old_name = 'xteink-cn-firmware.bin'
+        data = b'legacy-cn-firmware'
+        manifest['assets'][0].update({
+            'name': old_name,
+            'size': len(data),
+            'sha256': hashlib.sha256(data).hexdigest(),
+        })
+        self.store[cn_url] = json.dumps(manifest).encode()
+        self.store[self.release_url + old_name] = data
+        result = verify_nightly_release.verify_release(
+            self.index_url, self.current_sha, self.fetch
+        )
+        self.assertEqual(result['currentTargets'], len(nightly_targets.TARGETS) - 1)
+
+    def test_rejects_missing_target(self):
+        self.index['targets'].pop('sticky')
+        self.write_index()
+        with self.assertRaisesRegex(ValueError, 'canonical target set'):
+            verify_nightly_release.verify_release(self.index_url, self.current_sha, self.fetch)
+
+    def test_rejects_manifest_difference(self):
+        url = self.release_url + nightly_targets.manifest_name('sticky', 'zh-CN')
+        manifest = json.loads(self.store[url])
+        manifest['unexpected'] = True
+        self.store[url] = json.dumps(manifest).encode()
+        with self.assertRaisesRegex(ValueError, 'differ beyond flavor'):
+            verify_nightly_release.verify_release(self.index_url, self.current_sha, self.fetch)
+
+    def test_rejects_corrupt_asset(self):
+        url = self.release_url + nightly_targets.asset_name('sticky', 'firmware.bin')
+        self.store[url] += b'corrupt'
+        with self.assertRaisesRegex(ValueError, 'size or SHA-256'):
+            verify_nightly_release.verify_release(self.index_url, self.current_sha, self.fetch)
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -12,6 +12,7 @@ ROOT = SCRIPTS.parent
 sys.path.insert(0, str(SCRIPTS))
 
 import build_nightly_index
+import nightly_retention
 import nightly_targets
 import package_nightly_target
 import verify_nightly_release
@@ -58,8 +59,11 @@ class NightlyTargetTest(unittest.TestCase):
     def test_workflow_fails_closed_and_verifies_both_regions(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
         self.assertIn('group: nightly-publish', workflow)
+        self.assertNotIn("if: always() && needs.prepare.result == 'success'", workflow)
         self.assertNotIn('--dir previous/global || true', workflow)
         self.assertNotIn('-o previous/cn.json || true', workflow)
+        self.assertNotIn('--previous previous/', workflow)
+        self.assertNotIn('name: nightly-previous-', workflow)
         rolling = workflow.split('- name: Publish rolling global index last', 1)[1].split('  publish_cn:', 1)[0]
         c3_start = rolling.index('c3_artifact=')
         c3_end = rolling.index('          fi\n', c3_start)
@@ -67,6 +71,13 @@ class NightlyTargetTest(unittest.TestCase):
         verify = workflow.split('  verify_publish:', 1)[1]
         self.assertIn('needs: [publish_github, publish_cn]', verify)
         self.assertEqual(verify.count('python3 scripts/verify_nightly_release.py'), 2)
+        self.assertIn('  cleanup_github:\n    needs: verify_publish', workflow)
+        self.assertIn('  cleanup_cn:\n    needs: verify_publish', workflow)
+        self.assertEqual(workflow.count('python3 scripts/nightly_retention.py'), 2)
+        self.assertIn('gh release delete "$build_tag"', workflow)
+        self.assertIn('cos://${COS_BUCKET}/firmware/builds/${build_id}/', workflow)
+        self.assertIn('--cleanup-tag --yes', workflow)
+        self.assertIn('--recursive --force', workflow)
 
     def test_package_contains_one_binary_set_and_two_compatible_manifests(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -117,6 +128,7 @@ class NightlyTargetTest(unittest.TestCase):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
         github_job, china_job = workflow.split('  publish_cn:\n')
         github_job = github_job.split('  publish_github:\n')[1]
+        china_job = china_job.split('  verify_publish:\n')[0]
         self.assertIn('runs-on: ubuntu-latest', github_job)
         self.assertNotIn('COS_SECRET_', github_job)
         self.assertIn('runs-on: [self-hosted, Linux, X64, h2o]', china_job)
@@ -196,34 +208,29 @@ class NightlyIndexTest(unittest.TestCase):
             }
             (self.root / nightly_targets.manifest_name(target_id, flavor)).write_text(json.dumps(manifest))
 
-    def test_updates_complete_pair_and_retains_missing_target(self):
-        self.write_pair('sticky')
-        previous = {
-            'targets': {
-                'eego_a4': {'targetId': 'eego_a4', 'variants': {'global': {'version': 'old'}}},
-                'retired': {'targetId': 'retired'},
-            }
-        }
+    def write_all_pairs(self, revision='a' * 40, sdk_revision='b' * 40):
+        for target_id in nightly_targets.TARGETS:
+            self.write_pair(target_id, revision, sdk_revision)
+
+    def test_builds_complete_index(self):
+        self.write_all_pairs()
         index = build_nightly_index.build_index(
             self.root,
-            previous,
             'global',
             'https://example.com/nightly/',
             '2026-08-26T00:00:00Z',
             'nightly-test',
         )
-        self.assertIn('sticky', index['targets'])
-        self.assertIn('eego_a4', index['targets'])
-        self.assertNotIn('retired', index['targets'])
+        self.assertEqual(set(index['targets']), set(nightly_targets.TARGETS))
         self.assertEqual(
             index['targets']['sticky']['variants']['zh-CN']['manifestUrl'],
             'https://example.com/nightly/sticky-cn-manifest.json',
         )
 
     def test_china_variants_share_one_target_directory_and_binary(self):
-        self.write_pair('sticky')
+        self.write_all_pairs()
         index = build_nightly_index.build_index(
-            self.root, None, 'cn', 'https://assets.example/firmware/builds/test/', 'now', 'test'
+            self.root, 'cn', 'https://assets.example/firmware/builds/test/', 'now', 'test'
         )
         variants = index['targets']['sticky']['variants']
         self.assertEqual(
@@ -240,34 +247,112 @@ class NightlyIndexTest(unittest.TestCase):
         ]
         self.assertEqual(manifests[0]['assets'], manifests[1]['assets'])
 
-    def test_does_not_advance_incomplete_pair(self):
-        self.write_pair('sticky')
+    def test_rejects_incomplete_target_set(self):
+        self.write_all_pairs()
         (self.root / nightly_targets.manifest_name('sticky', 'zh-CN')).unlink()
-        index = build_nightly_index.build_index(
-            self.root, None, 'cn', 'https://assets.example/firmware/builds/test/', 'now', 'test'
-        )
-        self.assertNotIn('sticky', index['targets'])
+        with self.assertRaisesRegex(ValueError, 'expected one sticky/zh-CN manifest'):
+            build_nightly_index.build_index(
+                self.root, 'cn', 'https://assets.example/firmware/builds/test/', 'now', 'test'
+            )
 
     def test_rejects_mismatched_sdk_pair(self):
-        self.write_pair('sticky')
+        self.write_all_pairs()
         chinese = self.root / nightly_targets.manifest_name('sticky', 'zh-CN')
         manifest = json.loads(chinese.read_text())
         manifest['sdkSha'] = 'c' * 40
         chinese.write_text(json.dumps(manifest))
         with self.assertRaisesRegex(ValueError, 'SDK revisions do not match'):
             build_nightly_index.build_index(
-                self.root, None, 'global', 'https://example.com/', 'now', 'test'
+                self.root, 'global', 'https://example.com/', 'now', 'test'
             )
 
     def test_rejects_mismatched_asset_pair(self):
-        self.write_pair('sticky')
+        self.write_all_pairs()
         chinese = self.root / nightly_targets.manifest_name('sticky', 'zh-CN')
         manifest = json.loads(chinese.read_text())
         manifest['assets'][0]['sha256'] = 'e' * 64
         chinese.write_text(json.dumps(manifest))
         with self.assertRaisesRegex(ValueError, 'assets do not match'):
             build_nightly_index.build_index(
-                self.root, None, 'global', 'https://example.com/', 'now', 'test'
+                self.root, 'global', 'https://example.com/', 'now', 'test'
+            )
+
+    def test_rejects_mixed_target_revisions(self):
+        self.write_all_pairs()
+        self.write_pair('sticky', revision='c' * 40)
+        with self.assertRaisesRegex(ValueError, 'target CrossMux revisions do not match'):
+            build_nightly_index.build_index(
+                self.root, 'global', 'https://example.com/', 'now', 'test'
+            )
+
+
+class NightlyRetentionTest(unittest.TestCase):
+    def previous_index(self, storage, first_build, second_build):
+        targets = {}
+        for index, target_id in enumerate(nightly_targets.TARGETS):
+            build = second_build if index == 0 else first_build
+            if storage == 'github':
+                base = f'https://github.com/0x1abin/crossmux/releases/download/{build}/'
+            else:
+                base = f'https://assets.crossmux.cn/firmware/builds/{build}/{target_id}/'
+            targets[target_id] = {
+                'targetId': target_id,
+                'variants': {
+                    flavor: {
+                        'manifestUrl': base + nightly_targets.manifest_name(target_id, flavor)
+                    }
+                    for flavor in nightly_targets.FLAVOR_TOKENS
+                },
+            }
+        return {'schemaVersion': 1, 'channel': 'nightly', 'targets': targets}
+
+    def test_github_keeps_current_and_every_build_in_previous_index(self):
+        current = f'nightly-build-{"a" * 40}-10-1'
+        previous = f'nightly-build-{"b" * 40}-9-1'
+        previous_fallback = f'nightly-build-{"c" * 40}-8-1'
+        obsolete = f'nightly-build-{"d" * 40}-7-1'
+        candidates = '\n'.join((current, previous, previous_fallback, obsolete, 'v1.5.7'))
+        self.assertEqual(
+            nightly_retention.obsolete_builds(
+                'github',
+                current,
+                self.previous_index('github', previous, previous_fallback),
+                candidates,
+            ),
+            [obsolete],
+        )
+
+    def test_cos_extracts_build_directories_from_listing(self):
+        current = f'{"a" * 40}-10-1'
+        previous = f'{"b" * 40}-9-1'
+        previous_fallback = f'{"c" * 40}-8-1'
+        obsolete = f'{"d" * 40}-7-1'
+        candidates = '\n'.join(
+            f'firmware/builds/{build}/ | DIR'
+            for build in (current, previous, previous_fallback, obsolete)
+        )
+        self.assertEqual(
+            nightly_retention.obsolete_builds(
+                'cos',
+                current,
+                self.previous_index('cos', previous, previous_fallback),
+                candidates,
+            ),
+            [obsolete],
+        )
+
+    def test_rejects_unexpected_previous_url_and_incomplete_listing(self):
+        current = f'nightly-build-{"a" * 40}-10-1'
+        previous = f'nightly-build-{"b" * 40}-9-1'
+        index = self.previous_index('github', previous, previous)
+        index['targets']['sticky']['variants']['global']['manifestUrl'] = (
+            'https://example.com/firmware.bin'
+        )
+        with self.assertRaisesRegex(ValueError, 'unexpected previous sticky/global'):
+            nightly_retention.obsolete_builds('github', current, index, current)
+        with self.assertRaisesRegex(ValueError, 'missing from the candidate list'):
+            nightly_retention.obsolete_builds(
+                'github', current, self.previous_index('github', previous, previous), previous
             )
 
 
@@ -285,8 +370,8 @@ class PublishedNightlyTest(unittest.TestCase):
         self.store = {}
         self.fetches = {}
         targets = {}
-        for index, (target_id, target) in enumerate(nightly_targets.TARGETS.items()):
-            revision = self.old_sha if index == 0 else self.current_sha
+        for target_id, target in nightly_targets.TARGETS.items():
+            revision = self.current_sha
             assets = []
             for role, name, offset in verify_nightly_release.expected_assets(target_id):
                 data = f'{target_id}/{role}'.encode()
@@ -349,33 +434,27 @@ class PublishedNightlyTest(unittest.TestCase):
         self.fetches[url] = self.fetches.get(url, 0) + 1
         return self.store[url]
 
-    def test_verifies_current_and_retained_targets_with_one_asset_fetch(self):
+    def test_verifies_complete_current_release_with_one_asset_fetch(self):
         result = verify_nightly_release.verify_release(
             self.index_url, self.current_sha, self.fetch
         )
         self.assertEqual(result['targets'], len(nightly_targets.TARGETS))
-        self.assertEqual(result['currentTargets'], len(nightly_targets.TARGETS) - 1)
+        self.assertEqual(result['currentTargets'], len(nightly_targets.TARGETS))
         for url in self.store:
             if url.endswith('.bin'):
                 self.assertEqual(self.fetches[url], 1)
 
-    def test_accepts_legacy_assets_for_retained_target(self):
+    def test_rejects_target_from_previous_revision(self):
         target_id = 'xteink_x4'
-        cn_url = self.release_url + nightly_targets.manifest_name(target_id, 'zh-CN')
-        manifest = json.loads(self.store[cn_url])
-        old_name = 'xteink-cn-firmware.bin'
-        data = b'legacy-cn-firmware'
-        manifest['assets'][0].update({
-            'name': old_name,
-            'size': len(data),
-            'sha256': hashlib.sha256(data).hexdigest(),
-        })
-        self.store[cn_url] = json.dumps(manifest).encode()
-        self.store[self.release_url + old_name] = data
-        result = verify_nightly_release.verify_release(
-            self.index_url, self.current_sha, self.fetch
-        )
-        self.assertEqual(result['currentTargets'], len(nightly_targets.TARGETS) - 1)
+        for flavor in nightly_targets.FLAVOR_TOKENS:
+            url = self.release_url + nightly_targets.manifest_name(target_id, flavor)
+            manifest = json.loads(self.store[url])
+            manifest['crossmuxSha'] = self.old_sha
+            self.store[url] = json.dumps(manifest).encode()
+            self.index['targets'][target_id]['variants'][flavor]['crossmuxSha'] = self.old_sha
+        self.write_index()
+        with self.assertRaisesRegex(ValueError, 'does not point to the current revision'):
+            verify_nightly_release.verify_release(self.index_url, self.current_sha, self.fetch)
 
     def test_rejects_missing_target(self):
         self.index['targets'].pop('sticky')

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPTS = Path(__file__).resolve().parents[1]
@@ -43,10 +44,59 @@ class NightlyTargetTest(unittest.TestCase):
         )
         self.assertNotIn('beta', nightly_targets.version_for('1.5.7', 'sticky', 'global', '1234567'))
 
-    def test_github_release_includes_both_variants(self):
+    def test_workflow_packages_one_binary_set(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
         self.assertIn("find artifacts -type f -print", workflow)
         self.assertNotIn("find artifacts -path '*/global/*'", workflow)
+        self.assertEqual(workflow.count('python3 scripts/package_nightly_target.py "${{ matrix.targetId }}"'), 1)
+        self.assertNotIn('for flavor in global cn', workflow)
+        self.assertIn('cp "$c3_artifact/xteink-firmware.bin" firmware.bin', workflow)
+        self.assertIn('gh release delete-asset nightly firmware-cn.bin', workflow)
+
+    def test_package_contains_one_binary_set_and_two_compatible_manifests(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            build = root / '.pio/build/sticky_nightly'
+            build.mkdir(parents=True)
+            (build / 'bootloader.bin').write_bytes(b'bootloader')
+            (build / 'partitions.bin').write_bytes(b'partitions')
+            (build / 'firmware.bin').write_bytes(self.write_image(board='sticky').read_bytes())
+            boot_app0 = root / 'boot_app0.bin'
+            boot_app0.write_bytes(b'boot_app0')
+            (root / 'platformio.ini').write_text('[crosspoint]\nversion = 1.5.7\n')
+            output = root / 'dist/sticky'
+
+            def git_value(_root, *args):
+                return 'a' * (7 if '--short=7' in args else 40)
+
+            with (
+                mock.patch.object(package_nightly_target, 'verify_partition_csv'),
+                mock.patch.object(package_nightly_target, 'find_boot_app0', return_value=boot_app0),
+                mock.patch.object(package_nightly_target, 'git_value', side_effect=git_value),
+            ):
+                package_nightly_target.package_target(root, 'sticky', output)
+
+            self.assertEqual(
+                {path.name for path in output.iterdir()},
+                {
+                    'sticky-bootloader.bin',
+                    'sticky-partitions.bin',
+                    'sticky-boot_app0.bin',
+                    'sticky-firmware.bin',
+                    'sticky-global-manifest.json',
+                    'sticky-cn-manifest.json',
+                    'sticky-SHA256SUMS',
+                },
+            )
+            manifests = [
+                json.loads((output / nightly_targets.manifest_name('sticky', flavor)).read_text())
+                for flavor in nightly_targets.FLAVOR_TOKENS
+            ]
+            self.assertEqual(manifests[0]['assets'], manifests[1]['assets'])
+            self.assertEqual(
+                {key: value for key, value in manifests[0].items() if key != 'flavor'},
+                {key: value for key, value in manifests[1].items() if key != 'flavor'},
+            )
 
     def test_publish_jobs_keep_credentials_scoped(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
@@ -123,7 +173,11 @@ class NightlyIndexTest(unittest.TestCase):
                 'version': f'1.5.7-rc+{revision[:7]}',
                 'crossmuxSha': revision,
                 'sdkSha': sdk_revision,
-                'assets': [{'role': 'firmware', 'name': 'firmware.bin', 'sha256': 'd' * 64}],
+                'assets': [{
+                    'role': 'firmware',
+                    'name': nightly_targets.asset_name(target_id, 'firmware.bin'),
+                    'sha256': 'd' * 64,
+                }],
             }
             (self.root / nightly_targets.manifest_name(target_id, flavor)).write_text(json.dumps(manifest))
 
@@ -151,6 +205,26 @@ class NightlyIndexTest(unittest.TestCase):
             'https://example.com/nightly/sticky-cn-manifest.json',
         )
 
+    def test_china_variants_share_one_target_directory_and_binary(self):
+        self.write_pair('sticky')
+        index = build_nightly_index.build_index(
+            self.root, None, 'cn', 'https://assets.example/firmware/builds/test/', 'now', 'test'
+        )
+        variants = index['targets']['sticky']['variants']
+        self.assertEqual(
+            variants['global']['manifestUrl'],
+            'https://assets.example/firmware/builds/test/sticky/sticky-global-manifest.json',
+        )
+        self.assertEqual(
+            variants['zh-CN']['manifestUrl'],
+            'https://assets.example/firmware/builds/test/sticky/sticky-cn-manifest.json',
+        )
+        manifests = [
+            json.loads((self.root / nightly_targets.manifest_name('sticky', flavor)).read_text())
+            for flavor in nightly_targets.FLAVOR_TOKENS
+        ]
+        self.assertEqual(manifests[0]['assets'], manifests[1]['assets'])
+
     def test_does_not_advance_incomplete_pair(self):
         self.write_pair('sticky')
         (self.root / nightly_targets.manifest_name('sticky', 'zh-CN')).unlink()
@@ -170,13 +244,13 @@ class NightlyIndexTest(unittest.TestCase):
                 self.root, None, 'global', 'https://example.com/', 'now', 'test'
             )
 
-    def test_rejects_mismatched_firmware_pair(self):
+    def test_rejects_mismatched_asset_pair(self):
         self.write_pair('sticky')
         chinese = self.root / nightly_targets.manifest_name('sticky', 'zh-CN')
         manifest = json.loads(chinese.read_text())
         manifest['assets'][0]['sha256'] = 'e' * 64
         chinese.write_text(json.dumps(manifest))
-        with self.assertRaisesRegex(ValueError, 'firmware hashes do not match'):
+        with self.assertRaisesRegex(ValueError, 'assets do not match'):
             build_nightly_index.build_index(
                 self.root, None, 'global', 'https://example.com/', 'now', 'test'
             )

--- a/scripts/verify_nightly_release.py
+++ b/scripts/verify_nightly_release.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Verify published Nightly indexes, manifests, and binary assets."""
+
+import argparse
+import hashlib
+import json
+import re
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urljoin, urlparse
+
+from build_nightly_index import valid_manifest
+from nightly_targets import FLAVOR_TOKENS, TARGETS, asset_name, manifest_name
+
+
+SHA40 = re.compile(r'^[0-9a-f]{40}$')
+SHA256 = re.compile(r'^[0-9a-f]{64}$')
+ASSET_NAME = re.compile(r'^[a-z0-9][a-z0-9._-]*\.bin$')
+OFFSETS = {'bootloader': 0x0000, 'partitions': 0x8000, 'boot_app0': 0xE000, 'firmware': 0x10000}
+
+
+def fetch_bytes(url, attempts=3):
+    request = urllib.request.Request(url, headers={'User-Agent': 'crossmux-nightly-verifier'})
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return response.read()
+        except (urllib.error.URLError, TimeoutError) as error:
+            if attempt + 1 == attempts:
+                raise RuntimeError(f'failed to download {url}: {error}') from error
+            time.sleep(2 ** attempt)
+
+
+def read_json(url, fetch):
+    try:
+        return json.loads(fetch(url))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f'invalid JSON at {url}') from error
+
+
+def validate_url(url, index_url):
+    parsed = urlparse(url)
+    index_host = urlparse(index_url).hostname
+    if parsed.scheme != 'https':
+        raise ValueError(f'published URL is not HTTPS: {url}')
+    if index_host == 'github.com':
+        valid = parsed.hostname == 'github.com' and parsed.path.startswith(
+            '/0x1abin/crossmux/releases/download/nightly-build-'
+        )
+    elif index_host == 'assets.crossmux.cn':
+        valid = parsed.hostname == 'assets.crossmux.cn' and parsed.path.startswith('/firmware/builds/')
+    else:
+        valid = False
+    if not valid:
+        raise ValueError(f'published URL is outside the expected release path: {url}')
+
+
+def expected_assets(target_id):
+    roles = tuple(OFFSETS) if TARGETS[target_id]['fullInstall'] else ('firmware',)
+    return [(role, asset_name(target_id, f'{role}.bin'), OFFSETS[role]) for role in roles]
+
+
+def verify_release(index_url, expected_sha, fetch=fetch_bytes):
+    if not SHA40.fullmatch(expected_sha):
+        raise ValueError('expected SHA must contain 40 lowercase hex characters')
+    index = read_json(index_url, fetch)
+    if not isinstance(index, dict) or index.get('schemaVersion') != 1 or index.get('channel') != 'nightly':
+        raise ValueError('invalid Nightly index envelope')
+    targets = index.get('targets')
+    if not isinstance(targets, dict) or set(targets) != set(TARGETS):
+        raise ValueError('published Nightly index does not contain the canonical target set')
+
+    current_targets = 0
+    asset_count = 0
+    for target_id, target in TARGETS.items():
+        entry = targets[target_id]
+        if not isinstance(entry, dict) or any(
+            entry.get(key) != target[key]
+            for key in ('models', 'deviceSlug', 'boardTag', 'supportedChannels')
+        ) or entry.get('targetId') != target_id:
+            raise ValueError(f'invalid {target_id} index entry')
+        variants = entry.get('variants')
+        if not isinstance(variants, dict) or set(variants) != set(FLAVOR_TOKENS):
+            raise ValueError(f'invalid {target_id} variant set')
+
+        manifests = {}
+        manifest_urls = {}
+        for flavor in FLAVOR_TOKENS:
+            pointer = variants[flavor]
+            if not isinstance(pointer, dict) or not SHA40.fullmatch(str(pointer.get('crossmuxSha', ''))) or not SHA40.fullmatch(
+                str(pointer.get('sdkSha', ''))
+            ) or not isinstance(pointer.get('version'), str) or not isinstance(pointer.get('publishedAt'), str):
+                raise ValueError(f'invalid {target_id}/{flavor} pointer')
+            manifest_url = pointer.get('manifestUrl')
+            if not isinstance(manifest_url, str) or not manifest_url.endswith(manifest_name(target_id, flavor)):
+                raise ValueError(f'invalid {target_id}/{flavor} manifest URL')
+            validate_url(manifest_url, index_url)
+            manifest = read_json(manifest_url, fetch)
+            if not valid_manifest(manifest, target_id, flavor):
+                raise ValueError(f'invalid {target_id}/{flavor} manifest')
+            for key in ('version', 'crossmuxSha', 'sdkSha'):
+                if manifest.get(key) != pointer.get(key):
+                    raise ValueError(f'{target_id}/{flavor} manifest does not match its index pointer')
+            manifests[flavor] = manifest
+            manifest_urls[flavor] = manifest_url
+
+        revisions = {manifest['crossmuxSha'] for manifest in manifests.values()}
+        sdk_revisions = {manifest['sdkSha'] for manifest in manifests.values()}
+        versions = {manifest['version'] for manifest in manifests.values()}
+        if len(revisions) != 1 or len(sdk_revisions) != 1 or len(versions) != 1:
+            raise ValueError(f'{target_id} compatibility manifest revisions differ')
+        is_current = manifests['global']['crossmuxSha'] == expected_sha
+        if is_current:
+            comparable = [
+                {key: value for key, value in manifest.items() if key != 'flavor'}
+                for manifest in manifests.values()
+            ]
+            if comparable[0] != comparable[1]:
+                raise ValueError(f'{target_id} compatibility manifests differ beyond flavor')
+            current_targets += 1
+
+        expected = expected_assets(target_id)
+        seen_urls = set()
+        role_urls = {role: set() for role, _name, _offset in expected}
+        for flavor, manifest in manifests.items():
+            assets = manifest['assets']
+            if len(assets) != len(expected):
+                raise ValueError(f'{target_id}/{flavor} has an unexpected asset count')
+            for asset, (role, neutral_name, offset) in zip(assets, expected):
+                name = asset.get('name') if isinstance(asset, dict) else None
+                if not isinstance(asset, dict) or asset.get('role') != role or not isinstance(
+                    name, str
+                ) or not ASSET_NAME.fullmatch(name) or (is_current and name != neutral_name) or asset.get(
+                    'offset'
+                ) != offset or type(asset.get('size')) is not int or asset['size'] <= 0 or not SHA256.fullmatch(
+                    str(asset.get('sha256', ''))
+                ):
+                    raise ValueError(f'{target_id}/{flavor} has an invalid {role} asset')
+                asset_url = urljoin(manifest_urls[flavor], name)
+                validate_url(asset_url, index_url)
+                role_urls[role].add(asset_url)
+                if asset_url in seen_urls:
+                    continue
+                seen_urls.add(asset_url)
+                data = fetch(asset_url)
+                if len(data) != asset['size'] or hashlib.sha256(data).hexdigest() != asset['sha256']:
+                    raise ValueError(f'{target_id}/{name} failed size or SHA-256 verification')
+                asset_count += 1
+        if is_current and any(len(urls) != 1 for urls in role_urls.values()):
+            raise ValueError(f'{target_id} compatibility manifests do not share one binary set')
+
+    if current_targets == 0:
+        raise ValueError('published index did not advance any target to the current revision')
+    return {'targets': len(targets), 'currentTargets': current_targets, 'assets': asset_count}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--index-url', required=True)
+    parser.add_argument('--expected-sha', required=True)
+    args = parser.parse_args()
+    result = verify_release(args.index_url, args.expected_sha)
+    print(
+        f"Verified {result['targets']} targets ({result['currentTargets']} current) "
+        f"and {result['assets']} assets from {args.index_url}"
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/verify_nightly_release.py
+++ b/scripts/verify_nightly_release.py
@@ -110,15 +110,15 @@ def verify_release(index_url, expected_sha, fetch=fetch_bytes):
         versions = {manifest['version'] for manifest in manifests.values()}
         if len(revisions) != 1 or len(sdk_revisions) != 1 or len(versions) != 1:
             raise ValueError(f'{target_id} compatibility manifest revisions differ')
-        is_current = manifests['global']['crossmuxSha'] == expected_sha
-        if is_current:
-            comparable = [
-                {key: value for key, value in manifest.items() if key != 'flavor'}
-                for manifest in manifests.values()
-            ]
-            if comparable[0] != comparable[1]:
-                raise ValueError(f'{target_id} compatibility manifests differ beyond flavor')
-            current_targets += 1
+        if revisions != {expected_sha}:
+            raise ValueError(f'{target_id} does not point to the current revision')
+        comparable = [
+            {key: value for key, value in manifest.items() if key != 'flavor'}
+            for manifest in manifests.values()
+        ]
+        if comparable[0] != comparable[1]:
+            raise ValueError(f'{target_id} compatibility manifests differ beyond flavor')
+        current_targets += 1
 
         expected = expected_assets(target_id)
         seen_urls = set()
@@ -131,7 +131,7 @@ def verify_release(index_url, expected_sha, fetch=fetch_bytes):
                 name = asset.get('name') if isinstance(asset, dict) else None
                 if not isinstance(asset, dict) or asset.get('role') != role or not isinstance(
                     name, str
-                ) or not ASSET_NAME.fullmatch(name) or (is_current and name != neutral_name) or asset.get(
+                ) or not ASSET_NAME.fullmatch(name) or name != neutral_name or asset.get(
                     'offset'
                 ) != offset or type(asset.get('size')) is not int or asset['size'] <= 0 or not SHA256.fullmatch(
                     str(asset.get('sha256', ''))
@@ -147,11 +147,9 @@ def verify_release(index_url, expected_sha, fetch=fetch_bytes):
                 if len(data) != asset['size'] or hashlib.sha256(data).hexdigest() != asset['sha256']:
                     raise ValueError(f'{target_id}/{name} failed size or SHA-256 verification')
                 asset_count += 1
-        if is_current and any(len(urls) != 1 for urls in role_urls.values()):
+        if any(len(urls) != 1 for urls in role_urls.values()):
             raise ValueError(f'{target_id} compatibility manifests do not share one binary set')
 
-    if current_targets == 0:
-        raise ValueError('published index did not advance any target to the current revision')
     return {'targets': len(targets), 'currentTargets': current_targets, 'assets': asset_count}
 
 


### PR DESCRIPTION
## Summary
- publish one regional-neutral binary set per Nightly hardware target with two compatibility manifests
- require all seven targets to succeed before either regional publication starts
- fail closed when previous GitHub/COS indexes cannot be loaded and serialize Nightly publication
- verify both published indexes, manifests, sizes, and SHA-256 values before cleanup
- retain the current build and every build referenced by the previous index, then delete older GitHub Releases/tags and COS prefixes
- remove the legacy rolling `firmware-cn.bin` independently of C3 build success

At steady state this keeps the current and previous successful Nightly. The first complete run may retain multiple prior build IDs because the live indexes currently contain target-level fallbacks; the following complete run converges to two.

Companion web compatibility PR: https://github.com/0x1abin/crossmux-web/pull/64

## Validation
- `python3 -m unittest scripts.tests.test_nightly_release` (23 tests)
- Python syntax checks for index, retention, and publication verification scripts
- Nightly workflow YAML and dependency structure checks
- live read-only parsing of the current GitHub and COS indexes
- COSCLI v1.0.8 checksum and cleanup flag verification
- C3 `gh_release_rc` and S3 `sticky_nightly` builds
- X4/Sticky packaging and `sha256sum -c` smoke checks
- `git diff --check`