### PR TITLE
fix(eego-a4): restore deep-sleep wake

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,7 +446,6 @@ void setup() {
   const auto onboardingMode =
       settingsLoaded ? LanguageSelectActivity::Mode::Upgrade : LanguageSelectActivity::Mode::Initial;
   const bool requiresOnboarding = CrossPointSettings::requiresOnboarding(SETTINGS.onboardingVersion);
-  Frontlight.begin(SETTINGS.frontlightBrightness, SETTINGS.frontlightWarmth, SETTINGS.frontlightOn != 0);
 #ifndef SIMULATOR
   halClock.setUseChinaServers(SETTINGS.contentProfile == CrossPointSettings::ContentProfile::China);
 #endif
@@ -487,6 +486,8 @@ void setup() {
     default:
       break;
   }
+
+  Frontlight.begin(SETTINGS.frontlightBrightness, SETTINGS.frontlightWarmth, SETTINGS.frontlightOn != 0);
 
   // Recovery firmware mode: hold a side button together with power at boot. X4 Pro uses
   // BTN_DOWN/GPIO7 because BTN_UP/GPIO0 is an ESP32-S3 boot strap; other boards keep BTN_UP.


### PR DESCRIPTION
## Summary

- advance FreeInk SDK to [freeink-sdk#13](https://github.com/0x1abin/freeink-sdk/pull/13), which retains EEGO GPIO4 through deep sleep
- initialize the frontlight only after power-button and USB wake validation
- leave onboarding auto-sleep and every non-EEGO latch policy unchanged

## Root cause

The SDK upstream sync removed fork-only `power.latch0/1` sleep holds. EEGO still declares GPIO4 as its active-high battery latch, so auto-sleep could drop power and make the next press a cold boot. If that boot failed the existing press-duration check, the early return to sleep bypassed normal frontlight shutdown and left a lit but unresponsive retained screen.

## Validation

- `git diff --check` in both repositories
- `./bin/clang-format-fix --check`
- `pio run -e eego_a4 -e simulator_eego_a4`
- EEGO build: 64,572 B static RAM; 5,654,798 B flash

## Hardware follow-up

- verify GPIO3 low, GPIO6 off, GPIO4 held high, and GPIO8 wake
- confirm `ESP_RST_DEEPSLEEP` rather than `ESP_RST_POWERON`
- cover invalid short press, valid long press, and USB connect/disconnect across three sleep-wake cycles