### PR TITLE
ci: retry incomplete nightly downloads

### DIFF
--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -19,6 +19,21 @@ import verify_nightly_release
 
 
 class NightlyTargetTest(unittest.TestCase):
+    def test_fetch_retries_incomplete_reads(self):
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.side_effect = [
+            verify_nightly_release.http.client.IncompleteRead(b'partial', 1),
+            b'complete',
+        ]
+        with mock.patch.object(
+            verify_nightly_release.urllib.request, 'urlopen', return_value=response
+        ) as urlopen, mock.patch.object(verify_nightly_release.time, 'sleep'):
+            self.assertEqual(
+                verify_nightly_release.fetch_bytes('https://assets.crossmux.cn/asset.bin'),
+                b'complete',
+            )
+        self.assertEqual(urlopen.call_count, 2)
+
     def test_matrix_has_c3_and_six_s3_targets(self):
         matrix = package_nightly_target.matrix()['include']
         self.assertEqual(len(matrix), 7)

--- a/scripts/verify_nightly_release.py
+++ b/scripts/verify_nightly_release.py
@@ -3,6 +3,7 @@
 
 import argparse
 import hashlib
+import http.client
 import json
 import re
 import time
@@ -26,7 +27,7 @@ def fetch_bytes(url, attempts=3):
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
                 return response.read()
-        except (urllib.error.URLError, TimeoutError) as error:
+        except (http.client.IncompleteRead, urllib.error.URLError, TimeoutError) as error:
             if attempt + 1 == attempts:
                 raise RuntimeError(f'failed to download {url}: {error}') from error
             time.sleep(2 ** attempt)


### PR DESCRIPTION
Retry `http.client.IncompleteRead` with the verifier's existing three-attempt exponential backoff. This covers transient CDN/COS connection truncation without changing firmware or OTA contracts.

Validation: `python3 -m unittest scripts.tests.test_nightly_release` (25 passed), `git diff --check`.