### PR TITLE
refactor: require manual review for upstream sync

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,98 +1,98 @@
 ---
 name: sync-upstream
-description: Automate and review CrossMux/CrossPoint upstream repository synchronization. Use when the user asks to sync, update, compare, or merge upstream changes, especially upstream/develop, into this repo through a new branch and pull request instead of committing directly on main or the active target branch. Covers overlap review, upstream-preferred conflict policy, remote/base detection, agent sync branch creation, squash-sync fallback, validation builds, pushing to origin, and opening a draft PR.
+description: Inspect, rehearse, and publish approval-gated upstream synchronization for CrossMux, its FreeInk SDK fork, and its CrossPoint Simulator fork. Use when comparing or syncing upstream changes through isolated candidates and separate draft pull requests.
 ---
 
 # Sync Upstream
 
-Use this skill when syncing upstream changes into the current repo. The default
-source is `upstream/develop`, because that is the current upstream integration
-branch for this project. Never commit directly on `main` or the
-super.engineering target branch.
+Synchronize three components in order:
 
-## Primary Command
+1. `Free-Ink/freeink-sdk:main` into `0x1abin/freeink-sdk:main`.
+2. `crosspoint-reader/crosspoint-simulator:main` into
+   `0x1abin/crosspoint-simulator:main`.
+3. `crosspoint-reader/crosspoint-reader:develop` into CrossMux, pinning both
+   reviewed fork revisions.
 
-From the repository root, run:
+Never commit directly on a component's base branch. Never merge a dependency
+pull request or flash hardware as part of this skill.
+
+## Staged workflow
+
+Run one phase at a time from the CrossMux repository root:
 
 ```bash
 python3 .claude/skills/sync-upstream/scripts/sync_upstream.py inspect
-python3 .claude/skills/sync-upstream/scripts/sync_upstream.py run --draft
+python3 .claude/skills/sync-upstream/scripts/sync_upstream.py start --component sdk
+python3 .claude/skills/sync-upstream/scripts/sync_upstream.py publish \
+  --component sdk --candidate /path/printed/by/start --draft
 ```
 
-Private forks can append repeatable build environments, for example
-`--extra-build-env gh_weread_pro`.
+Repeat `start` and `publish` for `simulator`, then `crossmux`. `start` prepares
+an isolated candidate and prints its path; it never commits, pushes, or opens a
+pull request. `publish` is a separate, externally mutating step and requires
+the user's explicit authorization in the current conversation. There is no
+one-command happy path.
 
-`run --draft` does the whole happy path:
+`inspect` always checks all three components. If a dependency fork is behind,
+sync it even when the incoming CrossMux commit does not change that dependency.
+Do not start `simulator` until the SDK fork contains its parent `main`; do not
+start `crossmux` until both dependency forks contain their parent `main` and no
+corresponding sync pull request remains open.
 
-1. Reads the super.engineering target branch with `sc worktree status --json`
-   when available.
-2. Fetches `origin/<base>` and `upstream/develop`.
-3. Creates a new `agent/sync-upstream-develop-<sha>` branch from `origin/<base>`.
-4. Merges upstream without committing yet.
-5. Runs repository sanity checks and both build commands.
-6. Commits, pushes to `origin`, and opens a draft PR.
+## Mandatory manual review
 
-Check the `inspect` output before `run`. If `base_branch` is not the intended
-CrossMux integration branch, pass `--base-branch main` or set the worktree target
-outside this skill before continuing.
+Do not choose a side automatically. Manual review is required for:
 
-If the merge stops with conflicts, resolve them, stage only the intended files,
-then continue with:
+- every Git-unmerged path;
+- every file changed on both sides since their merge base, even if Git merged
+  it cleanly;
+- different files or symbols that replace, duplicate, or alter the same
+  behavior or call path.
 
-```bash
-python3 .claude/skills/sync-upstream/scripts/sync_upstream.py publish --draft
-```
+Before resolving anything, ask the user interactively. Prefer the structured
+user-input control when it is available and present at most three behavior
+decisions per batch. Otherwise ask explicit numbered options and stop for the
+answer. A static conflict report is context, not completed review.
 
-## Conflict Policy
+Present each decision with:
 
-- Review behavioral overlap before resolving file conflicts. When upstream now
-  provides the same capability and satisfies CrossMux business requirements,
-  use the upstream implementation and remove the duplicate local path.
-- Keep a CrossMux-local implementation only for a requirement upstream does not
-  meet. Limit it to that gap and record the reason in the PR body; do not retain
-  parallel implementations merely because the local one landed first.
-- For Chinese support, prefer upstream's generic CJK parsing, layout, rendering,
-  and font mechanisms. Preserve CN-build-only behavior only where upstream does
-  not provide the same offline, first-boot, glyph-coverage, distribution, or
-  flash-budget guarantees.
-- `.skills/SKILL.md` is a thin map. When upstream changes it, follow
-  `docs/engineering/upstream-merge-policy.md`: keep the map thin, route deep
-  content into `docs/engineering/`, and do not drop upstream hunks silently.
-- Preserve CrossMux-local behavior, branding, docs, apps, and release settings
-  unless the user explicitly asks to remove them.
-- For i18n YAML, preserve a union of flat keys. Keep Chinese build behavior and
-  existing translations unless an upstream key intentionally replaces them.
-- For submodules, verify the old directory is clean before removing stale
-  directories, then run `git submodule update --init --recursive`.
-- If an upstream change is intentionally skipped as out of scope, mention the
-  skipped hunk in the PR body.
-- When an upstream change alters a cache layout or pagination, advance the
-  CrossMux per-flavor cache versions above every shipped value and update
-  `docs/file-formats.md`.
+1. the local behavior;
+2. the upstream behavior;
+3. the compatibility and product impact;
+4. a recommendation without treating it as approval.
+
+Offer the local version, upstream version, and any safe combined resolution as
+mutually exclusive options, putting the recommendation first without treating
+it as approval. Files may share one question only when they form one behavior
+chain; list every covered review item in that question. After each answer,
+restate the locked choice before applying it, then continue asking until every
+review item is covered. Do not resolve, stage, commit, push, or open a pull
+request for an unanswered item.
+
+Pass one `--review-note` per approved review item when publishing; the script
+refuses to publish a candidate with review items and no recorded decision.
+Include every decision in the Draft PR body. If there were no review items,
+record that fact instead. Keep interaction in the agent workflow: do not add a
+terminal prompt or another CLI phase between `start` and `publish`.
+
+Use CodeGraph when available to trace shared symbols and call paths; otherwise
+use `rg` and source inspection. Preserve CrossMux-specific branding, apps,
+release settings, translations, and device behavior unless the user explicitly
+approves changing them. Continue to follow the cache-version, thin-map,
+submodule, i18n, HAL, input, and allocation rules in `AGENTS.md` and
+`docs/engineering/`.
 
 ## Validation
 
-The script runs these before publishing unless `--skip-builds` is explicitly
-used:
+`publish` performs component-specific checks unless `--skip-builds` was
+explicitly authorized:
 
-```bash
-git diff --check
-git diff --cached --check
-pio run
-pio run -e gh_release_cn
-```
+- SDK: its four existing host test scripts, then the CrossMux PlatformIO
+  validation and any repeatable `--extra-build-env` values.
+- Simulator: its host compatibility self-test, all four CrossMux simulator
+  environments, and the CrossMux CMake/CTest host suite.
+- CrossMux: index/conflict-marker checks, `git diff --check`, `pio run`,
+  `pio run -e gh_release_cn`, and extra build environments.
 
-It also checks for unresolved index entries and conflict markers in tracked
-files.
-
-## Self-Review
-
-- [ ] The current branch is not the base branch.
-- [ ] Only the upstream sync is in the diff; unrelated local files are not
-      staged.
-- [ ] `.skills/SKILL.md` still follows the thin-map policy.
-- [ ] Submodules are initialized and no stale SDK directory was staged by
-      accident.
-- [ ] Both build commands passed, or the PR explicitly explains why they were
-      skipped.
-- [ ] The PR is a draft unless the user requested a ready-for-review PR.
+Report local checks, dependency Draft PRs, CrossMux Draft PR, CI, deployment,
+and physical-device acceptance separately.

--- a/.claude/skills/sync-upstream/scripts/sync_upstream.py
+++ b/.claude/skills/sync-upstream/scripts/sync_upstream.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Automate the CrossMux upstream sync branch and PR flow."""
+"""Inspect, rehearse, and publish approval-gated three-repository syncs."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -13,11 +14,52 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Sequence
-
+from typing import Sequence, cast
 
 DEFAULT_UPSTREAM_BRANCH = "develop"
