### PR TITLE
refactor(m4): positively identify batch one

### DIFF
--- a/docs/engineering/murphy-m4.md
+++ b/docs/engineering/murphy-m4.md
@@ -35,18 +35,26 @@ has no Home key, so `H` is ignored. It does not replace hardware tests for
 display batches/ghosting, FT6336U IRQ/reset behavior, SDMMC contention, PWM
 curves, PSRAM, or standby current.
 
-M4 batch detection runs before the normal GPIO input setup. R13 is a second
-100 kΩ pull-up in parallel on GPIO1/KEY1; together with the key's 100 nF
-capacitor it halves the charge time on batch 2. The firmware measures seven
-50%-charge times in a fixed 28-byte stack array, caches only a result outside
-the guard band in NVS key `cphw/m4_batch_v1`, and otherwise falls back to batch
-2 without caching. A pressed Up key therefore cannot permanently select the
-wrong batch. `HalGPIO::begin()` applies the result to touch before input starts;
-`HalDisplay::begin()` reads the same HAL state before constructing the immutable
-SSD1677 batch configuration. No batch state allocates from the heap.
+M4 batch detection runs before the normal GPIO input setup. GPIO1/KEY1 has a
+100 kΩ pull-up and 100 nF capacitor and serves as the reference channel.
+GPIO2/KEY2 has the same network; R13 is a second 100 kΩ pull-up in parallel on
+that channel and should halve its charge time on batch 2. The firmware measures
+seven paired 50%-charge times in two fixed arrays (56 stack bytes). It confirms
+batch 1 only when both medians are 5200–10000 µs and GPIO2/GPIO1 is 75–125%.
+Any pressed key, failed discharge, timeout, out-of-range sample, ratio mismatch,
+or other result uses the market-default batch 2.
+
+Only a confirmed batch 1 is cached in `cphw/m4_batch_v2`. A cached First value
+is restored directly; Second, damaged, and missing values trigger a fresh safe
+probe and are not deleted. Batch 2 is never written, so it is rechecked on each
+boot and remains the fallback. `HalGPIO::begin()` applies the result to touch
+before input starts; `HalDisplay::begin()` reads the same HAL state before
+constructing the immutable SSD1677 batch configuration. The probe uses no heap
+allocation.
 [ESP32-S3 Datasheet v2.2](https://documentation.espressif.com/esp32_s3_datasheet_en.pdf)
-Table 2-8 maps GPIO1 to ADC1_CH0; its documented 60 µs power-up low glitch is
-also shorter than the 50 ms settle delay before the charged reference sample.
+Table 2-8 maps GPIO1 to ADC1_CH0 and GPIO2 to ADC1_CH1; its documented 60 µs
+power-up low glitch is also shorter than the 50 ms settle delay before the
+charged reference samples.
 
 Batch 1 (no R13) uses the `0x3C` pseudo-temperature and touch short-axis range
 `[-52,553]`; batch 2 (R13 fitted) uses `0x50` and `[-47,514]`. The selected
@@ -54,10 +62,14 @@ temperature is applied to HALF and window refreshes. For recovery or hardware
 diagnostics, `-DFREEINK_MURPHY_M4_BATCH1=1` forces batch 1 and bypasses the
 probe. The product UI deliberately has no manual batch setting.
 
-First-batch hardware validation measured 101 charge-time samples on GPIO1:
-median 6008 µs, range 6004–6059 µs, and coefficient of variation 0.379%.
-This passes the batch-1 interval and 10% stability gate. Second-batch hardware
-validation remains required before removing the experimental release gate.
+The available GPIO1 reference-channel data is stable: first-batch hardware
+measured a 6008 µs median across 101 samples (6004–6059 µs, 0.379% coefficient
+of variation), while known second-batch hardware measured 6218 µs
+(6170–6233 µs, 101/101 valid). Their overlap proves GPIO1 alone cannot identify
+the batch. GPIO2/R13 has not been sampled on hardware, so the production rule
+does not attempt to identify batch 2; it only confirms the no-R13 first-batch
+topology and otherwise uses batch 2. A first-batch restart log has confirmed
+that an existing `m4_batch_v2=First` cache still restores batch 1.
 
 The first-batch input build was also sampled for 70 seconds after startup. The
 touch task retained at least 1120 bytes of its 3072-byte static stack while
@@ -89,11 +101,12 @@ and app at `0x10000` without overwriting NVS.
 
 ## Hardware release gate
 
-- Verify direction, edge pattern, Full/Fast/Half/window/grayscale and ghosting
-  on the second display batch; the first-batch RC probe stability gate is
-  complete. Confirm first boot probes and caches the right batch, later boots
-  use the cache, and holding Up during an uncached probe cannot persist a
-  result.
+- Before changing the first-batch gate, measure paired GPIO1/GPIO2 RC samples
+  and verify its absolute and ratio bounds. Confirm only a positive first-batch
+  result is cached, a later boot restores that cache, and holding Up or Down
+  during an uncached probe cannot persist a result. Verify direction, edge
+  pattern, Full/Fast/Half/window/grayscale and ghosting on the second display
+  batch.
 - Verify four-corner touch, swipes and rotations, including a short touch while
   an e-paper refresh blocks the main loop; confirm GPIO46 remains unusable and
   that GPIO7 display reset is followed by successful FT6336U reinitialization

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -10,6 +10,13 @@
 
 #include "Waveshare397Power.h"
 
+#if FREEINK_DEVICE_MURPHY_M4
+#include <array>
+#include <optional>
+
+#include "MurphyM4BatchDetection.h"
+#endif
+
 #if FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_WAVESHARE_EPAPER_397
 #include <soc/usb_serial_jtag_reg.h>
 #endif
@@ -53,7 +60,8 @@ constexpr char HW_NAMESPACE[] = "cphw";
 constexpr char NVS_KEY_DEV_OVERRIDE[] = "dev_ovr";  // 0=auto, 1=x4, 2=x3
 constexpr char NVS_KEY_DEV_CACHED[] = "dev_det";    // 0=unknown, 1=x4, 2=x3
 #if FREEINK_DEVICE_MURPHY_M4
-constexpr char NVS_KEY_M4_BATCH[] = "m4_batch_v1";
+constexpr char NVS_KEY_M4_BATCH[] = "m4_batch_v2";
+constexpr uint8_t NVS_M4_BATCH_FIRST = 1;
 constexpr uint16_t M4_CHARGED_ADC_MIN = 3000;
 constexpr uint32_t M4_CHARGE_SETTLE_MS = 50;
 constexpr uint32_t M4_DISCHARGE_US = 2000;
@@ -134,48 +142,71 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 }
 
 #if FREEINK_DEVICE_MURPHY_M4
