### PR TITLE
ci: preserve COS version status output

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -360,11 +360,12 @@ jobs:
           COS_REGION: ${{ secrets.COS_REGION }}
         run: |
           set -euo pipefail
-          cos_args=(--init-skip --disable-log -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
+          cos_args=(--init-skip -i "$COS_SECRET_ID" -k "$COS_SECRET_KEY" \
             -e "cos.${COS_REGION}.myqcloud.com")
           if [ -n "$COS_SESSION_TOKEN" ]; then
             cos_args+=(--token "$COS_SESSION_TOKEN")
           fi
+          quiet_cos_args=(--disable-log "${cos_args[@]}")
           versioning="$("$RUNNER_TEMP/coscli" bucket-versioning --method get \
             "${cos_args[@]}" "cos://${COS_BUCKET}")"
           list_args=(--limit -1)
@@ -373,7 +374,7 @@ jobs:
             list_args+=(--recursive --all-versions)
             rm_args+=(--all-versions)
           fi
-          "$RUNNER_TEMP/coscli" ls "${cos_args[@]}" \
+          "$RUNNER_TEMP/coscli" ls "${quiet_cos_args[@]}" \
             "cos://${COS_BUCKET}/firmware/builds/" "${list_args[@]}" \
             > cos-builds.txt
           python3 scripts/nightly_retention.py \
@@ -383,7 +384,7 @@ jobs:
             --candidates cos-builds.txt \
             > obsolete-cos-builds.txt
           while IFS= read -r build_id; do
-            if ! "$RUNNER_TEMP/coscli" rm "${cos_args[@]}" \
+            if ! "$RUNNER_TEMP/coscli" rm "${quiet_cos_args[@]}" \
               "cos://${COS_BUCKET}/firmware/builds/${build_id}/" "${rm_args[@]}" \
               --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
               find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -78,6 +78,11 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertIn('cos://${COS_BUCKET}/firmware/builds/${build_id}/', workflow)
         self.assertIn('--cleanup-tag --yes', workflow)
         self.assertIn('--recursive --force', workflow)
+        cleanup = workflow.split('- name: Delete obsolete COS Nightly builds', 1)[1]
+        self.assertIn('quiet_cos_args=(--disable-log "${cos_args[@]}")', cleanup)
+        versioning = cleanup.split('versioning=', 1)[1].split('list_args=', 1)[0]
+        self.assertIn('"${cos_args[@]}"', versioning)
+        self.assertNotIn('quiet_cos_args', versioning)
 
     def test_package_contains_one_binary_set_and_two_compatible_manifests(self):
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- keep COSCLI logging enabled only for the bucket-versioning query
- retain quiet output for object listing and deletion
- prevent regression with a workflow assertion

## Root cause
COSCLI v1.0.8 sends the version status through its logger. Passing --disable-log discarded the status, so cleanup never selected --all-versions.

## Verification
- python3 -m unittest scripts.tests.test_nightly_release
- git diff --check

Follow-up to the Nightly acceptance run: https://github.com/0x1abin/crossmux/actions/runs/33154281196