-DEFAULT_BRANCH_PREFIX = "agent/sync-upstream"
+DEFAULT_BRANCH_PREFIX = "codex/sync-upstream"
+STATE_FILE = "sync-upstream-review.json"
+SIMULATOR_ENVS = (
+    "simulator",
+    "simulator_x3",
+    "simulator_eego_a4",
+    "simulator_murphy_m4",
+)
+SDK_HOST_TESTS = (
+    "libs/book/ContentProtection/test/host/run.sh",
+    "libs/book/FreeInkBook/test/host/run.sh",
+    "libs/hardware/InputManager/test/host/run.sh",
+    "libs/ui/FreeInkUI/test/host/run.sh",
+)
+
+
+@dataclass(frozen=True)
+class Dependency:
+    name: str
+    parent_repo: str
+    fork_repo: str
+
+    @property
+    def parent_url(self) -> str:
+        return f"https://github.com/{self.parent_repo}.git"
+
+    @property
+    def fork_url(self) -> str:
+        return f"https://github.com/{self.fork_repo}.git"
+
+    @property
+    def branch_prefix(self) -> str:
+        return f"codex/sync-{self.name}-main"
+
+
+DEPENDENCIES = {
+    "sdk": Dependency("sdk", "Free-Ink/freeink-sdk", "0x1abin/freeink-sdk"),
+    "simulator": Dependency(
+        "simulator",
+        "crosspoint-reader/crosspoint-simulator",
+        "0x1abin/crosspoint-simulator",
+    ),
+}
 
 
 class CommandError(RuntimeError):
@@ -45,6 +87,20 @@ class Context:
         return f"refs/remotes/{self.origin_remote}/{self.base_branch}"
 
 
