### PR TITLE
ci: finalize COS nightly cleanup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -375,17 +375,24 @@ jobs:
           if [ -n "$COS_SESSION_TOKEN" ]; then
             cos_args+=(--token "$COS_SESSION_TOKEN")
           fi
-          quiet_cos_args=(--disable-log "${cos_args[@]}")
-          versioning="$("$RUNNER_TEMP/coscli" bucket-versioning --method get \
-            "${cos_args[@]}" "cos://${COS_BUCKET}")"
+          if ! versioning="$("$RUNNER_TEMP/coscli" bucket-versioning --method get \
+            "${cos_args[@]}" "cos://${COS_BUCKET}" 2>&1)"; then
+            printf '%s\n' "$versioning"
+            echo "::error::COS versioning lookup failed; verify cos:GetBucketVersioning"
+            exit 1
+          fi
           list_args=(--limit -1)
           rm_args=(--recursive --force)
           if grep -Eq 'Enabled|Suspended' <<< "$versioning"; then
             rm_args+=(--all-versions)
           fi
-          "$RUNNER_TEMP/coscli" ls "${quiet_cos_args[@]}" \
+          if ! "$RUNNER_TEMP/coscli" ls "${cos_args[@]}" \
             "cos://${COS_BUCKET}/firmware/builds/" "${list_args[@]}" \
-            > cos-builds.txt
+            > cos-builds.txt 2>&1; then
+            cat cos-builds.txt
+            echo "::error::COS object listing failed; verify cos:GetBucket"
+            exit 1
+          fi
           python3 scripts/nightly_retention.py \
             --storage cos \
             --current "$BUILD_ID" \
@@ -393,7 +400,7 @@ jobs:
             --candidates cos-builds.txt \
             > obsolete-cos-builds.txt
           while IFS= read -r build_id; do
-            if ! "$RUNNER_TEMP/coscli" rm "${quiet_cos_args[@]}" \
+            if ! "$RUNNER_TEMP/coscli" rm "${cos_args[@]}" \
               "cos://${COS_BUCKET}/firmware/builds/${build_id}/" "${rm_args[@]}" \
               --fail-output-path "$RUNNER_TEMP/coscli-errors"; then
               find "$RUNNER_TEMP/coscli-errors" -type f -name error.report -exec cat {} + \

--- a/docs/engineering/firmware-release.md
+++ b/docs/engineering/firmware-release.md
@@ -58,11 +58,11 @@ writing any immutable COS object and passes credentials directly to each COS
 command instead of persisting a CLI config file. Required repository secrets
 are `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET`, and `COS_REGION`;
 `COS_SESSION_TOKEN` is optional. Gitee is not a firmware release destination.
-The COS identity also needs `cos:GetBucketVersioning`,
-`cos:GetBucketObjectVersions`, `cos:DeleteObject`, and
-`cos:DeleteMultipleObjects`. Cleanup detects versioned buckets and removes
-every version of an obsolete build prefix rather than leaving hidden historical
-objects.
+The COS identity also needs `cos:GetBucket` for the current-object listing,
+`cos:GetBucketVersioning` to detect the bucket state,
+`cos:GetBucketObjectVersions` for versioned cleanup, `cos:DeleteObject`, and
+`cos:DeleteMultipleObjects`. Cleanup detects versioned buckets and removes every
+version of an obsolete build prefix rather than leaving hidden historical objects.
 
 ## Index contract and failure behavior
 

--- a/scripts/tests/test_nightly_release.py
+++ b/scripts/tests/test_nightly_release.py
@@ -99,10 +99,10 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertIn('--cleanup-tag --yes', workflow)
         self.assertIn('--recursive --force', workflow)
         cleanup = workflow.split('- name: Delete obsolete COS Nightly builds', 1)[1]
-        self.assertIn('quiet_cos_args=(--disable-log "${cos_args[@]}")', cleanup)
         versioning = cleanup.split('versioning=', 1)[1].split('list_args=', 1)[0]
         self.assertIn('"${cos_args[@]}"', versioning)
-        self.assertNotIn('quiet_cos_args', versioning)
+        self.assertIn('cos:GetBucketVersioning', versioning)
+        self.assertIn('2>&1', versioning)
 
     def test_package_contains_one_binary_set_and_two_compatible_manifests(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -190,6 +190,13 @@ class NightlyTargetTest(unittest.TestCase):
         self.assertNotIn('list_args+=(--recursive --all-versions)', cleanup)
         self.assertIn('rm_args+=(--all-versions)', cleanup)
         self.assertIn('-name error.report -exec cat {} +', workflow)
+        self.assertNotIn('--disable-log', cleanup)
+        listing = cleanup.split('if ! "$RUNNER_TEMP/coscli" ls', 1)[1].split(
+            'python3 scripts/nightly_retention.py', 1
+        )[0]
+        self.assertIn('"${cos_args[@]}"', listing)
+        self.assertIn('cos:GetBucket', listing)
+        self.assertIn('2>&1', listing)
 
     def write_image(self, chip_id=0x0009, board='eego_a4'):
         image = bytearray(24)


### PR DESCRIPTION
## Summary
- surface COS versioning and object-list permission failures
- keep cleanup fail-closed while preserving delete reports
- document the required cos:GetBucket permission

## Validation
- python3 -m unittest scripts.tests.test_nightly_release
- local fake-COSCLI matrix: disabled, enabled, suspended, version/list denial, partial delete failure
- git diff --check