### PR TITLE
ci: align hardware package smoke test

### DIFF
--- a/.github/workflows/hardware-ci.yml
+++ b/.github/workflows/hardware-ci.yml
@@ -141,8 +141,6 @@ jobs:
         run: |
           set -euo pipefail
           for target in sticky xteink_x4_pro m5stack_paper_mono eego_a4 murphy_m4 waveshare_epaper_397; do
-            python3 scripts/package_nightly_target.py "$target" --flavor global
-            python3 scripts/package_nightly_target.py "$target" --flavor zh-CN
-            (cd "dist/$target/global" && sha256sum --check *-SHA256SUMS)
-            (cd "dist/$target/cn" && sha256sum --check *-SHA256SUMS)
+            python3 scripts/package_nightly_target.py "$target"
+            (cd "dist/$target" && sha256sum --check *-SHA256SUMS)
           done

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -49,12 +49,15 @@ class NightlyTargetTest(unittest.TestCase):
 
     def test_workflow_packages_one_binary_set(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        hardware_workflow = (ROOT / '.github/workflows/hardware-ci.yml').read_text()
         self.assertIn("find artifacts -type f -print", workflow)
         self.assertNotIn("find artifacts -path '*/global/*'", workflow)
         self.assertEqual(workflow.count('python3 scripts/package_nightly_target.py "${{ matrix.targetId }}"'), 1)
         self.assertNotIn('for flavor in global cn', workflow)
         self.assertIn('cp "$c3_artifact/xteink-firmware.bin" firmware.bin', workflow)
         self.assertIn('gh release delete-asset nightly firmware-cn.bin', workflow)
+        self.assertNotIn('--flavor', hardware_workflow)
+        self.assertIn('(cd "dist/$target" && sha256sum --check *-SHA256SUMS)', hardware_workflow)
 
     def test_workflow_fails_closed_and_verifies_both_regions(self):
         workflow = (ROOT / '.github/workflows/nightly.yml').read_text()


### PR DESCRIPTION
## Summary
- remove obsolete per-flavor Nightly packaging calls from Hardware CI
- verify the unified target directory checksum once
- add a static regression assertion

Follow-up to #251.

## Verification
- `python3 -m unittest scripts.tests.test_nightly_release`
- `git diff --check`