-enum class NvsMurphyM4Batch : uint8_t { Unknown = 0, First = 1, Second = 2 };
+bool hasCachedFirstMurphyM4Batch() { return readNvsUChar(NVS_KEY_M4_BATCH, 0) == NVS_M4_BATCH_FIRST; }
 
-NvsMurphyM4Batch readNvsMurphyM4Batch() {
-  const uint8_t raw = readNvsUChar(NVS_KEY_M4_BATCH, static_cast<uint8_t>(NvsMurphyM4Batch::Unknown));
-  if (raw > static_cast<uint8_t>(NvsMurphyM4Batch::Second)) return NvsMurphyM4Batch::Unknown;
-  return static_cast<NvsMurphyM4Batch>(raw);
-}
+struct MurphyM4ProbePin {
+  uint8_t pin;
+  uint16_t chargedAdc = 0;
+};
 
-freeink::MurphyM4BatchProbe probeMurphyM4Batch(uint32_t* medianOut) {
-  const int8_t pin = BoardConfig::ACTIVE.input.up;
-  if (pin < 0) return freeink::MurphyM4BatchProbe::Inconclusive;
+struct MurphyM4ProbeMeasurement {
+  uint32_t referenceMedianUs = 0;
+  uint32_t targetMedianUs = 0;
+};
 
-  analogSetPinAttenuation(static_cast<uint8_t>(pin), ADC_11db);
+std::optional<MurphyM4ProbePin> configureMurphyM4ProbePin(const int8_t pin) {
+  if (pin < 0) return std::nullopt;
   const gpio_num_t gpioPin = static_cast<gpio_num_t>(pin);
+  analogSetPinAttenuation(static_cast<uint8_t>(pin), ADC_11db);
   gpio_set_pull_mode(gpioPin, GPIO_FLOATING);
   gpio_set_direction(gpioPin, GPIO_MODE_INPUT);
-  delay(M4_CHARGE_SETTLE_MS);
+  return MurphyM4ProbePin{static_cast<uint8_t>(pin)};
+}
 
-  const uint16_t chargedAdc = analogRead(pin);
-  if (chargedAdc < M4_CHARGED_ADC_MIN) return freeink::MurphyM4BatchProbe::Inconclusive;
-
-  std::array<uint32_t, freeink::MURPHY_M4_BATCH_SAMPLE_COUNT> riseTimes{};
-  for (auto& riseTime : riseTimes) {
-    gpio_set_level(gpioPin, 0);
-    gpio_set_direction(gpioPin, GPIO_MODE_OUTPUT);
-    delayMicroseconds(M4_DISCHARGE_US);
-    if (analogRead(pin) > chargedAdc / 10) {
-      gpio_set_direction(gpioPin, GPIO_MODE_INPUT);
-      return freeink::MurphyM4BatchProbe::Inconclusive;
-    }
-
+std::optional<uint32_t> measureMurphyM4RiseTime(const MurphyM4ProbePin& probePin) {
+  const gpio_num_t gpioPin = static_cast<gpio_num_t>(probePin.pin);
+  gpio_set_level(gpioPin, 0);
+  gpio_set_direction(gpioPin, GPIO_MODE_OUTPUT);
+  delayMicroseconds(M4_DISCHARGE_US);
+  if (analogRead(probePin.pin) > probePin.chargedAdc / 10) {
     gpio_set_direction(gpioPin, GPIO_MODE_INPUT);
-    const uint32_t startedAt = micros();
-    while (analogRead(pin) < chargedAdc / 2) {
-      if (micros() - startedAt > M4_RISE_TIMEOUT_US) return freeink::MurphyM4BatchProbe::Inconclusive;
-    }
-    riseTime = micros() - startedAt;
+    return std::nullopt;
   }
 
-  const uint32_t median = freeink::medianMurphyM4RiseTime(riseTimes);
-  if (medianOut) *medianOut = median;
-  return freeink::classifyMurphyM4RiseTime(median);
+  gpio_set_direction(gpioPin, GPIO_MODE_INPUT);
+  const uint32_t startedAt = micros();
+  while (analogRead(probePin.pin) < probePin.chargedAdc / 2) {
+    if (micros() - startedAt > M4_RISE_TIMEOUT_US) return std::nullopt;
+  }
+  return micros() - startedAt;
+}
+
+std::optional<MurphyM4ProbeMeasurement> probeMurphyM4Batch() {
+  auto referencePin = configureMurphyM4ProbePin(BoardConfig::ACTIVE.input.up);
+  auto targetPin = configureMurphyM4ProbePin(BoardConfig::ACTIVE.input.down);
+  if (!referencePin || !targetPin || referencePin->pin == targetPin->pin) {
+    return std::nullopt;
+  }
+
+  delay(M4_CHARGE_SETTLE_MS);
+  referencePin->chargedAdc = analogRead(referencePin->pin);
+  targetPin->chargedAdc = analogRead(targetPin->pin);
+  if (referencePin->chargedAdc < M4_CHARGED_ADC_MIN || targetPin->chargedAdc < M4_CHARGED_ADC_MIN) {
+    return std::nullopt;
+  }
+
+  std::array<uint32_t, MurphyM4BatchDetection::SAMPLE_COUNT> referenceRiseTimes{};
+  std::array<uint32_t, MurphyM4BatchDetection::SAMPLE_COUNT> targetRiseTimes{};
+  for (std::size_t index = 0; index < referenceRiseTimes.size(); ++index) {
+    const auto referenceRiseTime = measureMurphyM4RiseTime(*referencePin);
+    const auto targetRiseTime = measureMurphyM4RiseTime(*targetPin);
+    if (!referenceRiseTime || !targetRiseTime) return std::nullopt;
+    referenceRiseTimes[index] = *referenceRiseTime;
+    targetRiseTimes[index] = *targetRiseTime;
+  }
+
+  return MurphyM4ProbeMeasurement{MurphyM4BatchDetection::median(referenceRiseTimes),
+                                  MurphyM4BatchDetection::median(targetRiseTimes)};
 }
 
 freeink::MurphyM4Batch detectMurphyM4Batch() {
@@ -183,30 +214,27 @@ freeink::MurphyM4Batch detectMurphyM4Batch() {
   LOG_INF("HW", "Murphy M4 batch forced to first by build flag");
   return freeink::MurphyM4Batch::First;
 #else
-  switch (readNvsMurphyM4Batch()) {
-    case NvsMurphyM4Batch::First:
-      LOG_INF("HW", "Murphy M4 batch 1 from NVS cache");
-      return freeink::MurphyM4Batch::First;
-    case NvsMurphyM4Batch::Second:
-      LOG_INF("HW", "Murphy M4 batch 2 from NVS cache");
-      return freeink::MurphyM4Batch::Second;
-    case NvsMurphyM4Batch::Unknown:
-      break;
+  if (hasCachedFirstMurphyM4Batch()) {
+    LOG_INF("HW", "Murphy M4 batch 1 from NVS cache");
+    return freeink::MurphyM4Batch::First;
   }
 
-  uint32_t medianUs = 0;
-  switch (probeMurphyM4Batch(&medianUs)) {
-    case freeink::MurphyM4BatchProbe::First:
-      writeNvsUChar(NVS_KEY_M4_BATCH, static_cast<uint8_t>(NvsMurphyM4Batch::First));
-      LOG_INF("HW", "Murphy M4 batch probe: first (median=%lu us)", static_cast<unsigned long>(medianUs));
-      return freeink::MurphyM4Batch::First;
-    case freeink::MurphyM4BatchProbe::Second:
-      writeNvsUChar(NVS_KEY_M4_BATCH, static_cast<uint8_t>(NvsMurphyM4Batch::Second));
-      LOG_INF("HW", "Murphy M4 batch probe: second (median=%lu us)", static_cast<unsigned long>(medianUs));
-      return freeink::MurphyM4Batch::Second;
-    case freeink::MurphyM4BatchProbe::Inconclusive:
-      LOG_ERR("HW", "Murphy M4 batch probe inconclusive; using batch 2 fallback");
-      return freeink::MurphyM4Batch::Second;
+  const auto measurement = probeMurphyM4Batch();
+  if (measurement &&
+      MurphyM4BatchDetection::isFirstBatch(measurement->referenceMedianUs, measurement->targetMedianUs)) {
+    writeNvsUChar(NVS_KEY_M4_BATCH, NVS_M4_BATCH_FIRST);
+    LOG_INF("HW", "Murphy M4 batch probe: first (gpio1=%lu us gpio2=%lu us)",
+            static_cast<unsigned long>(measurement->referenceMedianUs),
+            static_cast<unsigned long>(measurement->targetMedianUs));
+    return freeink::MurphyM4Batch::First;
+  }
+
+  if (measurement) {
+    LOG_INF("HW", "Murphy M4 batch probe did not confirm first (gpio1=%lu us gpio2=%lu us); using batch 2",
+            static_cast<unsigned long>(measurement->referenceMedianUs),
+            static_cast<unsigned long>(measurement->targetMedianUs));
+  } else {
+    LOG_ERR("HW", "Murphy M4 batch probe failed; using batch 2");
   }
   return freeink::MurphyM4Batch::Second;
 #endif

--- a/lib/hal/MurphyM4BatchDetection.h
+++ b/lib/hal/MurphyM4BatchDetection.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace MurphyM4BatchDetection {
+
+constexpr std::size_t SAMPLE_COUNT = 7;
+constexpr uint32_t FIRST_BATCH_RISE_MIN_US = 5200;
+constexpr uint32_t FIRST_BATCH_RISE_MAX_US = 10000;
+constexpr uint32_t FIRST_BATCH_RATIO_MIN_PERCENT = 75;
+constexpr uint32_t FIRST_BATCH_RATIO_MAX_PERCENT = 125;
+
+constexpr uint32_t median(std::array<uint32_t, SAMPLE_COUNT>& samples) {
+  for (std::size_t i = 1; i < samples.size(); ++i) {
+    const uint32_t value = samples[i];
+    std::size_t j = i;
+    while (j > 0 && samples[j - 1] > value) {
+      samples[j] = samples[j - 1];
+      --j;
+    }
+    samples[j] = value;
+  }
+  return samples[samples.size() / 2];
+}
+
+constexpr bool isFirstBatch(const uint32_t referenceRiseUs, const uint32_t targetRiseUs) {
+  if (referenceRiseUs < FIRST_BATCH_RISE_MIN_US || referenceRiseUs > FIRST_BATCH_RISE_MAX_US ||
+      targetRiseUs < FIRST_BATCH_RISE_MIN_US || targetRiseUs > FIRST_BATCH_RISE_MAX_US) {
+    return false;
+  }
+
+  const uint64_t scaledTarget = static_cast<uint64_t>(targetRiseUs) * 100;
+  return scaledTarget >= static_cast<uint64_t>(referenceRiseUs) * FIRST_BATCH_RATIO_MIN_PERCENT &&
+         scaledTarget <= static_cast<uint64_t>(referenceRiseUs) * FIRST_BATCH_RATIO_MAX_PERCENT;
+}
+
+}  // namespace MurphyM4BatchDetection

--- a/test/murphy_m4_batch/CMakeLists.txt
+++ b/test/murphy_m4_batch/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(MurphyM4BatchTest MurphyM4BatchTest.cpp)
 
 target_include_directories(MurphyM4BatchTest PRIVATE
+  ${REPO_ROOT}/lib/hal
   ${REPO_ROOT}/freeink-sdk/libs/hardware/BoardConfig/include
 )
 

--- a/test/murphy_m4_batch/MurphyM4BatchTest.cpp
+++ b/test/murphy_m4_batch/MurphyM4BatchTest.cpp
@@ -3,21 +3,32 @@
 #include <array>
 
 #include "MurphyM4Batch.h"
+#include "MurphyM4BatchDetection.h"
 
-TEST(MurphyM4Batch, ClassifiesRiseTimeAndRejectsGuardBand) {
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(2000), freeink::MurphyM4BatchProbe::Second);
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(4500), freeink::MurphyM4BatchProbe::Second);
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(5200), freeink::MurphyM4BatchProbe::First);
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(10000), freeink::MurphyM4BatchProbe::First);
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(4800), freeink::MurphyM4BatchProbe::Inconclusive);
-  EXPECT_EQ(freeink::classifyMurphyM4RiseTime(15000), freeink::MurphyM4BatchProbe::Inconclusive);
+TEST(MurphyM4Batch, ConfirmsOnlyMatchedFirstBatchChannels) {
+  EXPECT_TRUE(MurphyM4BatchDetection::isFirstBatch(6008, 6050));
+  EXPECT_TRUE(MurphyM4BatchDetection::isFirstBatch(5200, 5200));
+  EXPECT_TRUE(MurphyM4BatchDetection::isFirstBatch(10000, 10000));
+  EXPECT_TRUE(MurphyM4BatchDetection::isFirstBatch(5200, 6500));
+  EXPECT_TRUE(MurphyM4BatchDetection::isFirstBatch(10000, 7500));
+}
+
+TEST(MurphyM4Batch, DefaultsOutsideFirstBatchGates) {
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(5199, 5200));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(5200, 5199));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(10001, 10000));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(10000, 10001));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(10000, 5200));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(5200, 6501));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(6218, 3109));
+  EXPECT_FALSE(MurphyM4BatchDetection::isFirstBatch(0, 0));
 }
 
 TEST(MurphyM4Batch, MedianRejectsOutliers) {
-  std::array<uint32_t, freeink::MURPHY_M4_BATCH_SAMPLE_COUNT> samples = {
+  std::array<uint32_t, MurphyM4BatchDetection::SAMPLE_COUNT> samples = {
       6900, 12000, 6800, 7000, 100, 6950, 6850,
   };
-  EXPECT_EQ(freeink::medianMurphyM4RiseTime(samples), 6900U);
+  EXPECT_EQ(MurphyM4BatchDetection::median(samples), 6900U);
 }
 
 TEST(MurphyM4Batch, AppliesReferenceTouchCalibration) {


### PR DESCRIPTION
## Summary

- replace the obsolete GPIO1-only classifier with paired GPIO1/GPIO2 RC measurement
- positively identify only batch 1; every unconfirmed or failed probe uses market-default batch 2
- cache only a confirmed First value in cphw/m4_batch_v2 and preserve the recovery build flag
- keep all new includes and probe code behind FREEINK_DEVICE_MURPHY_M4
- move detection policy out of the SDK public API

Depends on 0x1abin/freeink-sdk#15.

## Detection rule

Both seven-sample medians must be 5200–10000 us and GPIO2/GPIO1 must be 75–125%. The probe retains the existing ADC >= 3000, 50 ms settle, 2 ms discharge, 50% threshold, and 15 ms timeout gates. It uses two fixed seven-item arrays (56 stack bytes) and no heap allocation.

Known GPIO1-only hardware samples overlap: batch 1 median 6008 us and known batch 2 median 6218 us. The new rule therefore does not infer a batch from GPIO1 alone. Existing first-batch logs confirm m4_batch_v2=First cache restoration.

## Validation

- Murphy M4 batch host tests: 4/4 passed
- latest main: murphy_m4 and default builds passed
- isolation matrix passed: sticky, x4pro, eego_a4, waveshare_epaper_397, and papermono
- git diff --check passed in the main repository and SDK

## Risk

GPIO2 paired RC timing has not been captured on hardware. The conservative failure mode is intentional: only a strong batch-1 match selects batch 1; all other results retain batch-2 display and touch parameters. Display waveforms, touch calibration values, buttons, and background touch polling are unchanged.