### PR TITLE
ci: validate stable release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: Validate release tag
+        run: |
+          version="$(python3 -c 'import configparser; config = configparser.ConfigParser(); config.read("platformio.ini"); print(config["crosspoint"]["version"])')"
+          case "$GITHUB_REF_NAME" in
+            "$version"|"v$version") ;;
+            *) echo "::error::Release tag $GITHUB_REF_NAME does not match firmware version $version"; exit 1 ;;
+          esac
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
## Summary
- read the firmware version from `platformio.ini` before the Stable build
- accept only `<version>` or `v<version>` tags
- fail before compilation when the release tag and embedded firmware version differ

Stable asset names and the `firmware-cn.bin` compatibility asset are unchanged.

## Validation
- current version tag passes
- current version with a `v` prefix passes
- a mismatched version tag fails
- `git diff --check`