### PR TITLE
ci: make nightly cleanup retry-safe

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,6 +83,8 @@ jobs:
   publish_github:
     needs: [prepare, build]
     runs-on: ubuntu-latest
+    outputs:
+      build_tag: ${{ steps.build.outputs.build_tag }}
     permissions:
       contents: write
     env:
@@ -92,6 +94,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - id: build
+        run: echo "build_tag=$BUILD_TAG" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:
@@ -179,6 +184,8 @@ jobs:
   publish_cn:
     needs: [prepare, build]
     runs-on: [self-hosted, Linux, X64, h2o]
+    outputs:
+      build_id: ${{ steps.build.outputs.build_id }}
     permissions:
       contents: read
     env:
@@ -187,6 +194,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - id: build
+        run: echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:
@@ -292,12 +302,12 @@ jobs:
             --expected-sha "$GITHUB_SHA"
 
   cleanup_github:
-    needs: verify_publish
+    needs: [verify_publish, publish_github]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
-      BUILD_TAG: nightly-build-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+      BUILD_TAG: ${{ needs.publish_github.outputs.build_tag }}
     steps:
       - uses: actions/checkout@v6
 
@@ -325,12 +335,12 @@ jobs:
           done < obsolete-github-builds.txt
 
   cleanup_cn:
-    needs: verify_publish
+    needs: [verify_publish, publish_cn]
     runs-on: [self-hosted, Linux, X64, h2o]
     permissions:
       contents: read
     env:
-      BUILD_ID: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+      BUILD_ID: ${{ needs.publish_cn.outputs.build_id }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -371,7 +381,6 @@ jobs:
           list_args=(--limit -1)
           rm_args=(--recursive --force)
           if grep -Eq 'Enabled|Suspended' <<< "$versioning"; then
-            list_args+=(--recursive --all-versions)
             rm_args+=(--all-versions)
           fi
           "$RUNNER_TEMP/coscli" ls "${quiet_cos_args[@]}" \

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -74,8 +74,10 @@ class NightlyTargetTest(unittest.TestCase):
         verify = workflow.split('  verify_publish:', 1)[1]
         self.assertIn('needs: [publish_github, publish_cn]', verify)
         self.assertEqual(verify.count('python3 scripts/verify_nightly_release.py'), 2)
-        self.assertIn('  cleanup_github:\n    needs: verify_publish', workflow)
-        self.assertIn('  cleanup_cn:\n    needs: verify_publish', workflow)
+        self.assertIn(
+            '  cleanup_github:\n    needs: [verify_publish, publish_github]', workflow
+        )
+        self.assertIn('  cleanup_cn:\n    needs: [verify_publish, publish_cn]', workflow)
         self.assertEqual(workflow.count('python3 scripts/nightly_retention.py'), 2)
         self.assertIn('gh release delete "$build_tag"', workflow)
         self.assertIn('cos://${COS_BUCKET}/firmware/builds/${build_id}/', workflow)
@@ -164,6 +166,14 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertIn('cos://${COS_BUCKET}/firmware/builds/', workflow)
         self.assertIn('cos_args+=(--token "$COS_SESSION_TOKEN")', workflow)
         self.assertIn('--fail-output-path "$RUNNER_TEMP/coscli-errors"', workflow)
+
+    def test_cleanup_reuses_the_published_attempt_and_lists_current_cos_objects_only(self):
+        workflow = (ROOT / '.github/workflows/nightly.yml').read_text()
+        self.assertIn('BUILD_TAG: ${{ needs.publish_github.outputs.build_tag }}', workflow)
+        self.assertIn('BUILD_ID: ${{ needs.publish_cn.outputs.build_id }}', workflow)
+        cleanup = workflow.split('  cleanup_cn:', 1)[1]
+        self.assertNotIn('list_args+=(--recursive --all-versions)', cleanup)
+        self.assertIn('rm_args+=(--all-versions)', cleanup)
         self.assertIn('-name error.report -exec cat {} +', workflow)
 
     def write_image(self, chip_id=0x0009, board='eego_a4'):


### PR DESCRIPTION
Fix the final Nightly acceptance failures:

- preserve the immutable build ID/tag from the publish jobs when cleanup-only reruns increment `run_attempt`
- list only current COS build prefixes to avoid timing out on every historical object version
- continue deleting all versions under each obsolete build prefix

Validation: `python3 -m unittest scripts.tests.test_nightly_release` (24 passed), `git diff --check`.