+@dataclass(frozen=True)
+class DependencyStatus:
+    name: str
+    parent_sha: str
+    fork_sha: str
+    parent_in_fork: bool
+    open_pr: bool
+    overlap_paths: tuple[str, ...]
+
+    @property
+    def action(self) -> str:
+        return decide_dependency_action(self.parent_in_fork, self.open_pr)
+
+
 def run(
     cmd: Sequence[str],
     *,
@@ -52,8 +108,10 @@ def run(
     check: bool = True,
     capture: bool = True,
     input_text: str | None = None,
+    log: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    print(f"$ {' '.join(cmd)}")
+    if log:
+        print(f"$ {' '.join(cmd)}")
     try:
         completed = subprocess.run(
             list(cmd),
@@ -67,36 +125,44 @@ def run(
         message = f"command not found: {cmd[0]}"
         if check:
             raise RuntimeError(message) from exc
-        completed = subprocess.CompletedProcess(list(cmd), 127, message + "\n")
-    if capture and completed.stdout:
+        return subprocess.CompletedProcess(list(cmd), 127, message + "\n")
+    if log and capture and completed.stdout:
         print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
     if check and completed.returncode != 0:
         raise CommandError(cmd, completed.returncode, completed.stdout or "")
     return completed
 
 
-def git(root: Path, *args: str, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess[str]:
-    return run(["git", *args], cwd=root, check=check, capture=capture)
-
-
-def repo_root() -> Path:
-    completed = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(completed.stdout.strip())
+def git(
+    root: Path,
+    *args: str,
+    check: bool = True,
+    capture: bool = True,
+    log: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=root, check=check, capture=capture, log=log)
 
 
 def git_output(root: Path, *args: str, check: bool = True) -> str:
-    completed = git(root, *args, check=check)
-    return completed.stdout.strip()
+    return git(root, *args, check=check, log=False).stdout.strip()
 
 
 def git_success(root: Path, *args: str) -> bool:
-    completed = subprocess.run(
-        ["git", *args],
-        cwd=str(root),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    return (
+        subprocess.run(
+            ["git", *args],
+            cwd=str(root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
     )
-    return completed.returncode == 0
+
+
+def repo_root() -> Path:
+    return Path(
+        run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd()).stdout.strip()
+    )
 
 
 def sc_target_branch(root: Path) -> str | None:
@@ -106,11 +172,9 @@ def sc_target_branch(root: Path) -> str | None:
     if completed.returncode != 0 or not completed.stdout.strip():
         return None
     try:
-        payload = json.loads(completed.stdout)
+        target = json.loads(completed.stdout).get("response", {}).get("target_branch")
     except json.JSONDecodeError:
         return None
-    response = payload.get("response", {})
-    target = response.get("target_branch")
     return target if isinstance(target, str) and target else None
 
 
@@ -131,26 +195,6 @@ def remote_branch_exists(root: Path, remote: str, branch: str) -> bool:
     return git_success(root, "show-ref", "--verify", f"refs/remotes/{remote}/{branch}")
 
 
-def script_relative_path(root: Path) -> str:
-    return Path(__file__).resolve().relative_to(root).as_posix()
-
-
-def base_contains_script(root: Path, base_ref: str) -> bool:
-    return git_success(root, "cat-file", "-e", f"{base_ref}:{script_relative_path(root)}")
-
-
-def require_base_contains_script(root: Path, base_ref: str) -> None:
-    if base_contains_script(root, base_ref):
-        return
-    rel_path = script_relative_path(root)
-    raise RuntimeError(
-        f"{base_ref} does not contain {rel_path}. "
-        "The detected base is probably wrong for this repo, or the skill has "
-        "not been merged into that base yet. Pass --base-branch main if the "
-        "CrossMux integration branch is intended."
-    )
-
-
 def choose_base_branch(root: Path, origin_remote: str, requested: str) -> str:
     if requested != "auto":
         return requested
@@ -163,7 +207,9 @@ def choose_base_branch(root: Path, origin_remote: str, requested: str) -> str:
     for candidate in ("main", "master"):
         if remote_branch_exists(root, origin_remote, candidate):
             return candidate
-    raise RuntimeError("Could not determine base branch; pass --base-branch explicitly.")
+    raise RuntimeError(
+        "Could not determine base branch; pass --base-branch explicitly."
+    )
 
 
 def choose_upstream_branch(root: Path, upstream_remote: str, requested: str) -> str:
@@ -174,70 +220,56 @@ def choose_upstream_branch(root: Path, upstream_remote: str, requested: str) -> 
     head = remote_head_branch(root, upstream_remote)
     if head:
         return head
-    raise RuntimeError("Could not determine upstream branch; pass --upstream-branch explicitly.")
+    raise RuntimeError(
+        "Could not determine upstream branch; pass --upstream-branch explicitly."
+    )
+
+
+def build_context(args: argparse.Namespace) -> Context:
+    root = repo_root()
+    return Context(
+        root=root,
+        base_branch=choose_base_branch(root, args.origin_remote, args.base_branch),
+        upstream_remote=args.upstream_remote,
+        origin_remote=args.origin_remote,
+        upstream_branch=choose_upstream_branch(
+            root, args.upstream_remote, args.upstream_branch
+        ),
+    )
 
 
 def fetch_branch(root: Path, remote: str, branch: str) -> None:
     git(root, "fetch", remote, f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}")
 
 
-def require_clean_worktree(root: Path) -> None:
-    status = git_output(root, "status", "--porcelain=v1", "-uall")
-    if status:
-        raise RuntimeError(
-            "Working tree is not clean. Commit, stash, or remove unrelated files before starting.\n"
-            + status
-        )
-
-
-def current_branch(root: Path) -> str:
-    branch = git_output(root, "branch", "--show-current")
-    if not branch:
-        raise RuntimeError("Detached HEAD is not supported for this sync flow.")
-    return branch
-
-
-def require_not_base_branch(root: Path, base_branch: str) -> None:
-    branch = current_branch(root)
-    if branch == base_branch:
-        raise RuntimeError(f"Refusing to publish from base branch {base_branch!r}.")
-
-
-def short_sha(root: Path, ref: str) -> str:
-    return git_output(root, "rev-parse", "--short=8", ref)
+def fetch_url_ref(root: Path, url: str, branch: str, ref: str) -> None:
+    git(root, "fetch", url, f"+refs/heads/{branch}:{ref}")
 
 
 def full_sha(root: Path, ref: str) -> str:
     return git_output(root, "rev-parse", ref)
 
 
-def sanitize_branch_component(value: str) -> str:
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip("/"))
-    return cleaned.strip("-") or "upstream"
-
-
-def branch_exists(root: Path, name: str, origin_remote: str) -> bool:
-    local_exists = git_success(root, "show-ref", "--verify", f"refs/heads/{name}")
-    remote_exists = git_success(root, "show-ref", "--verify", f"refs/remotes/{origin_remote}/{name}")
-    return local_exists or remote_exists
-
-
-def unique_branch_name(root: Path, prefix: str, upstream_branch: str, sha: str, origin_remote: str) -> str:
-    base = f"{prefix}-{sanitize_branch_component(upstream_branch)}-{sha}"
-    candidate = base
-    counter = 2
-    while branch_exists(root, candidate, origin_remote):
-        candidate = f"{base}-{counter}"
-        counter += 1
-    return candidate
+def short_sha(root: Path, ref: str) -> str:
+    return git_output(root, "rev-parse", "--short=8", ref)
 
 
 def is_ancestor(root: Path, ancestor: str, descendant: str) -> bool:
     return git_success(root, "merge-base", "--is-ancestor", ancestor, descendant)
 
 
-def has_merge_head(root: Path) -> bool:
-    return (root / ".git" / "MERGE_HEAD").exists() or bool(git_output(root, "rev-parse", "-q", "--verify", "MERGE_HEAD", check=False))
+def changed_paths(root: Path, base: str, tip: str) -> set[str]:
+    output = git_output(root, "diff", "--name-only", f"{base}..{tip}")
+    return {line for line in output.splitlines() if line}
+
+
+def overlap_paths(root: Path, left: str, right: str) -> tuple[str, ...]:
+    base = git_output(root, "merge-base", left, right, check=False)
+    if not base:
+        return ()
+    return tuple(
+        sorted(changed_paths(root, base, left) & changed_paths(root, base, right))
+    )
 
 
 def unmerged_paths(root: Path) -> list[str]:
@@ -246,143 +278,378 @@ def unmerged_paths(root: Path) -> list[str]:
 
 
 def staged_paths(root: Path) -> list[str]:
-    output = git_output(root, "diff", "--cached", "--name-only")
-    return [line for line in output.splitlines() if line]
+    return [
+        line
+        for line in git_output(root, "diff", "--cached", "--name-only").splitlines()
+        if line
+    ]
 
 
 def unstaged_tracked_paths(root: Path) -> list[str]:
-    output = git_output(root, "diff", "--name-only")
-    return [line for line in output.splitlines() if line]
+    return [
+        line for line in git_output(root, "diff", "--name-only").splitlines() if line
+    ]
 
 
-def sync_marker_found(root: Path, upstream_base_ref: str) -> bool:
-    marker_sha = short_sha(root, upstream_base_ref)
-    log = git_output(root, "log", "--format=%s", "--max-count=300", "HEAD")
-    lowered = log.lower()
-    return marker_sha.lower() in lowered or "sync upstream master" in lowered
+def has_merge_head(root: Path) -> bool:
+    return git_success(root, "rev-parse", "-q", "--verify", "MERGE_HEAD")
 
 
-def latest_synced_upstream_ref(root: Path, upstream_ref: str) -> str | None:
-    subjects = git_output(root, "log", "--format=%s", "--max-count=300", "HEAD")
-    pattern = re.compile(r"sync upstream \S+ into \S+ \(([0-9a-f]{7,40})\)", re.IGNORECASE)
-    for subject in subjects.splitlines():
-        match = pattern.search(subject)
-        if not match:
-            continue
-        candidate = match.group(1)
-        if git_success(root, "rev-parse", "--verify", f"{candidate}^{{commit}}") and is_ancestor(
-            root, candidate, upstream_ref
-        ):
-            return candidate
-    return None
+def decide_dependency_action(parent_in_fork: bool, open_pr: bool) -> str:
+    if parent_in_fork:
+        return "up-to-date"
+    return "wait-for-pr" if open_pr else "sync-required"
 
 
-def auto_squash_base(root: Path, ctx: Context, requested: str) -> str | None:
-    if requested == "none":
-        return None
-    if requested != "auto":
-        return requested
-    if ctx.upstream_branch != DEFAULT_UPSTREAM_BRANCH:
-        return None
-    synced_ref = latest_synced_upstream_ref(root, ctx.upstream_ref)
-    if synced_ref:
-        return synced_ref
-    candidate = f"refs/remotes/{ctx.upstream_remote}/master"
-    if not git_success(root, "show-ref", "--verify", candidate):
-        return None
-    if not is_ancestor(root, candidate, ctx.upstream_ref):
-        return None
-    if is_ancestor(root, candidate, "HEAD"):
-        return None
-    return candidate if sync_marker_found(root, candidate) else None
+def next_component(statuses: dict[str, DependencyStatus]) -> str:
+    for name in ("sdk", "simulator"):
+        if statuses[name].action != "up-to-date":
+            return name
+    return "crossmux"
 
 
-def apply_diff_from_base(root: Path, base_ref: str, upstream_ref: str) -> None:
-    diff = git(root, "diff", "--binary", f"{base_ref}..{upstream_ref}").stdout
+def sync_pr_open(root: Path, dependency: Dependency, parent_sha: str) -> bool:
+    expected = f"{dependency.branch_prefix}-{parent_sha[:8]}"
     completed = run(
-        ["git", "apply", "--3way", "--index"],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            dependency.fork_repo,
+            "--state",
+            "open",
+            "--json",
+            "headRefName",
+            "--limit",
+            "100",
+        ],
         cwd=root,
         check=False,
-        input_text=diff,
     )
     if completed.returncode != 0:
-        conflicts = unmerged_paths(root)
-        conflict_text = "\n".join(conflicts) if conflicts else completed.stdout
-        raise RuntimeError("Squash fallback stopped with conflicts:\n" + conflict_text)
-
-
-def create_merge(root: Path, ctx: Context, squash_from: str | None) -> None:
-    title = sync_title(ctx, short_sha(root, ctx.upstream_ref))
-    if squash_from:
-        print(f"Using squash fallback from {squash_from}.")
-        completed = git(
-            root,
-            "merge",
-            "--no-ff",
-            "--no-commit",
-            "-s",
-            "ours",
-            "-m",
-            title,
-            ctx.upstream_ref,
-            check=False,
+        raise RuntimeError(f"Could not inspect open PRs for {dependency.fork_repo}.")
+    try:
+        return any(
+            item.get("headRefName") == expected
+            for item in json.loads(completed.stdout or "[]")
         )
-        if completed.returncode != 0:
-            raise RuntimeError("Could not create ours merge for squash fallback.")
-        apply_diff_from_base(root, squash_from, ctx.upstream_ref)
-        return
-
-    completed = git(root, "merge", "--no-ff", "--no-commit", "-m", title, ctx.upstream_ref, check=False)
-    if completed.returncode != 0:
-        conflicts = unmerged_paths(root)
-        conflict_text = "\n".join(conflicts) if conflicts else completed.stdout
-        raise RuntimeError("Merge stopped with conflicts:\n" + conflict_text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid PR response for {dependency.fork_repo}.") from exc
 
 
-def repo_slug_from_remote(root: Path, remote: str) -> str | None:
-    url = git_output(root, "remote", "get-url", "--push", remote, check=False)
-    if not url:
-        url = git_output(root, "remote", "get-url", remote, check=False)
-    url = url.strip()
-    patterns = [
-        r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$",
-        r"^([^/]+)/([^/]+)$",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, url)
-        if match:
-            return f"{match.group(1)}/{match.group(2)}"
-    return None
+def inspect_dependency(
+    root: Path, dependency: Dependency, *, check_pr: bool = True
+) -> DependencyStatus:
+    parent_ref = f"refs/sync-upstream/{dependency.name}/parent-main"
+    fork_ref = f"refs/sync-upstream/{dependency.name}/fork-main"
+    fetch_url_ref(root, dependency.parent_url, "main", parent_ref)
+    fetch_url_ref(root, dependency.fork_url, "main", fork_ref)
+    parent_sha = full_sha(root, parent_ref)
+    return DependencyStatus(
+        name=dependency.name,
+        parent_sha=parent_sha,
+        fork_sha=full_sha(root, fork_ref),
+        parent_in_fork=is_ancestor(root, parent_ref, fork_ref),
+        open_pr=sync_pr_open(root, dependency, parent_sha) if check_pr else False,
+        overlap_paths=overlap_paths(root, fork_ref, parent_ref),
+    )
 
 
-def sync_title(ctx: Context, upstream_short: str) -> str:
-    return f"chore: sync upstream {ctx.upstream_branch} into {ctx.base_branch} ({upstream_short})"
+def inspect_dependencies(
+    root: Path, *, check_pr: bool = True
+) -> dict[str, DependencyStatus]:
+    return {
+        name: inspect_dependency(root, dependency, check_pr=check_pr)
+        for name, dependency in DEPENDENCIES.items()
+    }
 
 
-def pr_body(ctx: Context, upstream_full: str, skipped_builds: bool, extra_build_envs: Sequence[str]) -> str:
-    lines = [
-        "## Summary",
-        "",
-        f"- Sync `{ctx.upstream_remote}/{ctx.upstream_branch}` at `{upstream_full}` into `{ctx.base_branch}`.",
-        "- Keep the sync isolated on an agent branch for review.",
-        "",
-        "## Validation",
-        "",
-        "- `git diff --check`",
-        "- `git diff --cached --check`",
-    ]
-    if skipped_builds:
-        lines.append("- Builds skipped with `--skip-builds`")
-    else:
-        lines.extend(["- `pio run`", "- `pio run -e gh_release_cn`"])
-        lines.extend(f"- `pio run -e {env}`" for env in extra_build_envs)
-    return "\n".join(lines) + "\n"
+def candidate_path(
+    component: str, upstream_sha: str, override: str | None = None
+) -> Path:
+    base = (
+        Path(override)
+        if override
+        else Path(tempfile.gettempdir()) / "crossmux-sync-upstream"
+    )
+    return base / f"{component}-{upstream_sha[:8]}"
+
+
+def state_path(candidate: Path) -> Path:
+    git_dir = Path(git_output(candidate, "rev-parse", "--git-dir"))
+    if not git_dir.is_absolute():
+        git_dir = candidate / git_dir
+    return git_dir / STATE_FILE
+
+
+def write_state(candidate: Path, state: dict[str, object]) -> None:
+    state_path(candidate).write_text(
+        json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def read_state(candidate: Path) -> dict[str, object]:
+    path = state_path(candidate)
+    if not path.exists():
+        raise RuntimeError(f"Candidate has no review state: {candidate}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def candidate_id(component: str, base_sha: str, upstream_sha: str) -> str:
+    return hashlib.sha256(
+        f"{component}:{base_sha}:{upstream_sha}".encode()
+    ).hexdigest()[:16]
+
+
+def branch_name(component: str, upstream_sha: str) -> str:
+    prefix = (
+        DEFAULT_BRANCH_PREFIX
+        if component == "crossmux"
+        else DEPENDENCIES[component].branch_prefix
+    )
+    return f"{prefix}-{upstream_sha[:8]}"
+
+
+def merge_without_commit(candidate: Path, upstream_ref: str, title: str) -> list[str]:
+    completed = git(
+        candidate,
+        "merge",
+        "--no-ff",
+        "--no-commit",
+        "-m",
+        title,
+        upstream_ref,
+        check=False,
+    )
+    conflicts = unmerged_paths(candidate)
+    if completed.returncode != 0 and not conflicts:
+        raise CommandError(["git", "merge"], completed.returncode, completed.stdout)
+    return conflicts
+
+
+def clone_dependency_candidate(
+    root: Path,
+    dependency: Dependency,
+    status: DependencyStatus,
+    candidate: Path,
+    behavior_overlaps: Sequence[str],
+) -> dict[str, object]:
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "clone", dependency.fork_url, str(candidate)], cwd=root)
+    git(candidate, "remote", "add", "upstream", dependency.parent_url)
+    git(candidate, "fetch", "upstream", "main")
+    branch = branch_name(dependency.name, status.parent_sha)
+    git(candidate, "switch", "-c", branch, "origin/main")
+    overlaps = sorted(
+        set(overlap_paths(candidate, "origin/main", "upstream/main"))
+        | set(behavior_overlaps)
+    )
+    conflicts = merge_without_commit(
+        candidate,
+        "upstream/main",
+        f"chore: sync {dependency.name} upstream main ({status.parent_sha[:8]})",
+    )
+    state: dict[str, object] = {
+        "base_branch": "main",
+        "base_sha": status.fork_sha,
+        "branch": branch,
+        "candidate_id": candidate_id(
+            dependency.name, status.fork_sha, status.parent_sha
+        ),
+        "component": dependency.name,
+        "conflict_paths": conflicts,
+        "overlap_paths": overlaps,
+        "review_items": sorted(set(conflicts) | set(overlaps)),
+        "upstream_sha": status.parent_sha,
+    }
+    write_state(candidate, state)
+    return state
+
+
+def clone_crossmux_candidate(
+    ctx: Context,
+    statuses: dict[str, DependencyStatus],
+    candidate: Path,
+    behavior_overlaps: Sequence[str],
+) -> dict[str, object]:
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "clone", str(ctx.root), str(candidate)], cwd=ctx.root)
+    origin_url = git_output(ctx.root, "remote", "get-url", ctx.origin_remote)
+    upstream_url = git_output(ctx.root, "remote", "get-url", ctx.upstream_remote)
+    git(candidate, "remote", "set-url", "origin", origin_url)
+    git(candidate, "remote", "add", "upstream", upstream_url)
+    fetch_branch(candidate, "origin", ctx.base_branch)
+    fetch_branch(candidate, "upstream", ctx.upstream_branch)
+    upstream_ref = f"refs/remotes/upstream/{ctx.upstream_branch}"
+    base_ref = f"refs/remotes/origin/{ctx.base_branch}"
+    upstream_sha = full_sha(candidate, upstream_ref)
+    base_sha = full_sha(candidate, base_ref)
+    branch = branch_name("crossmux", upstream_sha)
+    git(candidate, "switch", "-C", branch, base_ref)
+    overlaps = sorted(
+        set(overlap_paths(candidate, base_ref, upstream_ref)) | set(behavior_overlaps)
+    )
+    conflicts = merge_without_commit(
+        candidate,
+        upstream_ref,
+        f"chore: sync upstream {ctx.upstream_branch} into {ctx.base_branch} ({upstream_sha[:8]})",
+    )
+    if not conflicts:
+        update_crossmux_dependency_pins(
+            candidate, statuses["sdk"].fork_sha, statuses["simulator"].fork_sha
+        )
+    state: dict[str, object] = {
+        "base_branch": ctx.base_branch,
+        "base_sha": base_sha,
+        "branch": branch,
+        "candidate_id": candidate_id("crossmux", base_sha, upstream_sha),
+        "component": "crossmux",
+        "conflict_paths": conflicts,
+        "overlap_paths": overlaps,
+        "review_items": sorted(set(conflicts) | set(overlaps)),
+        "sdk_sha": statuses["sdk"].fork_sha,
+        "simulator_sha": statuses["simulator"].fork_sha,
+        "upstream_sha": upstream_sha,
+    }
+    write_state(candidate, state)
+    return state
+
+
+def replace_simulator_pins(platformio: str, cmake: str, sha: str) -> tuple[str, str]:
+    platform_pattern = r"(simulator=https://github\.com/0x1abin/crosspoint-simulator\.git#)[0-9a-f]{40}"
+    cmake_pattern = r"(GIT_TAG )[0-9a-f]{40}"
+    platformio, platform_count = re.subn(
+        platform_pattern, rf"\g<1>{sha}", platformio, count=1
+    )
+    cmake, cmake_count = re.subn(cmake_pattern, rf"\g<1>{sha}", cmake, count=1)
+    if platform_count != 1 or cmake_count != 1:
+        raise RuntimeError("Could not update both CrossPoint Simulator pins.")
+    return platformio, cmake
+
+
+def update_crossmux_dependency_pins(
+    root: Path, sdk_sha: str, simulator_sha: str
+) -> None:
+    git(
+        root,
+        "config",
+        "-f",
+        ".gitmodules",
+        "submodule.freeink-sdk.url",
+        DEPENDENCIES["sdk"].fork_url,
+    )
+    git(root, "config", "-f", ".gitmodules", "submodule.freeink-sdk.branch", "main")
+    git(root, "submodule", "sync", "--", "freeink-sdk")
+    git(root, "submodule", "update", "--init", "--", "freeink-sdk")
+    sdk_root = root / "freeink-sdk"
+    git(sdk_root, "fetch", DEPENDENCIES["sdk"].fork_url, sdk_sha)
+    git(sdk_root, "checkout", "--detach", sdk_sha)
+    platform_path = root / "platformio.ini"
+    cmake_path = root / "test/CMakeLists.txt"
+    platformio, cmake = replace_simulator_pins(
+        platform_path.read_text(encoding="utf-8"),
+        cmake_path.read_text(encoding="utf-8"),
+        simulator_sha,
+    )
+    platform_path.write_text(platformio, encoding="utf-8")
+    cmake_path.write_text(cmake, encoding="utf-8")
+    git(
+        root,
+        "add",
+        ".gitmodules",
+        "freeink-sdk",
+        "platformio.ini",
+        "test/CMakeLists.txt",
+    )
+
+
+def summarize_state(candidate: Path, state: dict[str, object]) -> None:
+    summary = dict(state)
+    summary["candidate"] = str(candidate)
+    summary["requires_manual_review"] = bool(state["review_items"])
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def refresh_candidate(candidate: Path, state: dict[str, object]) -> dict[str, object]:
+    conflicts = unmerged_paths(candidate)
+    prior_items = cast(
+        list[str],
+        state.get(
+            "review_items",
+            list(cast(list[str], state["conflict_paths"]))
+            + list(cast(list[str], state["overlap_paths"])),
+        ),
+    )
+    state["conflict_paths"] = conflicts
+    state["review_items"] = sorted(set(prior_items) | set(conflicts))
+    write_state(candidate, state)
+    return state
+
+
+def gitlink_sha(root: Path, treeish: str) -> str:
+    entry = git_output(root, "ls-tree", treeish, "freeink-sdk")
+    match = re.match(r"160000 commit ([0-9a-f]{40})\tfreeink-sdk$", entry)
+    if not match:
+        raise RuntimeError(f"{treeish} does not contain the freeink-sdk gitlink.")
+    return match.group(1)
+
+
+def indexed_gitlink_sha(root: Path) -> str:
+    entry = git_output(root, "ls-files", "-s", "--", "freeink-sdk")
+    match = re.match(r"160000 ([0-9a-f]{40}) 0\tfreeink-sdk$", entry)
+    if not match:
+        raise RuntimeError("The index does not contain the freeink-sdk gitlink.")
+    return match.group(1)
+
+
+def simulator_pins(text: str) -> tuple[str, ...]:
+    platform = re.search(r"crosspoint-simulator\.git#([0-9a-f]{40})", text)
+    cmake = re.search(
+        r"GIT_REPOSITORY\s+https://github\.com/0x1abin/crosspoint-simulator\.git\s+"
+        r"GIT_TAG\s+([0-9a-f]{40})",
+        text,
+    )
+    return tuple(match.group(1) for match in (platform, cmake) if match)
+
+
+def inspect_crossmux(
+    ctx: Context, statuses: dict[str, DependencyStatus]
+) -> dict[str, object]:
+    fetch_branch(ctx.root, ctx.origin_remote, ctx.base_branch)
+    fetch_branch(ctx.root, ctx.upstream_remote, ctx.upstream_branch)
+    base_sha = full_sha(ctx.root, ctx.origin_base_ref)
+    upstream_sha = full_sha(ctx.root, ctx.upstream_ref)
+    platformio = git_output(ctx.root, "show", f"{ctx.origin_base_ref}:platformio.ini")
+    cmake = git_output(ctx.root, "show", f"{ctx.origin_base_ref}:test/CMakeLists.txt")
+    pins = simulator_pins(platformio + "\n" + cmake)
+    dependencies_ready = all(
+        status.action == "up-to-date" for status in statuses.values()
+    )
+    fully_synced = (
+        dependencies_ready
+        and is_ancestor(ctx.root, ctx.upstream_ref, ctx.origin_base_ref)
+        and gitlink_sha(ctx.root, ctx.origin_base_ref) == statuses["sdk"].fork_sha
+        and len(pins) == 2
+        and all(pin == statuses["simulator"].fork_sha for pin in pins)
+    )
+    return {
+        "action": (
+            "up-to-date"
+            if fully_synced
+            else ("ready" if dependencies_ready else "blocked-by-dependencies")
+        ),
+        "base_sha": base_sha,
+        "overlap_paths": overlap_paths(ctx.root, ctx.origin_base_ref, ctx.upstream_ref),
+        "simulator_pins": pins,
+        "upstream_sha": upstream_sha,
+    }
 
 
 def check_conflict_markers(root: Path) -> None:
-    left = "<" * 7
-    right = ">" * 7
-    completed = git(root, "grep", "-n", "-E", f"{left}|{right}", "--", ".", check=False)
+    completed = git(
+        root, "grep", "-n", "-E", f"{'<' * 7}|{'>' * 7}", "--", ".", check=False
+    )
     if completed.returncode == 0:
         raise RuntimeError("Conflict markers found in tracked files.")
     if completed.returncode not in (0, 1):
@@ -396,7 +663,7 @@ def validate_index(root: Path) -> None:
     unstaged = unstaged_tracked_paths(root)
     if unstaged:
         raise RuntimeError(
-            "Tracked files have unstaged changes. Stage resolved files before publishing:\n"
+            "Tracked files have unstaged changes; stage them before publishing:\n"
             + "\n".join(unstaged)
         )
     git(root, "diff", "--check")
@@ -404,116 +671,230 @@ def validate_index(root: Path) -> None:
     check_conflict_markers(root)
 
 
-def run_builds(root: Path, skip_builds: bool, extra_build_envs: Sequence[str]) -> None:
+def run_crossmux_builds(
+    root: Path, skip_builds: bool, extra_envs: Sequence[str]
+) -> None:
     if skip_builds:
         print("Skipping PlatformIO builds because --skip-builds was passed.")
         return
     run(["pio", "run"], cwd=root, capture=False)
     run(["pio", "run", "-e", "gh_release_cn"], cwd=root, capture=False)
-    for env in extra_build_envs:
+    for env in extra_envs:
         run(["pio", "run", "-e", env], cwd=root, capture=False)
 
 
-def commit_if_needed(root: Path, ctx: Context) -> None:
-    staged = staged_paths(root)
-    if not staged and not has_merge_head(root):
-        print("No staged changes or merge state to commit.")
-        return
-    upstream_short = short_sha(root, ctx.upstream_ref)
-    upstream_full = full_sha(root, ctx.upstream_ref)
-    title = sync_title(ctx, upstream_short)
-    body = f"Upstream: {ctx.upstream_remote}/{ctx.upstream_branch} {upstream_full}"
-    git(root, "commit", "-m", title, "-m", body)
-
-
-def push_branch(root: Path, origin_remote: str) -> None:
-    branch = current_branch(root)
-    git(root, "push", "-u", origin_remote, branch)
-
-
-def create_or_show_pr(
-    root: Path, ctx: Context, draft: bool, skip_builds: bool, extra_build_envs: Sequence[str]
+def validate_sdk_candidate(
+    candidate: Path, crossmux_root: Path, skip_builds: bool, extra_envs: Sequence[str]
 ) -> None:
-    repo = repo_slug_from_remote(root, ctx.origin_remote)
-    if not repo:
-        raise RuntimeError(f"Could not parse GitHub repo from remote {ctx.origin_remote!r}.")
-    branch = current_branch(root)
+    for script in SDK_HOST_TESTS:
+        run(["bash", script], cwd=candidate, capture=False)
+    if skip_builds:
+        print(
+            "Skipping CrossMux SDK candidate builds because --skip-builds was passed."
+        )
+        return
+    with tempfile.TemporaryDirectory(prefix="crossmux-sdk-check-") as temp_dir:
+        checkout = Path(temp_dir) / "crossmux"
+        run(["git", "clone", str(crossmux_root), str(checkout)], cwd=crossmux_root)
+        if (checkout / "freeink-sdk").exists():
+            shutil.rmtree(checkout / "freeink-sdk")
+        os.symlink(candidate, checkout / "freeink-sdk", target_is_directory=True)
+        run_crossmux_builds(checkout, False, extra_envs)
+
+
+def replace_simulator_with_local_candidate(platformio: str, candidate: Path) -> str:
+    pattern = (
+        r"simulator=https://github\.com/0x1abin/crosspoint-simulator\.git#[0-9a-f]{40}"
+    )
+    replaced, count = re.subn(
+        pattern, f"simulator=symlink://{candidate}", platformio, count=1
+    )
+    if count != 1:
+        raise RuntimeError("Could not point PlatformIO at the simulator candidate.")
+    return replaced
+
+
+def replace_cmake_simulator_with_local_candidate(cmake: str, candidate: Path) -> str:
+    pattern = (
+        r"FetchContent_Declare\(\s*crosspoint_simulator\s*"
+        r"GIT_REPOSITORY\s+https://github\.com/0x1abin/crosspoint-simulator\.git\s*"
+        r"GIT_TAG\s+[0-9a-f]{40}\s*\)"
+    )
+    replacement = (
+        f"FetchContent_Declare(\n  crosspoint_simulator\n  SOURCE_DIR {candidate}\n)"
+    )
+    replaced, count = re.subn(pattern, replacement, cmake, count=1)
+    if count != 1:
+        raise RuntimeError("Could not point CMake at the simulator candidate.")
+    return replaced
+
+
+def validate_simulator_candidate(
+    candidate: Path, crossmux_root: Path, skip_builds: bool
+) -> None:
+    run(["bash", "tests/run_host_compat_self_test.sh"], cwd=candidate, capture=False)
+    if skip_builds:
+        print(
+            "Skipping CrossMux simulator candidate builds because --skip-builds was passed."
+        )
+        return
+    with tempfile.TemporaryDirectory(prefix="crossmux-simulator-check-") as temp_dir:
+        checkout = Path(temp_dir) / "crossmux"
+        run(
+            ["git", "clone", "--recurse-submodules", str(crossmux_root), str(checkout)],
+            cwd=crossmux_root,
+        )
+        platform_path = checkout / "platformio.ini"
+        cmake_path = checkout / "test/CMakeLists.txt"
+        platform_path.write_text(
+            replace_simulator_with_local_candidate(
+                platform_path.read_text(encoding="utf-8"), candidate
+            ),
+            encoding="utf-8",
+        )
+        cmake_path.write_text(
+            replace_cmake_simulator_with_local_candidate(
+                cmake_path.read_text(encoding="utf-8"), candidate
+            ),
+            encoding="utf-8",
+        )
+        command = ["pio", "run"]
+        for env in SIMULATOR_ENVS:
+            command.extend(("-e", env))
+        run(command, cwd=checkout, capture=False)
+        run(["cmake", "-S", "test", "-B", "build/test"], cwd=checkout, capture=False)
+        run(["cmake", "--build", "build/test"], cwd=checkout, capture=False)
+        run(
+            ["ctest", "--test-dir", "build/test", "--output-on-failure"],
+            cwd=checkout,
+            capture=False,
+        )
+
+
+def commit_candidate(candidate: Path, state: dict[str, object]) -> None:
+    if not staged_paths(candidate) and not has_merge_head(candidate):
+        if full_sha(candidate, "HEAD") == state["base_sha"]:
+            raise RuntimeError("Candidate has no staged merge to commit.")
+        print("Candidate commit already exists; continuing publish retry.")
+        return
+    component = str(state["component"])
+    upstream_sha = str(state["upstream_sha"])
+    if component == "crossmux":
+        title = f"chore: sync upstream into {state['base_branch']} ({upstream_sha[:8]})"
+    else:
+        title = f"chore: sync {component} upstream main ({upstream_sha[:8]})"
+    git(candidate, "commit", "-m", title, "-m", f"Upstream: {upstream_sha}")
+
+
+def pr_body(
+    state: dict[str, object], review_notes: Sequence[str], skipped_builds: bool
+) -> str:
+    lines = [
+        "## Summary",
+        "",
+        f"- Component: `{state['component']}`.",
+        f"- Upstream revision: `{state['upstream_sha']}`.",
+        f"- Candidate review ID: `{state['candidate_id']}`.",
+        "",
+        "## Manual conflict and overlap review",
+        "",
+    ]
+    review_items = cast(list[str], state["review_items"])
+    if review_items:
+        lines.extend(
+            f"- `{item}`: {note}" for item, note in zip(review_items, review_notes)
+        )
+    else:
+        lines.append("- No Git conflicts or behavioral overlap candidates were found.")
+    lines.extend(
+        [
+            "",
+            "## Validation",
+            "",
+            "- `git diff --check`",
+            "- `git diff --cached --check`",
+        ]
+    )
+    lines.append(
+        "- Builds skipped with `--skip-builds`."
+        if skipped_builds
+        else "- Component validation completed locally."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def push_and_create_pr(
+    candidate: Path,
+    state: dict[str, object],
+    review_notes: Sequence[str],
+    skipped_builds: bool,
+) -> None:
+    component = str(state["component"])
+    repo = (
+        "0x1abin/crossmux"
+        if component == "crossmux"
+        else DEPENDENCIES[component].fork_repo
+    )
+    branch = str(state["branch"])
+    git(candidate, "push", "-u", "origin", branch)
     existing = run(
         ["gh", "pr", "view", branch, "--repo", repo, "--json", "url", "-q", ".url"],
-        cwd=root,
+        cwd=candidate,
         check=False,
     )
     if existing.returncode == 0 and existing.stdout.strip():
         print(f"PR already exists: {existing.stdout.strip()}")
         return
-
-    upstream_short = short_sha(root, ctx.upstream_ref)
-    upstream_full = full_sha(root, ctx.upstream_ref)
-    title = sync_title(ctx, upstream_short)
-    body = pr_body(ctx, upstream_full, skip_builds, extra_build_envs)
+    title = (
+        f"chore: sync upstream into {state['base_branch']} ({str(state['upstream_sha'])[:8]})"
+        if component == "crossmux"
+        else f"chore: sync {component} upstream main ({str(state['upstream_sha'])[:8]})"
+    )
+    body = pr_body(state, review_notes, skipped_builds)
     with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as handle:
         handle.write(body)
         body_path = handle.name
     try:
-        cmd = [
-            "gh",
-            "pr",
-            "create",
-            "--repo",
-            repo,
-            "--base",
-            ctx.base_branch,
-            "--head",
-            branch,
-            "--title",
-            title,
-            "--body-file",
-            body_path,
-        ]
-        if draft:
-            cmd.append("--draft")
-        run(cmd, cwd=root)
+        run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                repo,
+                "--base",
+                str(state["base_branch"]),
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body-file",
+                body_path,
+                "--draft",
+            ],
+            cwd=candidate,
+        )
     finally:
         os.unlink(body_path)
 
 
-def build_context(args: argparse.Namespace) -> Context:
-    root = repo_root()
-    base_branch = choose_base_branch(root, args.origin_remote, args.base_branch)
-    upstream_branch = choose_upstream_branch(root, args.upstream_remote, args.upstream_branch)
-    return Context(
-        root=root,
-        base_branch=base_branch,
-        upstream_remote=args.upstream_remote,
-        origin_remote=args.origin_remote,
-        upstream_branch=upstream_branch,
-    )
-
-
 def cmd_inspect(args: argparse.Namespace) -> int:
     ctx = build_context(args)
-    fetch_branch(ctx.root, ctx.origin_remote, ctx.base_branch)
-    fetch_branch(ctx.root, ctx.upstream_remote, ctx.upstream_branch)
-    upstream_full = full_sha(ctx.root, ctx.upstream_ref)
-    upstream_short = short_sha(ctx.root, ctx.upstream_ref)
-    suggested = unique_branch_name(
-        ctx.root,
-        args.branch_prefix,
-        ctx.upstream_branch,
-        upstream_short,
-        ctx.origin_remote,
-    )
+    statuses = inspect_dependencies(ctx.root)
+    crossmux = inspect_crossmux(ctx, statuses)
     summary = {
-        "base_contains_skill": base_contains_script(ctx.root, ctx.origin_base_ref),
-        "repo": str(ctx.root),
-        "current_branch": current_branch(ctx.root),
-        "base_branch": ctx.base_branch,
-        "origin_remote": ctx.origin_remote,
-        "upstream_remote": ctx.upstream_remote,
-        "upstream_branch": ctx.upstream_branch,
-        "upstream_sha": upstream_full,
-        "squash_from": auto_squash_base(ctx.root, ctx, args.squash_from),
-        "suggested_branch": suggested,
+        "crossmux": crossmux,
+        "dependencies": {
+            name: {
+                "action": status.action,
+                "fork_sha": status.fork_sha,
+                "open_pr": status.open_pr,
+                "overlap_paths": status.overlap_paths,
+                "parent_sha": status.parent_sha,
+            }
+            for name, status in statuses.items()
+        },
+        "next_component": next_component(statuses),
     }
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
@@ -521,100 +902,198 @@ def cmd_inspect(args: argparse.Namespace) -> int:
 
 def cmd_start(args: argparse.Namespace) -> int:
     ctx = build_context(args)
-    require_clean_worktree(ctx.root)
-    fetch_branch(ctx.root, ctx.origin_remote, ctx.base_branch)
-    fetch_branch(ctx.root, ctx.upstream_remote, ctx.upstream_branch)
-    require_base_contains_script(ctx.root, ctx.origin_base_ref)
-    if args.squash_from == "auto" and ctx.upstream_branch == DEFAULT_UPSTREAM_BRANCH:
-        git(
-            ctx.root,
-            "fetch",
-            ctx.upstream_remote,
-            f"+refs/heads/master:refs/remotes/{ctx.upstream_remote}/master",
-            check=False,
+    statuses = inspect_dependencies(ctx.root)
+    expected = next_component(statuses)
+    if args.component != expected:
+        raise RuntimeError(
+            f"Next component is {expected!r}; refusing to start {args.component!r}."
         )
-
-    upstream_short = short_sha(ctx.root, ctx.upstream_ref)
-    if is_ancestor(ctx.root, ctx.upstream_ref, ctx.origin_base_ref):
-        print(f"{ctx.origin_base_ref} already contains {ctx.upstream_ref}.")
+    if args.component == "crossmux":
+        crossmux_status = inspect_crossmux(ctx, statuses)
+        if crossmux_status["action"] == "up-to-date":
+            raise RuntimeError("crossmux is already up to date.")
+        upstream_sha = full_sha(ctx.root, ctx.upstream_ref)
+    else:
+        status = statuses[args.component]
+        if status.action != "sync-required":
+            raise RuntimeError(
+                f"{args.component} action is {status.action}; no candidate can be started."
+            )
+        upstream_sha = status.parent_sha
+    candidate = candidate_path(args.component, upstream_sha, args.candidate_root)
+    if candidate.exists():
+        state = refresh_candidate(candidate, read_state(candidate))
+        recorded_overlaps = cast(list[str], state["overlap_paths"])
+        state["overlap_paths"] = sorted(
+            set(recorded_overlaps) | set(args.behavior_overlap)
+        )
+        recorded_items = cast(list[str], state["review_items"])
+        state["review_items"] = sorted(set(recorded_items) | set(args.behavior_overlap))
+        if args.component == "crossmux" and not state["conflict_paths"]:
+            update_crossmux_dependency_pins(
+                candidate, statuses["sdk"].fork_sha, statuses["simulator"].fork_sha
+            )
+            state["sdk_sha"] = statuses["sdk"].fork_sha
+            state["simulator_sha"] = statuses["simulator"].fork_sha
+        write_state(candidate, state)
+        summarize_state(candidate, state)
         return 0
-
-    branch = unique_branch_name(ctx.root, args.branch_prefix, ctx.upstream_branch, upstream_short, ctx.origin_remote)
-    git(ctx.root, "switch", "-c", branch, ctx.origin_base_ref)
-    squash_from = auto_squash_base(ctx.root, ctx, args.squash_from)
-    create_merge(ctx.root, ctx, squash_from)
-    git(ctx.root, "submodule", "update", "--init", "--recursive")
-    print("Merge staged. Run publish after resolving any review concerns.")
+    if args.component == "crossmux":
+        state = clone_crossmux_candidate(
+            ctx, statuses, candidate, args.behavior_overlap
+        )
+    else:
+        state = clone_dependency_candidate(
+            ctx.root,
+            DEPENDENCIES[args.component],
+            statuses[args.component],
+            candidate,
+            args.behavior_overlap,
+        )
+    summarize_state(candidate, state)
     return 0
 
 
 def cmd_publish(args: argparse.Namespace) -> int:
-    ctx = build_context(args)
-    require_not_base_branch(ctx.root, ctx.base_branch)
-    fetch_branch(ctx.root, ctx.upstream_remote, ctx.upstream_branch)
-    validate_index(ctx.root)
-    run_builds(ctx.root, args.skip_builds, args.extra_build_env)
-    commit_if_needed(ctx.root, ctx)
-    push_branch(ctx.root, ctx.origin_remote)
-    create_or_show_pr(ctx.root, ctx, args.draft, args.skip_builds, args.extra_build_env)
+    candidate = Path(args.candidate).resolve()
+    state = refresh_candidate(candidate, read_state(candidate))
+    if state["component"] != args.component:
+        raise RuntimeError(
+            f"Candidate is for {state['component']!r}, not {args.component!r}."
+        )
+    conflicts = cast(list[str], state["conflict_paths"])
+    review_items = cast(list[str], state["review_items"])
+    if conflicts:
+        raise RuntimeError("Unresolved conflicts remain:\n" + "\n".join(conflicts))
+    if len(args.review_note) != len(review_items):
+        raise RuntimeError(
+            f"This candidate has {len(review_items)} manual review items but received "
+            f"{len(args.review_note)} approved --review-note values."
+        )
+    validate_index(candidate)
+    root = repo_root()
+    if args.component == "sdk":
+        current = inspect_dependency(root, DEPENDENCIES["sdk"])
+        if (
+            current.parent_sha != state["upstream_sha"]
+            or current.fork_sha != state["base_sha"]
+        ):
+            raise RuntimeError(
+                "SDK parent or fork moved after start; inspect and start a fresh candidate."
+            )
+        validate_sdk_candidate(candidate, root, args.skip_builds, args.extra_build_env)
+    elif args.component == "simulator":
+        current = inspect_dependency(root, DEPENDENCIES["simulator"])
+        if (
+            current.parent_sha != state["upstream_sha"]
+            or current.fork_sha != state["base_sha"]
+        ):
+            raise RuntimeError(
+                "Simulator parent or fork moved after start; inspect and start a fresh candidate."
+            )
+        validate_simulator_candidate(candidate, root, args.skip_builds)
+    else:
+        ctx = build_context(args)
+        statuses = inspect_dependencies(root)
+        current_crossmux = inspect_crossmux(ctx, statuses)
+        if (
+            current_crossmux["base_sha"] != state["base_sha"]
+            or current_crossmux["upstream_sha"] != state["upstream_sha"]
+        ):
+            raise RuntimeError(
+                "CrossMux base or upstream moved after start; inspect and start a fresh candidate."
+            )
+        if any(status.action != "up-to-date" for status in statuses.values()):
+            raise RuntimeError(
+                "A dependency fork is no longer up to date; publish it before CrossMux."
+            )
+        if (
+            statuses["sdk"].fork_sha != state["sdk_sha"]
+            or statuses["simulator"].fork_sha != state["simulator_sha"]
+        ):
+            raise RuntimeError(
+                "A dependency fork moved after start; rerun CrossMux start to refresh both pins."
+            )
+        expected_sdk = str(state["sdk_sha"])
+        expected_simulator = str(state["simulator_sha"])
+        if indexed_gitlink_sha(candidate) != expected_sdk:
+            raise RuntimeError(
+                "CrossMux candidate does not pin the reviewed SDK revision; rerun start."
+            )
+        pins = simulator_pins(
+            (candidate / "platformio.ini").read_text(encoding="utf-8")
+            + "\n"
+            + (candidate / "test/CMakeLists.txt").read_text(encoding="utf-8")
+        )
+        if len(pins) != 2 or any(pin != expected_simulator for pin in pins):
+            raise RuntimeError(
+                "CrossMux candidate does not pin one reviewed simulator revision; rerun start."
+            )
+        run_crossmux_builds(candidate, args.skip_builds, args.extra_build_env)
+    commit_candidate(candidate, state)
+    push_and_create_pr(candidate, state, args.review_note, args.skip_builds)
     return 0
 
 
-def cmd_run(args: argparse.Namespace) -> int:
-    start_status = cmd_start(args)
-    if start_status != 0:
-        return start_status
-    return cmd_publish(args)
-
-
 def add_common_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--origin-remote", default="origin", help="remote to push branches to")
-    parser.add_argument("--upstream-remote", default="upstream", help="remote to sync from")
-    parser.add_argument("--base-branch", default="auto", help="base branch, or auto from sc/origin HEAD")
-    parser.add_argument(
-        "--upstream-branch",
-        default=DEFAULT_UPSTREAM_BRANCH,
-        help=f"upstream branch to sync, default: {DEFAULT_UPSTREAM_BRANCH}",
-    )
-    parser.add_argument("--branch-prefix", default=DEFAULT_BRANCH_PREFIX, help="prefix for generated sync branches")
-    parser.add_argument(
-        "--squash-from",
-        default="auto",
-        help="base ref for squash fallback, 'auto', or 'none'",
-    )
+    parser.add_argument("--origin-remote", default="origin")
+    parser.add_argument("--upstream-remote", default="upstream")
+    parser.add_argument("--base-branch", default="auto")
+    parser.add_argument("--upstream-branch", default=DEFAULT_UPSTREAM_BRANCH)
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    inspect_parser = subparsers.add_parser("inspect", help="show detected remotes, branches, and suggested branch")
+    inspect_parser = subparsers.add_parser(
+        "inspect", help="inspect all three components"
+    )
     add_common_options(inspect_parser)
     inspect_parser.set_defaults(func=cmd_inspect)
 
-    start_parser = subparsers.add_parser("start", help="create a sync branch and stage the upstream merge")
+    start_parser = subparsers.add_parser(
+        "start", help="prepare one isolated candidate without publishing"
+    )
     add_common_options(start_parser)
+    start_parser.add_argument(
+        "--component", choices=("sdk", "simulator", "crossmux"), required=True
+    )
+    start_parser.add_argument(
+        "--candidate-root", help="override the temporary candidate parent directory"
+    )
+    start_parser.add_argument(
+        "--behavior-overlap",
+        action="append",
+        default=[],
+        help="record a manually discovered cross-file or cross-symbol overlap; repeatable",
+    )
     start_parser.set_defaults(func=cmd_start)
 
-    publish_parser = subparsers.add_parser("publish", help="validate, commit, push, and open a PR")
+    publish_parser = subparsers.add_parser(
+        "publish", help="validate and publish one approved candidate"
+    )
     add_common_options(publish_parser)
-    publish_parser.add_argument("--draft", action="store_true", default=True, help="open the PR as draft")
-    publish_parser.add_argument("--ready", action="store_false", dest="draft", help="open a ready-for-review PR")
-    publish_parser.add_argument("--skip-builds", action="store_true", help="skip PlatformIO build validation")
     publish_parser.add_argument(
-        "--extra-build-env", action="append", default=[], metavar="ENV", help="also run `pio run -e ENV`; repeatable"
+        "--component", choices=("sdk", "simulator", "crossmux"), required=True
+    )
+    publish_parser.add_argument(
+        "--candidate", required=True, help="candidate path printed by start"
+    )
+    publish_parser.add_argument(
+        "--draft", action="store_true", default=True, help=argparse.SUPPRESS
+    )
+    publish_parser.add_argument("--skip-builds", action="store_true")
+    publish_parser.add_argument(
+        "--extra-build-env", action="append", default=[], metavar="ENV"
+    )
+    publish_parser.add_argument(
+        "--review-note",
+        action="append",
+        default=[],
+        help="record one user-approved conflict or overlap resolution; repeatable",
     )
     publish_parser.set_defaults(func=cmd_publish)
-
-    run_parser = subparsers.add_parser("run", help="start and publish the sync in one command")
-    add_common_options(run_parser)
-    run_parser.add_argument("--draft", action="store_true", default=True, help="open the PR as draft")
-    run_parser.add_argument("--ready", action="store_false", dest="draft", help="open a ready-for-review PR")
-    run_parser.add_argument("--skip-builds", action="store_true", help="skip PlatformIO build validation")
-    run_parser.add_argument(
-        "--extra-build-env", action="append", default=[], metavar="ENV", help="also run `pio run -e ENV`; repeatable"
-    )
-    run_parser.set_defaults(func=cmd_run)
     return parser.parse_args(argv)
 
 

--- a/.claude/skills/sync-upstream/tests/test_sync_upstream.py
+++ b/.claude/skills/sync-upstream/tests/test_sync_upstream.py
@@ -1,0 +1,308 @@
+import argparse
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "sync_upstream.py"
+SPEC = importlib.util.spec_from_file_location("sync_upstream", SCRIPT)
+assert SPEC and SPEC.loader
+sync_upstream = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sync_upstream
+SPEC.loader.exec_module(sync_upstream)
+
+
+def command(root: Path, *args: str) -> str:
+    return subprocess.run(
+        list(args), cwd=root, check=True, text=True, stdout=subprocess.PIPE
+    ).stdout.strip()
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    command(path, "git", "init", "-b", "main")
+    command(path, "git", "config", "user.name", "Sync Test")
+    command(path, "git", "config", "user.email", "sync@example.com")
+
+
+def commit_file(root: Path, name: str, content: str, message: str) -> None:
+    (root / name).write_text(content, encoding="utf-8")
+    command(root, "git", "add", name)
+    command(root, "git", "commit", "-m", message)
+
+
+def status(name: str, action: str) -> object:
+    parent_in_fork = action == "up-to-date"
+    open_pr = action == "wait-for-pr"
+    return sync_upstream.DependencyStatus(
+        name, "a" * 40, "b" * 40, parent_in_fork, open_pr, ()
+    )
+
+
+class DependencyStateTest(unittest.TestCase):
+    def test_fork_already_contains_parent(self):
+        self.assertEqual(
+            sync_upstream.decide_dependency_action(True, False), "up-to-date"
+        )
+
+    def test_fork_behind_requires_sync(self):
+        self.assertEqual(
+            sync_upstream.decide_dependency_action(False, False), "sync-required"
+        )
+
+    def test_open_pull_request_blocks_next_stage(self):
+        self.assertEqual(
+            sync_upstream.decide_dependency_action(False, True), "wait-for-pr"
+        )
+
+    def test_dependencies_gate_crossmux_in_order(self):
+        self.assertEqual(
+            sync_upstream.next_component(
+                {
+                    "sdk": status("sdk", "sync-required"),
+                    "simulator": status("simulator", "up-to-date"),
+                }
+            ),
+            "sdk",
+        )
+        self.assertEqual(
+            sync_upstream.next_component(
+                {
+                    "sdk": status("sdk", "up-to-date"),
+                    "simulator": status("simulator", "wait-for-pr"),
+                }
+            ),
+            "simulator",
+        )
+        self.assertEqual(
+            sync_upstream.next_component(
+                {
+                    "sdk": status("sdk", "up-to-date"),
+                    "simulator": status("simulator", "up-to-date"),
+                }
+            ),
+            "crossmux",
+        )
+
+
+class PinUpdateTest(unittest.TestCase):
+    def test_updates_both_simulator_pins_to_one_revision(self):
+        sha = "c" * 40
+        platformio, cmake = sync_upstream.replace_simulator_pins(
+            "simulator=https://github.com/0x1abin/crosspoint-simulator.git#" + "a" * 40,
+            "GIT_REPOSITORY https://github.com/0x1abin/crosspoint-simulator.git\n  GIT_TAG "
+            + "b" * 40,
+            sha,
+        )
+        pins = sync_upstream.simulator_pins(platformio + "\n" + cmake)
+        self.assertEqual(pins, (sha, sha))
+
+
+class ReviewGateTest(unittest.TestCase):
+    def test_pr_body_pairs_each_review_item_with_its_decision(self):
+        state = {
+            "component": "sdk",
+            "upstream_sha": "a" * 40,
+            "candidate_id": "review-id",
+            "review_items": ["one.cpp", "two.cpp"],
+        }
+        body = sync_upstream.pr_body(
+            state,
+            ["Keep the local API.", "Use the combined implementation."],
+            False,
+        )
+        self.assertIn("`one.cpp`: Keep the local API.", body)
+        self.assertIn("`two.cpp`: Use the combined implementation.", body)
+
+    def test_resolved_conflict_remains_a_review_item(self):
+        state = {
+            "component": "sdk",
+            "conflict_paths": ["shared.cpp"],
+            "overlap_paths": [],
+            "review_items": ["shared.cpp"],
+        }
+        with patch.object(
+            sync_upstream, "unmerged_paths", return_value=[]
+        ), patch.object(sync_upstream, "write_state"):
+            refreshed = sync_upstream.refresh_candidate(Path("/tmp/not-used"), state)
+        self.assertEqual(refreshed["conflict_paths"], [])
+        self.assertEqual(refreshed["review_items"], ["shared.cpp"])
+
+    def test_publish_requires_review_note_for_overlap(self):
+        state = {
+            "component": "sdk",
+            "conflict_paths": [],
+            "overlap_paths": ["shared.cpp"],
+            "review_items": ["shared.cpp"],
+        }
+        args = argparse.Namespace(
+            candidate="/tmp/not-used",
+            component="sdk",
+            review_note=[],
+            skip_builds=True,
+            extra_build_env=[],
+        )
+        with patch.object(
+            sync_upstream, "read_state", return_value=state
+        ), patch.object(sync_upstream, "refresh_candidate", return_value=state):
+            with self.assertRaisesRegex(RuntimeError, "1 manual review items"):
+                sync_upstream.cmd_publish(args)
+
+    def test_publish_requires_one_note_per_review_item(self):
+        state = {
+            "component": "sdk",
+            "conflict_paths": [],
+            "overlap_paths": ["one.cpp", "two.cpp"],
+            "review_items": ["one.cpp", "two.cpp"],
+        }
+        args = argparse.Namespace(
+            candidate="/tmp/not-used",
+            component="sdk",
+            review_note=["Approved one.cpp resolution."],
+            skip_builds=True,
+            extra_build_env=[],
+        )
+        with patch.object(
+            sync_upstream, "read_state", return_value=state
+        ), patch.object(sync_upstream, "refresh_candidate", return_value=state):
+            with self.assertRaisesRegex(RuntimeError, "2 manual review items"):
+                sync_upstream.cmd_publish(args)
+
+    def test_cli_has_no_run_shortcut(self):
+        with self.assertRaises(SystemExit):
+            sync_upstream.parse_args(["run"])
+
+
+class IsolatedMergeDryRunTest(unittest.TestCase):
+    def test_start_prepares_candidate_without_commit_push_or_pr(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            base = temp / "base"
+            init_repo(base)
+            commit_file(base, "shared.txt", "value=0\n", "base")
+            fork = temp / "fork"
+            parent = temp / "parent"
+            command(temp, "git", "clone", str(base), str(fork))
+            command(temp, "git", "clone", str(base), str(parent))
+            for repo in (fork, parent):
+                command(repo, "git", "config", "user.name", "Sync Test")
+                command(repo, "git", "config", "user.email", "sync@example.com")
+            commit_file(fork, "fork.txt", "fork\n", "fork change")
+            commit_file(parent, "parent.txt", "parent\n", "parent change")
+            fork_sha = command(fork, "git", "rev-parse", "HEAD")
+            parent_sha = command(parent, "git", "rev-parse", "HEAD")
+            statuses = {
+                "sdk": sync_upstream.DependencyStatus(
+                    "sdk", parent_sha, fork_sha, False, False, ()
+                ),
+                "simulator": status("simulator", "up-to-date"),
+            }
+            args = argparse.Namespace(
+                component="sdk",
+                candidate_root=str(temp / "candidates"),
+                behavior_overlap=[],
+            )
+            context = sync_upstream.Context(
+                base, "main", "upstream", "origin", "develop"
+            )
+            with patch.object(
+                sync_upstream, "build_context", return_value=context
+            ), patch.object(
+                sync_upstream, "inspect_dependencies", return_value=statuses
+            ), patch.object(
+                sync_upstream.Dependency,
+                "fork_url",
+                new_callable=PropertyMock,
+                return_value=str(fork),
+            ), patch.object(
+                sync_upstream.Dependency,
+                "parent_url",
+                new_callable=PropertyMock,
+                return_value=str(parent),
+            ), patch.object(
+                sync_upstream, "push_and_create_pr"
+            ) as publish:
+                self.assertEqual(sync_upstream.cmd_start(args), 0)
+                publish.assert_not_called()
+
+            candidate = sync_upstream.candidate_path(
+                "sdk", parent_sha, str(temp / "candidates")
+            )
+            self.assertEqual(command(candidate, "git", "rev-parse", "HEAD"), fork_sha)
+            self.assertTrue(sync_upstream.has_merge_head(candidate))
+            self.assertEqual(command(fork, "git", "branch", "--show-current"), "main")
+
+    def test_clean_same_file_overlap_stays_uncommitted(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir) / "base"
+            init_repo(base)
+            commit_file(
+                base,
+                "shared.txt",
+                "local=0\nkeep=1\nkeep=2\nkeep=3\nkeep=4\nupstream=0\n",
+                "base",
+            )
+
+            fork = Path(temp_dir) / "fork"
+            upstream = Path(temp_dir) / "upstream"
+            command(Path(temp_dir), "git", "clone", str(base), str(fork))
+            command(Path(temp_dir), "git", "clone", str(base), str(upstream))
+            for repo in (fork, upstream):
+                command(repo, "git", "config", "user.name", "Sync Test")
+                command(repo, "git", "config", "user.email", "sync@example.com")
+            commit_file(
+                fork,
+                "shared.txt",
+                "local=1\nkeep=1\nkeep=2\nkeep=3\nkeep=4\nupstream=0\n",
+                "fork change",
+            )
+            commit_file(
+                upstream,
+                "shared.txt",
+                "local=0\nkeep=1\nkeep=2\nkeep=3\nkeep=4\nupstream=1\n",
+                "upstream change",
+            )
+            command(fork, "git", "remote", "add", "upstream", str(upstream))
+            command(fork, "git", "fetch", "upstream", "main")
+
+            head_before = command(fork, "git", "rev-parse", "HEAD")
+            self.assertEqual(
+                sync_upstream.overlap_paths(fork, "HEAD", "upstream/main"),
+                ("shared.txt",),
+            )
+            self.assertEqual(
+                sync_upstream.merge_without_commit(fork, "upstream/main", "test merge"),
+                [],
+            )
+            self.assertEqual(command(fork, "git", "rev-parse", "HEAD"), head_before)
+            self.assertTrue(sync_upstream.has_merge_head(fork))
+
+    def test_git_conflict_is_left_for_manual_review(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir) / "base"
+            init_repo(base)
+            commit_file(base, "shared.txt", "value=0\n", "base")
+            fork = Path(temp_dir) / "fork"
+            upstream = Path(temp_dir) / "upstream"
+            command(Path(temp_dir), "git", "clone", str(base), str(fork))
+            command(Path(temp_dir), "git", "clone", str(base), str(upstream))
+            for repo in (fork, upstream):
+                command(repo, "git", "config", "user.name", "Sync Test")
+                command(repo, "git", "config", "user.email", "sync@example.com")
+            commit_file(fork, "shared.txt", "value=local\n", "fork change")
+            commit_file(upstream, "shared.txt", "value=upstream\n", "upstream change")
+            command(fork, "git", "remote", "add", "upstream", str(upstream))
+            command(fork, "git", "fetch", "upstream", "main")
+
+            self.assertEqual(
+                sync_upstream.merge_without_commit(fork, "upstream/main", "test merge"),
+                ["shared.txt"],
+            )
+            self.assertEqual(sync_upstream.unmerged_paths(fork), ["shared.txt"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the one-command upstream sync with approval-gated `inspect`, `start`, and `publish` stages
- synchronize the FreeInk SDK and CrossPoint Simulator forks before CrossMux, then pin both reviewed revisions
- require explicit manual decisions for Git conflicts and behavioral overlap before publishing

## Validation

- `python3 -m unittest discover -v -s .claude/skills/sync-upstream/tests` (13 tests)
- `python3 /Users/zzb/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/sync-upstream`
- `git diff --check`

PlatformIO builds and hardware validation were not run because this PR only changes the sync skill tooling.
