### PR TITLE
fix: improve touch and button UI

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -44,6 +44,7 @@ full reasoning, examples, and edge cases.
 11. **Edit sources, not generated files** (`*.generated.h`, `I18n*` generated headers). → [generated-files.md](docs/engineering/generated-files.md)
 12. **Verify repo context before any git op; ask before committing.** Unqualified PR requests target `0x1abin/crossmux:main` via `origin` without asking; an explicit user target overrides this default. Never stage `.gitignore`d files. → [git-workflow.md](docs/engineering/git-workflow.md)
 13. **One physical button gesture causes one action.** Normal Activities read the shared input snapshot; across popups and Activities, gate inherited held buttons and consume the triggering release. → [ui-and-input.md](docs/engineering/ui-and-input.md)
+14. **Adjacent interactive controls keep at least 6 px of visible space.** Their hit regions must not overlap, and drawing plus hit-testing must use the same geometry source. → [touch-and-ui.md](docs/contributing/touch-and-ui.md)
 
 ## Quick Reference
 

--- a/docs/contributing/touch-and-ui.md
+++ b/docs/contributing/touch-and-ui.md
@@ -84,6 +84,36 @@ See [`FileBrowserActivity`](../../src/activities/home/FileBrowserActivity.cpp)'s
 - `TextStyle.maxLines` defaults to 1 and truncates with an ellipsis. Set `maxLines` explicitly on any dialog headline or message that can wrap.
 - Everything stays allocation-free in steady state. A local `std::vector` inside `buildScreen()` is **not** allocation-free even with `reserve()` first: it starts at zero capacity on every call, `reserve()` allocates, and the destructor frees that storage before the call returns — real allocator work and fragmentation risk on every repaint (cursor move, tap flash, ...), not just on data changes. Build `ListItem` rows into activity-owned storage instead, reserved once when the underlying data loads (`onEnter()`/a `load*()` — see the skeleton above and `FileBrowserActivity::rebuildRowItems()`), and reused unchanged by every `buildScreen()` call. Use a fixed-capacity array (e.g. `ListItem rows[MAX]`, as `OptionPopup` and `KOReaderSyncActivity`'s action rows do) when the count is small and bounded. Do not hold FUI `props` across renders — only the row storage they point into.
 
+### Spacing and hit geometry
+
+Adjacent interactive controls must have at least **6 px of visible background**
+between them in every theme and orientation. A theme token may request more
+space, but never less. Hit regions must stay inside their control's drawn
+rectangle and must not overlap a neighbour.
+
+Calculate each rectangle once and pass that same value to both drawing and
+interaction registration. Do not repeat the arithmetic in a touch handler.
+FreeInkUI components already follow this rule; custom surfaces should expose a
+small geometry helper, as `gameTouchActionRect()` does.
+
+```cpp
+const Rect action = actionRect(index);  // one source of truth
+drawAction(action, label);
+frame.hit(action, ACTION_SELECT, index, fui::InputTouch);
+```
+
+Do not draw tightly packed buttons and then enlarge each hit area into the gap:
+that creates ambiguous taps even when the visible controls appear separate.
+
+Review every interactive screen for:
+
+- a touch path and a logical-button path to every action;
+- tap activation on release, with press used only for feedback;
+- swipe/page gestures that never activate the row beneath them;
+- at least 6 px between adjacent controls and no overlapping hit rectangles;
+- shared drawing/hit geometry in every supported orientation;
+- no allocation while rendering or routing steady-state input.
+
 ### Component inventory
 
 All under `freeink-sdk/libs/ui/FreeInkUI/include/components/`:

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -4,6 +4,7 @@
 #include "CrossPointSettings.h"
 #include "I18n.h"
 #include "components/UITheme.h"
+#include "util/ButtonNavigator.h"
 
 void Activity::onEnter() { LOG_DBG("ACT", "Entering activity: %s", name.c_str()); }
 
@@ -70,6 +71,18 @@ Activity::ListTouchResult Activity::handleListTouch(int& selectedIndex, const in
   if (mappedInput.wasListItemTapped(touched, itemCount, selectedIndex, listTop, listHeight, hasSubtitle)) {
     selectedIndex = touched;
     return ListTouchResult::Activated;
+  }
+  const auto swipe = mappedInput.wasSwipe();
+  if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
+    const int pageItems = GUI.getListPageItems(listHeight, hasSubtitle);
+    const int next = swipe == MappedInputManager::SwipeDir::Up
+                         ? ButtonNavigator::nextPageIndex(selectedIndex, itemCount, pageItems)
+                         : ButtonNavigator::previousPageIndex(selectedIndex, itemCount, pageItems);
+    if (next != selectedIndex) {
+      selectedIndex = next;
+      requestUpdate();
+    }
+    return ListTouchResult::Consumed;
   }
   return ListTouchResult::None;
 }

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -100,8 +100,8 @@ class Activity {
     Activated  // tap landed on a row: selectedIndex is updated, caller activates it
   };
 
-  // Shared touch handling for selectable list screens: touchdown highlights the
-  // touched row, a tap selects and reports Activated. The caller supplies the
-  // list band and runs its own activate action on Activated.
+  // Compatibility path for legacy theme lists: touchdown highlights, tap
+  // activates, and vertical swipe changes a whole page without activation.
+  // New screens use UiListActivity and its separate selection/viewport state.
   ListTouchResult handleListTouch(int& selectedIndex, int itemCount, int listTop, int listHeight, bool hasSubtitle);
 };

--- a/src/activities/apps/AppsMenuActivity.cpp
+++ b/src/activities/apps/AppsMenuActivity.cpp
@@ -7,12 +7,14 @@
 #include <string>
 
 #include "../../components/UITheme.h"
+#include "../../components/UiAppHelpers.h"
 #include "../../components/icons/inx_apps.h"
-#include "../../util/PaginationDots.h"
 #include "CrossPointSettings.h"
 #include "InxItemLayout.h"
 #include "OpdsServerStore.h"
 #include "fontIds.h"
+
+namespace fui = freeink::ui;
 
 namespace {
 
@@ -111,20 +113,6 @@ constexpr bool appIdsAreUnique() {
   return true;
 }
 
-constexpr bool usesSideScrollBar(const CrossPointSettings::UI_THEME theme) {
-  switch (theme) {
-    case CrossPointSettings::LYRA:
-    case CrossPointSettings::LYRA_3_COVERS:
-    case CrossPointSettings::LYRA_CAROUSEL:
-    case CrossPointSettings::INX:
-      return true;
-    case CrossPointSettings::CLASSIC:
-    case CrossPointSettings::ROUNDEDRAFF:
-      return false;
-  }
-  return false;
-}
-
 static_assert(kAppCount <= 32, "the app catalog must fit hiddenAppsMask");
 static_assert(static_cast<uint8_t>(AppId::Count) <= 32, "hiddenAppsMask supports at most 32 stable app IDs");
 static_assert(static_cast<uint8_t>(AppId::Buddy) == CrossPointSettings::BUDDY_APP_ID,
@@ -182,7 +170,8 @@ int AppsMenuActivity::getVisibleAppCount() {
 }
 
 void AppsMenuActivity::selectMainTabContentEdge(const MainTabContentEdge edge) {
-  selected = MainTabs::contentEdgeIndex(edge, getVisibleAppCount());
+  nav.selected = MainTabs::contentEdgeIndex(edge, getVisibleAppCount());
+  nav.follow(getVisibleAppCount());
 }
 
 int AppsMenuActivity::getAppIndexForVisibleIndex(const int visibleIndex) {
@@ -191,12 +180,23 @@ int AppsMenuActivity::getAppIndexForVisibleIndex(const int visibleIndex) {
 }
 
 void AppsMenuActivity::onEnter() {
-  Activity::onEnter();
-  selected = 0;
-  requestUpdate();
+  UiListActivity::onEnter();
+  rebuildRowItems();
 }
 
-void AppsMenuActivity::onExit() { Activity::onExit(); }
+void AppsMenuActivity::rebuildRowItems() {
+  rowItems.clear();
+  rowItems.reserve(static_cast<size_t>(getVisibleAppCount()));
+  for (int visibleIndex = 0; visibleIndex < getVisibleAppCount(); ++visibleIndex) {
+    const int appIndex = getAppIndexForVisibleIndex(visibleIndex);
+    if (appIndex < 0) continue;
+    fui::ListItem item;
+    item.label = I18N.get(kAppEntries[appIndex].titleId);
+    item.icon = listIconFor(kAppEntries[appIndex].icon, 32);
+    item.actionValue = static_cast<int16_t>(visibleIndex);
+    rowItems.push_back(item);
+  }
+}
 
 bool AppsMenuActivity::usesIconLayout() const {
   return UITheme::getInstance().hasMainTabs() &&
@@ -208,67 +208,59 @@ int AppsMenuActivity::iconIndexFromPoint(const int x, const int y) const {
   const int top = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
   const int height = renderer.getScreenHeight() - top - metrics.buttonHintsHeight - metrics.verticalSpacing;
   return InxGridGeometry::indexFromPoint(x, y - top, renderer.getScreenWidth(), height,
-                                         InxGridGeometry::pageStart(selected, getVisibleAppCount()),
+                                         InxGridGeometry::pageStart(nav.selected, getVisibleAppCount()),
                                          getVisibleAppCount());
 }
 
 void AppsMenuActivity::openSelected() {
-  const int appIndex = getAppIndexForVisibleIndex(selected);
+  const int appIndex = getAppIndexForVisibleIndex(nav.selected);
   if (appIndex >= 0) (activityManager.*kAppEntries[appIndex].open)();
 }
 
-void AppsMenuActivity::loop() {
+void AppsMenuActivity::activateIndex(const int index) {
+  app.clearTapFlash();
+  nav.selected = index;
+  openSelected();
+}
+
+bool AppsMenuActivity::handleCustomInput() {
+  if (!usesIconLayout()) return false;
+
   const int visibleCount = getVisibleAppCount();
-  if (usesIconLayout()) {
-    int x = 0;
-    int y = 0;
-    if (mappedInput.wasScreenTouchDown(x, y)) {
-      const int touched = iconIndexFromPoint(x, y);
-      if (touched >= 0 && touched != selected) {
-        selected = touched;
-        requestUpdate();
-      }
-      return;
-    }
-    if (mappedInput.wasScreenTapped(x, y)) {
-      const int touched = iconIndexFromPoint(x, y);
-      if (touched >= 0) {
-        selected = touched;
-        openSelected();
-      }
-      return;
-    }
-    const auto swipe = mappedInput.wasSwipe();
-    if (swipe == MappedInputManager::SwipeDir::Up) {
-      selected = ButtonNavigator::nextPageIndex(selected, visibleCount, InxGridGeometry::itemsPerPage);
+  int x = 0;
+  int y = 0;
+  if (mappedInput.wasScreenTouchDown(x, y)) {
+    const int touched = iconIndexFromPoint(x, y);
+    if (touched >= 0 && touched != nav.selected) {
+      nav.selected = touched;
       requestUpdate();
-      return;
     }
-    if (swipe == MappedInputManager::SwipeDir::Down) {
-      selected = ButtonNavigator::previousPageIndex(selected, visibleCount, InxGridGeometry::itemsPerPage);
-      requestUpdate();
-      return;
+    return true;
+  }
+  if (mappedInput.wasScreenTapped(x, y)) {
+    const int touched = iconIndexFromPoint(x, y);
+    if (touched >= 0) {
+      nav.selected = touched;
+      openSelected();
     }
+    return true;
   }
-
-  buttonNavigator.onNext([this, visibleCount] {
-    selected = ButtonNavigator::nextIndex(selected, visibleCount);
+  const auto swipe = mappedInput.wasSwipe();
+  if (swipe == MappedInputManager::SwipeDir::Up) {
+    nav.selected = ButtonNavigator::nextPageIndex(nav.selected, visibleCount, InxGridGeometry::itemsPerPage);
     requestUpdate();
-  });
-  buttonNavigator.onPrevious([this, visibleCount] {
-    selected = ButtonNavigator::previousIndex(selected, visibleCount);
-    requestUpdate();
-  });
-
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    openSelected();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    activityManager.goHome();
+    return true;
   }
+  if (swipe == MappedInputManager::SwipeDir::Down) {
+    nav.selected = ButtonNavigator::previousPageIndex(nav.selected, visibleCount, InxGridGeometry::itemsPerPage);
+    requestUpdate();
+    return true;
+  }
+  return false;
 }
 
 void AppsMenuActivity::drawIconGrid(const Rect& rect, const int visibleCount, const bool showSelection) const {
-  const int start = InxGridGeometry::pageStart(selected, visibleCount);
+  const int start = InxGridGeometry::pageStart(nav.selected, visibleCount);
   const int cellWidth = rect.width / InxGridGeometry::columns;
   const int cellHeight = rect.height / InxGridGeometry::rows;
   const int lineHeight = renderer.getLineHeight(UI_10_FONT_ID);
@@ -282,7 +274,7 @@ void AppsMenuActivity::drawIconGrid(const Rect& rect, const int visibleCount, co
     const int column = slot % InxGridGeometry::columns;
     const int row = slot / InxGridGeometry::columns;
     const Rect cell{rect.x + column * cellWidth + 4, rect.y + row * cellHeight + 4, cellWidth - 8, cellHeight - 8};
-    const bool isSelected = showSelection && visibleIndex == selected;
+    const bool isSelected = showSelection && visibleIndex == nav.selected;
     if (isSelected) renderer.fillRect(cell.x, cell.y, cell.width, cell.height, true);
 
     const int iconX = cell.x + (cell.width - iconSize) / 2;
@@ -297,18 +289,13 @@ void AppsMenuActivity::drawIconGrid(const Rect& rect, const int visibleCount, co
   GUI.drawSideScrollBar(renderer, rect, visibleCount, start, InxGridGeometry::itemsPerPage);
 }
 
-void AppsMenuActivity::render(RenderLock&&) {
+void AppsMenuActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int sw = renderer.getScreenWidth();
   const int sh = renderer.getScreenHeight();
-
-  renderer.clearScreen();
-  drawPageHeader(Rect{0, metrics.topPadding, sw, metrics.headerHeight}, tr(STR_APPS_TITLE));
-
   const int listY = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
   const int listH = sh - listY - metrics.buttonHintsHeight - metrics.verticalSpacing;
   const int visibleCount = getVisibleAppCount();
-  const auto theme = static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme);
   const bool showSelection = showMainTabContentSelection();
 
   if (visibleCount == 0) {
@@ -316,41 +303,29 @@ void AppsMenuActivity::render(RenderLock&&) {
   } else if (usesIconLayout()) {
     drawIconGrid(Rect{0, listY, sw, listH}, visibleCount, showSelection);
   } else {
-    // Halved inter-row gap (8 -> 4 on LYRA) keeps the home-tile look but tightens the list.
-    const int spacing = metrics.menuSpacing / 2;
-    const int rowStep = metrics.menuRowHeight + spacing;
-    // Number of rows that fit: n rows occupy n*rowHeight + (n-1)*spacing <= listH.
-    const int perPage = std::max(1, (listH + spacing) / rowStep);
-    const int totalPages = (visibleCount + perPage - 1) / perPage;
-    const int page = selected / perPage;
-    const int pageStart = page * perPage;
-    const int pageCount = std::min(perPage, visibleCount - pageStart);
-
-    // ponytail: scan at most 32 entries instead of keeping a RAM-backed filtered list.
-    GUI.drawButtonMenu(
-        renderer, Rect{0, listY, sw, listH}, pageCount, showSelection ? selected - pageStart : -1,
-        [pageStart](int i) {
-          const int appIndex = getAppIndexForVisibleIndex(i + pageStart);
-          return appIndex >= 0 ? std::string(I18N.get(kAppEntries[appIndex].titleId)) : std::string();
-        },
-        [pageStart](int i) {
-          const int appIndex = getAppIndexForVisibleIndex(i + pageStart);
-          return appIndex >= 0 ? kAppEntries[appIndex].icon : UIIcon::None;
-        },
-        spacing);
-
-    if (totalPages > 1) {
-      if (usesSideScrollBar(theme)) {
-        GUI.drawSideScrollBar(renderer, Rect{0, listY, sw, listH}, visibleCount, pageStart, perPage);
-      } else {
-        const int dotsY = listY + listH - 8;
-        drawPaginationDots(renderer, sw, dotsY, totalPages, page);
-      }
-    }
+    const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+    screen.setContentMargin(fui::Insets{static_cast<int16_t>(listY), static_cast<int16_t>(sw - (safe.x + safe.width)),
+                                        static_cast<int16_t>(sh - (safe.y + safe.height)),
+                                        static_cast<int16_t>(safe.x)});
+    fui::ListProps props;
+    props.items = rowItems.data();
+    props.count = static_cast<uint16_t>(rowItems.size());
+    props.action = ACTION_ROW;
+    props.inputMask = fui::InputTouch;
+    syncListViewport(screen, props);
+    screen.list(props);
   }
+}
 
+void AppsMenuActivity::drawChrome() {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  drawPageHeader(Rect{0, metrics.topPadding, renderer.getScreenWidth(), metrics.headerHeight}, tr(STR_APPS_TITLE));
+}
+
+void AppsMenuActivity::drawFooter() {
+  const int visibleCount = getVisibleAppCount();
   const auto labels = mainTabButtonLabels(tr(STR_BACK), tr(STR_SELECT), visibleCount > 1);
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-
-  renderer.displayBuffer();
 }
+
+void AppsMenuActivity::onBackButton() { activityManager.goHome(); }

--- a/src/activities/apps/AppsMenuActivity.h
+++ b/src/activities/apps/AppsMenuActivity.h
@@ -2,23 +2,21 @@
 
 #include <I18n.h>
 
-#include "../../util/ButtonNavigator.h"
-#include "../Activity.h"
+#include <vector>
+
+#include "activities/UiListActivity.h"
 
 // Apps menu — the single entry-point on the home screen for all non-reader sub-apps
 // (Sudoku, Gomoku, Ugly Avatar, ...). The full list is the constexpr `kAppEntries` table
 // in AppsMenuActivity.cpp; add a new app by assigning a stable AppId, appending one row,
 // and adding goTo<App>() in ActivityManager. See src/activities/apps/README.md.
-class AppsMenuActivity final : public Activity {
+class AppsMenuActivity final : public UiListActivity {
  public:
   AppsMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("AppsMenu", renderer, mappedInput) {}
+      : UiListActivity("AppsMenu", renderer, mappedInput) {}
   ~AppsMenuActivity() override = default;
 
   void onEnter() override;
-  void onExit() override;
-  void loop() override;
-  void render(RenderLock&&) override;
   MainTab mainTab() const override { return MainTab::Apps; }
   void selectMainTabContentEdge(MainTabContentEdge edge) override;
 
@@ -30,11 +28,21 @@ class AppsMenuActivity final : public Activity {
  private:
   static int getVisibleAppCount();
   static int getAppIndexForVisibleIndex(int visibleIndex);
+  int listCount() const override { return getVisibleAppCount(); }
+  void buildScreen(UiScreen& screen) override;
+  void activateIndex(int index) override;
+  bool handleCustomInput() override;
+  void onBackButton() override;
+  void drawChrome() override;
+  void drawFooter() override;
   bool usesIconLayout() const;
   int iconIndexFromPoint(int x, int y) const;
+  void rebuildRowItems();
   void openSelected();
   void drawIconGrid(const Rect& rect, int visibleCount, bool showSelection) const;
 
-  ButtonNavigator buttonNavigator;
-  int selected = 0;
+  // Allocated once on entry and reused for every repaint. The app catalog is
+  // bounded to 32 entries; dynamic storage avoids pinning the maximum in every
+  // live Apps activity while keeping render allocation-free.
+  std::vector<freeink::ui::ListItem> rowItems;
 };

--- a/src/activities/apps/GameUi.cpp
+++ b/src/activities/apps/GameUi.cpp
@@ -4,10 +4,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "GfxRenderer.h"
-#include "MappedInputManager.h"
-#include "fontIds.h"
-
 void gameFormatElapsed(uint32_t ms, char* out, size_t outLen) {
   const uint32_t totalSec = ms / 1000;
   const uint32_t mm = (totalSec / 60) % 100;
@@ -40,79 +36,11 @@ bool gameIntersectionFromPoint(const int originX, const int originY, const int p
 Rect gameTouchActionRect(const int screenWidth, const int screenHeight, const int sidePadding, const int gap,
                          const int height, const int index, const int count) {
   if (screenWidth <= 0 || screenHeight <= 0 || height <= 0 || count <= 0 || index < 0 || index >= count) return Rect{};
+  constexpr int MIN_ACTION_GAP = 6;
   const int safePadding = std::max(0, sidePadding);
-  const int safeGap = std::max(0, gap);
+  const int safeGap = count > 1 ? std::max(MIN_ACTION_GAP, gap) : 0;
   const int availableWidth = screenWidth - safePadding * 2 - safeGap * (count - 1);
   if (availableWidth < count) return Rect{};
   const int width = availableWidth / count;
   return Rect{safePadding + index * (width + safeGap), screenHeight - safePadding - height, width, height};
-}
-
-Rect gameMenuPanelRect(const int screenWidth, const int screenHeight, const int width, const int titleHeight,
-                       const int rowHeight, const int rowCount) {
-  if (screenWidth <= 0 || screenHeight <= 0 || width <= 0 || titleHeight < 0 || rowHeight <= 0 || rowCount <= 0) {
-    return Rect{};
-  }
-  const int height = titleHeight + rowHeight * rowCount + 4;
-  if (width > screenWidth || height > screenHeight) return Rect{};
-  return Rect{(screenWidth - width) / 2, (screenHeight - height) / 2, width, height};
-}
-
-GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& panel, const int titleHeight,
-                                        const int rowHeight, const int itemCount, uint8_t& selected) {
-  if (itemCount <= 0 || itemCount > UINT8_MAX || panel.width <= 0 || panel.height <= 0 || titleHeight < 0 ||
-      rowHeight <= 0) {
-    return GameMenuInputResult::None;
-  }
-
-  int touched = -1;
-  const auto touch =
-      input.rowTouch(touched, panel.y + titleHeight, rowHeight, itemCount, panel.x, panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    selected = static_cast<uint8_t>(touched);
-    return touch == MappedInputManager::RowTouch::Tap ? GameMenuInputResult::Activated
-                                                      : GameMenuInputResult::SelectionChanged;
-  }
-
-  if (input.wasPressed(MappedInputManager::Button::Up) || input.wasPressed(MappedInputManager::Button::Left)) {
-    selected = static_cast<uint8_t>((selected + itemCount - 1) % itemCount);
-    return GameMenuInputResult::SelectionChanged;
-  }
-  if (input.wasPressed(MappedInputManager::Button::Down) || input.wasPressed(MappedInputManager::Button::Right)) {
-    selected = static_cast<uint8_t>((selected + 1) % itemCount);
-    return GameMenuInputResult::SelectionChanged;
-  }
-  if (input.wasReleased(MappedInputManager::Button::Confirm)) return GameMenuInputResult::Activated;
-  if (input.wasReleased(MappedInputManager::Button::Back)) return GameMenuInputResult::Dismissed;
-  return GameMenuInputResult::None;
-}
-
-void gameDrawMenu(const GfxRenderer& renderer, const Rect& panel, const int titleHeight, const int rowHeight,
-                  const char* title, const GameMenuItem* items, const int itemCount, const int selected) {
-  if (panel.width <= 0 || panel.height <= 0 || titleHeight < 0 || rowHeight <= 0 || !title || !items ||
-      itemCount <= 0) {
-    return;
-  }
-
-  renderer.fillRect(panel.x, panel.y, panel.width, panel.height, false);
-  renderer.drawRect(panel.x, panel.y, panel.width, panel.height, 2, true);
-  renderer.fillRect(panel.x + 2, panel.y + titleHeight, panel.width - 4, 1, true);
-
-  const int itemTextHeight = renderer.getTextHeight(UI_12_FONT_ID);
-  const int hintTextHeight = renderer.getTextHeight(UI_10_FONT_ID);
-  renderer.drawText(UI_12_FONT_ID, panel.x + 12, panel.y + gameCenterY(titleHeight, itemTextHeight), title);
-
-  for (int i = 0; i < itemCount; ++i) {
-    const int rowY = panel.y + titleHeight + i * rowHeight;
-    const bool inverted = i == selected;
-    if (inverted) renderer.fillRect(panel.x + 1, rowY, panel.width - 2, rowHeight, true);
-
-    const char* label = items[i].label ? items[i].label : "";
-    renderer.drawText(UI_12_FONT_ID, panel.x + 12, rowY + gameCenterY(rowHeight, itemTextHeight), label, !inverted);
-    const char* hint = items[i].hint;
-    if (!hint || hint[0] == '\0') continue;
-    const int hintWidth = renderer.getTextWidth(UI_10_FONT_ID, hint);
-    renderer.drawText(UI_10_FONT_ID, panel.x + panel.width - 12 - hintWidth,
-                      rowY + gameCenterY(rowHeight, hintTextHeight) + 2, hint, !inverted);
-  }
 }

--- a/src/activities/apps/GameUi.h
+++ b/src/activities/apps/GameUi.h
@@ -8,13 +8,6 @@
 class GfxRenderer;
 class MappedInputManager;
 
-struct GameMenuItem {
-  const char* label;
-  const char* hint;
-};
-
-enum class GameMenuInputResult : uint8_t { None, SelectionChanged, Activated, Dismissed };
-
 inline int gameCenterY(int boxH, int textH) { return (boxH - textH) / 2; }
 inline int gameCenteredBlockY(int top, int bottom, int blockH) { return top + (bottom - top - blockH) / 2; }
 
@@ -24,8 +17,3 @@ bool gameGridCellFromPoint(const Rect& grid, int rows, int columns, int x, int y
 bool gameIntersectionFromPoint(int originX, int originY, int pitch, int rows, int columns, int x, int y, int& row,
                                int& column);
 Rect gameTouchActionRect(int screenWidth, int screenHeight, int sidePadding, int gap, int height, int index, int count);
-Rect gameMenuPanelRect(int screenWidth, int screenHeight, int width, int titleHeight, int rowHeight, int rowCount);
-GameMenuInputResult gameHandleMenuInput(MappedInputManager& input, const Rect& panel, int titleHeight, int rowHeight,
-                                        int itemCount, uint8_t& selected);
-void gameDrawMenu(const GfxRenderer& renderer, const Rect& panel, int titleHeight, int rowHeight, const char* title,
-                  const GameMenuItem* items, int itemCount, int selected);

--- a/src/activities/apps/README.md
+++ b/src/activities/apps/README.md
@@ -119,13 +119,12 @@ Choose the smallest pattern that fits:
 |---|---|---|
 | Stateless, single screen | `avatar/UglyAvatarActivity` | `Activity`, `GameUi` action geometry; no Store or menu Activity |
 | Stateful, single screen | `2048/Game2048Activity`, `woodfish/WoodfishActivity` | Board/state object plus `GameSaveDebouncer` or an app-specific idle checkpoint |
-| Board game with launcher | `sudoku/` | Separate Board, Store, MenuActivity, GameActivity; `GameUi` menu/input helpers |
+| Board game with launcher | `sudoku/` | Separate Board, Store, MenuActivity, GameActivity; `OptionPopup` for in-game menus |
 
-`GameMenuItem` is a fixed-array row descriptor (`label` plus optional `hint`).
-Use `gameHandleMenuInput()` for touch and logical-button navigation and switch
-exhaustively on its result. Use `gameDrawMenu()` for the matching modal. Keep
-rules, win detection, AI, and persistence in the game: they are not framework
-concerns.
+Use `OptionPopup` for in-game action and difficulty menus. It owns touch hit
+testing, logical-button navigation, and the inherited-input barrier. Build its
+labels when the popup opens, not during rendering. Keep rules, win detection,
+AI, and persistence in the game: they are not framework concerns.
 
 ---
 

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -64,7 +64,6 @@ void ChineseChessGameActivity::onEnter() {
   blackElapsedMs = 0;
   lastTickMs = millis();
   saveDebouncer.clear();
-  menuSel = 0;
   statsRecorded = false;
   resignedFlag = false;
   resignWinner = Side::Red;
@@ -210,26 +209,8 @@ void ChineseChessGameActivity::handleInputPlaying() {
 }
 
 void ChineseChessGameActivity::handleInputGameMenu() {
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 320;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, MENU_ITEM_COUNT);
-  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
-    case GameMenuInputResult::None:
-      return;
-    case GameMenuInputResult::SelectionChanged:
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Activated:
-      runMenuItem(menuSel);
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Dismissed:
-      resumeFromMenu();
-      requestUpdate();
-      return;
-  }
+  gameMenu.handleInput(mappedInput, [this] { requestUpdate(); });
+  if (!gameMenu.isActive() && state == State::GameMenu) resumeFromMenu();
 }
 
 void ChineseChessGameActivity::handleInputGameOver() {
@@ -365,7 +346,11 @@ void ChineseChessGameActivity::onGameOver() {
 
 void ChineseChessGameActivity::enterGameMenu() {
   state = State::GameMenu;
-  menuSel = 0;
+  const char* options[MENU_ITEM_COUNT] = {
+      tr(STR_GAME_RESUME), tr(STR_GOMOKU_UNDO), tr(STR_GOMOKU_RESIGN), tr(STR_GAME_NEW_GAME), tr(STR_GAME_EXIT),
+  };
+  gameMenu.show(tr(STR_GAME_GAME_MENU), options, MENU_ITEM_COUNT, 0,
+                [this](const int index) { runMenuItem(static_cast<uint8_t>(index)); });
 }
 
 void ChineseChessGameActivity::resumeFromMenu() {
@@ -448,7 +433,7 @@ void ChineseChessGameActivity::render(RenderLock&&) {
       break;
     case State::GameMenu:
       renderPlaying();
-      renderGameMenu();
+      if (gameMenu.processRender(renderer, mappedInput)) return;
       break;
     case State::GameOver:
       renderGameOver();
@@ -723,23 +708,6 @@ void ChineseChessGameActivity::drawFooter() {
       hasSelection ? tr(STR_CHINESE_CHESS_CANCEL) : tr(STR_GAME_GAME_MENU_BTN),
       hasSelection ? tr(STR_CHINESE_CHESS_MOVE) : tr(STR_CHINESE_CHESS_SELECT_BTN), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-}
-
-// ---------- Game menu modal ----------
-
-void ChineseChessGameActivity::renderGameMenu() {
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  const Rect panel =
-      gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), ""}, {tr(STR_GOMOKU_RESIGN), ""},
-      {tr(STR_GAME_NEW_GAME), ""}, {tr(STR_GAME_EXIT), ""},
-  };
-  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
-
-  const auto hints = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, hints.btn1, hints.btn2, hints.btn3, hints.btn4);
 }
 
 // ---------- Game over screen ----------

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
@@ -7,6 +7,7 @@
 #include "ChineseChessAI.h"
 #include "ChineseChessBoard.h"
 #include "ChineseChessStore.h"
+#include "components/OptionPopup.h"
 
 class ChineseChessGameActivity final : public Activity {
  public:
@@ -57,7 +58,7 @@ class ChineseChessGameActivity final : public Activity {
   bool aiThinkingArmed = false;
   bool aiThinkingShown = false;
 
-  uint8_t menuSel = 0;
+  OptionPopup gameMenu;
 
   bool statsRecorded = false;
   bool resignedFlag = false;
@@ -69,7 +70,6 @@ class ChineseChessGameActivity final : public Activity {
 
   // Drawing
   void renderPlaying();
-  void renderGameMenu();
   void renderGameOver();
   void drawTitleBar();
   void drawBoard();

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
@@ -70,8 +70,8 @@ void ChineseChessMenuActivity::loop() {
     return;
   }
 
-  if (showingAiDifficulty) {
-    handleAiDifficultyInput();
+  if (difficultyPopup.isActive()) {
+    difficultyPopup.handleInput(mappedInput, [this] { requestUpdate(); });
     return;
   }
 
@@ -100,44 +100,6 @@ void ChineseChessMenuActivity::loop() {
   }
 }
 
-void ChineseChessMenuActivity::handleAiDifficultyInput() {
-  constexpr int kNumLevels = 3;
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 320;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, kNumLevels);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, kNumLevels, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    aiDifficultySel = touched;
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) {
-      ChineseChessStore::clear();
-      activityManager.replaceActivityWith<ChineseChessGameActivity>(ChineseChessMode::VsAi, false,
-                                                                    static_cast<ChineseChessAiLevel>(aiDifficultySel));
-    }
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    aiDifficultySel = (aiDifficultySel + kNumLevels - 1) % kNumLevels;
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    aiDifficultySel = (aiDifficultySel + 1) % kNumLevels;
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    ChineseChessStore::clear();
-    const auto level = static_cast<ChineseChessAiLevel>(aiDifficultySel);
-    activityManager.replaceActivityWith<ChineseChessGameActivity>(ChineseChessMode::VsAi, false, level);
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    showingAiDifficulty = false;
-    requestUpdate();
-  }
-}
-
 void ChineseChessMenuActivity::onSelect() {
   if (selected < 0 || selected >= static_cast<int>(items.size())) return;
   const Item& it = items[selected];
@@ -148,8 +110,13 @@ void ChineseChessMenuActivity::onSelect() {
       return;
     case ItemKind::NewGame:
       if (it.mode == ChineseChessMode::VsAi) {
-        aiDifficultySel = static_cast<int>(ChineseChessAiLevel::Medium);
-        showingAiDifficulty = true;
+        const char* options[] = {tr(STR_GOMOKU_DIFF_EASY), tr(STR_GOMOKU_DIFF_MEDIUM), tr(STR_GOMOKU_DIFF_HARD)};
+        difficultyPopup.show(tr(STR_GOMOKU_DIFFICULTY), options, 3, static_cast<int>(ChineseChessAiLevel::Medium),
+                             [this](const int index) {
+                               ChineseChessStore::clear();
+                               activityManager.replaceActivityWith<ChineseChessGameActivity>(
+                                   ChineseChessMode::VsAi, false, static_cast<ChineseChessAiLevel>(index));
+                             });
         requestUpdate();
         return;
       }
@@ -171,9 +138,7 @@ void ChineseChessMenuActivity::render(RenderLock&&) {
     renderStats();
   } else {
     renderList();
-    if (showingAiDifficulty) {
-      renderAiDifficulty();
-    }
+    if (difficultyPopup.processRender(renderer, mappedInput)) return;
   }
 
   renderer.displayBuffer(HalDisplay::FAST_REFRESH);
@@ -275,43 +240,4 @@ void ChineseChessMenuActivity::renderStats() {
 
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-}
-
-void ChineseChessMenuActivity::renderAiDifficulty() {
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  constexpr int kRows = 3;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, kRows);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  const int titleTextH = renderer.getTextHeight(UI_12_FONT_ID);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(UI_12_FONT_ID, x + 12, y + (titleH - titleTextH) / 2, tr(STR_GOMOKU_DIFFICULTY));
-
-  const char* labels[kRows] = {
-      tr(STR_GOMOKU_DIFF_EASY),
-      tr(STR_GOMOKU_DIFF_MEDIUM),
-      tr(STR_GOMOKU_DIFF_HARD),
-  };
-
-  const int itemTextH = renderer.getTextHeight(UI_12_FONT_ID);
-  const int firstY = y + titleH;
-
-  for (int i = 0; i < kRows; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == aiDifficultySel);
-    if (inverted) {
-      renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    }
-    renderer.drawText(UI_12_FONT_ID, x + 12, rowY + (rowH - itemTextH) / 2, labels[i], !inverted);
-  }
-
-  const auto hints = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, hints.btn1, hints.btn2, hints.btn3, hints.btn4);
 }

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
@@ -6,6 +6,7 @@
 #include "../../../util/ButtonNavigator.h"
 #include "../../Activity.h"
 #include "ChineseChessStore.h"
+#include "components/OptionPopup.h"
 
 class ChineseChessMenuActivity final : public Activity {
  public:
@@ -32,8 +33,7 @@ class ChineseChessMenuActivity final : public Activity {
   bool showingStats = false;
   ChineseChessStats cachedStats;
 
-  bool showingAiDifficulty = false;
-  int aiDifficultySel = static_cast<int>(ChineseChessAiLevel::Medium);
+  OptionPopup difficultyPopup;
 
   bool hasResume = false;
   ChineseChessMode resumeMode = ChineseChessMode::TwoPlayer;
@@ -45,6 +45,4 @@ class ChineseChessMenuActivity final : public Activity {
   void onSelect();
   void renderList();
   void renderStats();
-  void renderAiDifficulty();
-  void handleAiDifficultyInput();
 };

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -52,7 +52,6 @@ void GomokuGameActivity::onEnter() {
   elapsedMs = 0;
   lastTickMs = millis();
   saveDebouncer.clear();
-  menuSel = 0;
   statsRecorded = false;
   resignedFlag = false;
   resignWinner = GomokuBoard::Stone::Empty;
@@ -194,26 +193,8 @@ void GomokuGameActivity::handleInputPlaying() {
 }
 
 void GomokuGameActivity::handleInputGameMenu() {
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 320;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, MENU_ITEM_COUNT);
-  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
-    case GameMenuInputResult::None:
-      return;
-    case GameMenuInputResult::SelectionChanged:
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Activated:
-      runMenuItem(menuSel);
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Dismissed:
-      resumeFromMenu();
-      requestUpdate();
-      return;
-  }
+  gameMenu.handleInput(mappedInput, [this] { requestUpdate(); });
+  if (!gameMenu.isActive() && state == State::GameMenu) resumeFromMenu();
 }
 
 void GomokuGameActivity::handleInputGameOver() {
@@ -315,7 +296,11 @@ void GomokuGameActivity::onGameOver() {
 
 void GomokuGameActivity::enterGameMenu() {
   state = State::GameMenu;
-  menuSel = 0;
+  const char* options[MENU_ITEM_COUNT] = {
+      tr(STR_GAME_RESUME), tr(STR_GOMOKU_UNDO), tr(STR_GOMOKU_RESIGN), tr(STR_GAME_NEW_GAME), tr(STR_GAME_EXIT),
+  };
+  gameMenu.show(tr(STR_GAME_GAME_MENU), options, MENU_ITEM_COUNT, 0,
+                [this](const int index) { runMenuItem(static_cast<uint8_t>(index)); });
 }
 
 void GomokuGameActivity::resumeFromMenu() {
@@ -398,7 +383,7 @@ void GomokuGameActivity::render(RenderLock&&) {
       break;
     case State::GameMenu:
       renderPlaying();
-      renderGameMenu();
+      if (gameMenu.processRender(renderer, mappedInput)) return;
       break;
     case State::GameOver:
       renderGameOver();
@@ -622,25 +607,6 @@ void GomokuGameActivity::drawFooter() {
 
   const auto labels = mappedInput.mapLabels(backLabel, confirmLabel, leftLabel, rightLabel);
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-}
-
-// ---------- Game Menu modal ----------
-
-void GomokuGameActivity::renderGameMenu() {
-  // Compact modal: title 28 + 5 rows × 32 + 4 = 192 px tall, 320 px wide. Mirrors Sudoku.
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  const Rect panel =
-      gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  char undoHint[24] = "";
-  if (board.moveCount > 0) {
-    snprintf(undoHint, sizeof(undoHint), tr(STR_GOMOKU_MOVE_FMT), static_cast<unsigned>(board.moveCount));
-  }
-  const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},   {tr(STR_GOMOKU_UNDO), undoHint},        {tr(STR_GOMOKU_RESIGN), ""},
-      {tr(STR_GAME_NEW_GAME), ""}, {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
-  };
-  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }
 
 // ---------- Game Over screen ----------

--- a/src/activities/apps/gomoku/GomokuGameActivity.h
+++ b/src/activities/apps/gomoku/GomokuGameActivity.h
@@ -6,6 +6,7 @@
 #include "../GameSaveDebouncer.h"
 #include "GomokuBoard.h"
 #include "GomokuStore.h"
+#include "components/OptionPopup.h"
 
 class GomokuGameActivity final : public Activity {
  public:
@@ -49,7 +50,7 @@ class GomokuGameActivity final : public Activity {
   bool aiThinkingArmed = false;
   bool aiThinkingShown = false;
 
-  uint8_t menuSel = 0;
+  OptionPopup gameMenu;
 
   // End-game outcome (set when state transitions to GameOver).
   // Keeps recording idempotent: stats are written exactly once per game.
@@ -66,7 +67,6 @@ class GomokuGameActivity final : public Activity {
 
   // Drawing
   void renderPlaying();
-  void renderGameMenu();
   void renderGameOver();
   void drawTitleBar();
   void drawBoard();

--- a/src/activities/apps/gomoku/GomokuMenuActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.cpp
@@ -78,8 +78,8 @@ void GomokuMenuActivity::loop() {
     return;
   }
 
-  if (showingAiDifficulty) {
-    handleAiDifficultyInput();
+  if (difficultyPopup.isActive()) {
+    difficultyPopup.handleInput(mappedInput, [this] { requestUpdate(); });
     return;
   }
 
@@ -108,44 +108,6 @@ void GomokuMenuActivity::loop() {
   }
 }
 
-void GomokuMenuActivity::handleAiDifficultyInput() {
-  constexpr int kNumLevels = 3;
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 320;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, kNumLevels);
-  int touched = -1;
-  const auto touch = mappedInput.rowTouch(touched, panel.y + titleHeight, rowHeight, kNumLevels, panel.x,
-                                          panel.x + panel.width, rowHeight);
-  if (touch != MappedInputManager::RowTouch::None) {
-    aiDifficultySel = touched;
-    requestUpdate();
-    if (touch == MappedInputManager::RowTouch::Tap) {
-      GomokuStore::clear();
-      activityManager.replaceActivityWith<GomokuGameActivity>(GomokuMode::VsAi, pendingAiBoardSize, false,
-                                                              static_cast<GomokuAiLevel>(aiDifficultySel));
-    }
-    return;
-  }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Left)) {
-    aiDifficultySel = (aiDifficultySel + kNumLevels - 1) % kNumLevels;
-    requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down) ||
-             mappedInput.wasPressed(MappedInputManager::Button::Right)) {
-    aiDifficultySel = (aiDifficultySel + 1) % kNumLevels;
-    requestUpdate();
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    GomokuStore::clear();
-    const auto level = static_cast<GomokuAiLevel>(aiDifficultySel);
-    activityManager.replaceActivityWith<GomokuGameActivity>(GomokuMode::VsAi, pendingAiBoardSize, false, level);
-  } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    showingAiDifficulty = false;
-    requestUpdate();
-  }
-}
-
 void GomokuMenuActivity::onSelect() {
   if (selected < 0 || selected >= static_cast<int>(items.size())) return;
   const Item& it = items[selected];
@@ -156,10 +118,14 @@ void GomokuMenuActivity::onSelect() {
       return;
     case ItemKind::NewGame:
       if (it.mode == GomokuMode::VsAi) {
-        // Open the difficulty modal; actual launch happens on Confirm there.
         pendingAiBoardSize = it.boardSize;
-        aiDifficultySel = static_cast<int>(GomokuAiLevel::Medium);
-        showingAiDifficulty = true;
+        const char* options[] = {tr(STR_GOMOKU_DIFF_EASY), tr(STR_GOMOKU_DIFF_MEDIUM), tr(STR_GOMOKU_DIFF_HARD)};
+        difficultyPopup.show(tr(STR_GOMOKU_DIFFICULTY), options, 3, static_cast<int>(GomokuAiLevel::Medium),
+                             [this](const int index) {
+                               GomokuStore::clear();
+                               activityManager.replaceActivityWith<GomokuGameActivity>(
+                                   GomokuMode::VsAi, pendingAiBoardSize, false, static_cast<GomokuAiLevel>(index));
+                             });
         requestUpdate();
         return;
       }
@@ -181,11 +147,7 @@ void GomokuMenuActivity::render(RenderLock&&) {
     renderStats();
   } else {
     renderList();
-    // Modal floats over the list — keep the list rendered behind it so the
-    // user retains spatial context (mirrors the in-game GameMenu pattern).
-    if (showingAiDifficulty) {
-      renderAiDifficulty();
-    }
+    if (difficultyPopup.processRender(renderer, mappedInput)) return;
   }
 
   renderer.displayBuffer(HalDisplay::FAST_REFRESH);
@@ -297,45 +259,4 @@ void GomokuMenuActivity::renderStats() {
 
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-}
-
-void GomokuMenuActivity::renderAiDifficulty() {
-  // Compact modal mirroring GomokuGameActivity::renderGameMenu (same widths
-  // / row height / fonts so it feels consistent across the app).
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  constexpr int kRows = 3;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, kRows);
-  const int x = panel.x;
-  const int y = panel.y;
-  const int w = panel.width;
-  const int h = panel.height;
-
-  renderer.fillRect(x, y, w, h, false);
-  renderer.drawRect(x, y, w, h, 2, true);
-
-  const int titleTextH = renderer.getTextHeight(UI_12_FONT_ID);
-  renderer.fillRect(x + 2, y + titleH, w - 4, 1, true);
-  renderer.drawText(UI_12_FONT_ID, x + 12, y + (titleH - titleTextH) / 2, tr(STR_GOMOKU_DIFFICULTY));
-
-  const char* labels[kRows] = {
-      tr(STR_GOMOKU_DIFF_EASY),
-      tr(STR_GOMOKU_DIFF_MEDIUM),
-      tr(STR_GOMOKU_DIFF_HARD),
-  };
-
-  const int itemTextH = renderer.getTextHeight(UI_12_FONT_ID);
-  const int firstY = y + titleH;
-
-  for (int i = 0; i < kRows; i++) {
-    const int rowY = firstY + i * rowH;
-    const bool inverted = (i == aiDifficultySel);
-    if (inverted) {
-      renderer.fillRect(x + 1, rowY, w - 2, rowH, true);
-    }
-    renderer.drawText(UI_12_FONT_ID, x + 12, rowY + (rowH - itemTextH) / 2, labels[i], !inverted);
-  }
-
-  const auto hints = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, hints.btn1, hints.btn2, hints.btn3, hints.btn4);
 }

--- a/src/activities/apps/gomoku/GomokuMenuActivity.h
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.h
@@ -6,6 +6,7 @@
 #include "../../../util/ButtonNavigator.h"
 #include "../../Activity.h"
 #include "GomokuStore.h"
+#include "components/OptionPopup.h"
 
 class GomokuMenuActivity final : public Activity {
  public:
@@ -35,9 +36,8 @@ class GomokuMenuActivity final : public Activity {
 
   // Difficulty modal state. Active when the user picked an AI option and we
   // need them to pick a level before launching the game.
-  bool showingAiDifficulty = false;
+  OptionPopup difficultyPopup;
   uint8_t pendingAiBoardSize = 15;
-  int aiDifficultySel = static_cast<int>(GomokuAiLevel::Medium);
 
   // Resume slot info for the "Continue Game" subtitle.
   bool hasResume = false;
@@ -51,6 +51,4 @@ class GomokuMenuActivity final : public Activity {
   void onSelect();
   void renderList();
   void renderStats();
-  void renderAiDifficulty();
-  void handleAiDifficultyInput();
 };

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -245,7 +245,19 @@ void MinesweeperGameActivity::flushSave() {
 
 void MinesweeperGameActivity::enterGameMenu() {
   state = State::GameMenu;
-  menuSel = 0;
+  const bool isFlagged =
+      cursorR < board.rows && cursorC < board.cols && board.at(cursorR, cursorC).state == MinesweeperBoard::Flagged;
+  const char* options[MENU_ITEM_COUNT] = {
+      tr(STR_GAME_RESUME),
+      tr(STR_MINESWEEPER_TOGGLE_MODE),
+      isFlagged ? tr(STR_MINESWEEPER_UNFLAG_HERE) : tr(STR_MINESWEEPER_FLAG_HERE),
+      tr(STR_MINESWEEPER_USE_HINT),
+      tr(STR_MINESWEEPER_RESTART),
+      tr(STR_GAME_NEW_GAME),
+      tr(STR_GAME_EXIT),
+  };
+  gameMenu.show(tr(STR_GAME_GAME_MENU), options, MENU_ITEM_COUNT, 0,
+                [this](const int index) { runMenuItem(static_cast<uint8_t>(index)); });
 }
 
 void MinesweeperGameActivity::handleInputPlaying() {
@@ -316,26 +328,8 @@ void MinesweeperGameActivity::handleInputPlaying() {
 }
 
 void MinesweeperGameActivity::handleInputGameMenu() {
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 340;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, MENU_ITEM_COUNT);
-  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
-    case GameMenuInputResult::None:
-      return;
-    case GameMenuInputResult::SelectionChanged:
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Activated:
-      runMenuItem(menuSel);
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Dismissed:
-      resumeFromMenu();
-      requestUpdate();
-      return;
-  }
+  gameMenu.handleInput(mappedInput, [this] { requestUpdate(); });
+  if (!gameMenu.isActive() && state == State::GameMenu) resumeFromMenu();
 }
 
 void MinesweeperGameActivity::runMenuItem(uint8_t i) {
@@ -403,7 +397,7 @@ void MinesweeperGameActivity::render(RenderLock&&) {
       break;
     case State::GameMenu:
       renderPlaying();
-      renderGameMenu();
+      if (gameMenu.processRender(renderer, mappedInput)) return;
       break;
     case State::Won:
       renderEnd(true);
@@ -432,7 +426,7 @@ void MinesweeperGameActivity::renderPlaying() {
 
 void MinesweeperGameActivity::drawTitleBar() {
   const int w = renderer.getScreenWidth();
-  renderer.drawLine(0, TITLE_BAR_H, w, TITLE_BAR_H, true);
+  renderer.drawLine(0, TITLE_BAR_H, w - 1, TITLE_BAR_H, true);
 
   const int textH = renderer.getTextHeight(kStatusFont);
   const int y = gameCenterY(TITLE_BAR_H, textH);
@@ -668,32 +662,4 @@ void MinesweeperGameActivity::renderEnd(bool won) {
   }
 
   drawFooter();
-}
-
-void MinesweeperGameActivity::renderGameMenu() {
-  // Compact modal sized for English; MENU_ITEM_COUNT rows × rowH + title.
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  const Rect panel =
-      gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 340, titleH, rowH, MENU_ITEM_COUNT);
-  const bool isFlagged =
-      (cursorR < board.rows && cursorC < board.cols && board.at(cursorR, cursorC).state == MinesweeperBoard::Flagged);
-  const char* flagItemLabel = isFlagged ? tr(STR_MINESWEEPER_UNFLAG_HERE) : tr(STR_MINESWEEPER_FLAG_HERE);
-  const char* hintMode = flagMode ? tr(STR_MINESWEEPER_MODE_FLAG) : tr(STR_MINESWEEPER_MODE_DIG);
-  char hintHint[16];
-  if (hintsLeft > 0) {
-    snprintf(hintHint, sizeof(hintHint), tr(STR_MINESWEEPER_HINTS_LEFT), static_cast<int>(hintsLeft));
-  } else {
-    snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_MINESWEEPER_NO_HINTS));
-  }
-  const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},
-      {tr(STR_MINESWEEPER_TOGGLE_MODE), hintMode},
-      {flagItemLabel, ""},
-      {tr(STR_MINESWEEPER_USE_HINT), hintHint},
-      {tr(STR_MINESWEEPER_RESTART), ""},
-      {tr(STR_GAME_NEW_GAME), ""},
-      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
-  };
-  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.h
@@ -5,6 +5,7 @@
 #include "../../Activity.h"
 #include "../GameSaveDebouncer.h"
 #include "MinesweeperBoard.h"
+#include "components/OptionPopup.h"
 
 class MinesweeperGameActivity final : public Activity {
  public:
@@ -37,7 +38,7 @@ class MinesweeperGameActivity final : public Activity {
   bool resumeRequested = false;
   bool statsRecorded = false;
 
-  uint8_t menuSel = 0;
+  OptionPopup gameMenu;
   static constexpr uint8_t MENU_ITEM_COUNT = 7;
 
   // Portrait layout. Board occupies the same vertical slot as Sudoku's grid
@@ -57,7 +58,6 @@ class MinesweeperGameActivity final : public Activity {
 
   // Drawing
   void renderPlaying();
-  void renderGameMenu();
   void renderEnd(bool won);
   void drawTitleBar();
   void drawBoard();

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -135,30 +135,17 @@ void SudokuGameActivity::handleInputWon() {
 
 void SudokuGameActivity::enterGameMenu() {
   state = State::GameMenu;
-  menuSel = 0;
+  const char* options[MENU_ITEM_COUNT] = {
+      tr(STR_GAME_RESUME),    tr(STR_SUDOKU_TOGGLE_NOTES), tr(STR_SUDOKU_USE_HINT), tr(STR_SUDOKU_CHECK_ERRORS),
+      tr(STR_SUDOKU_RESTART), tr(STR_GAME_NEW_GAME),       tr(STR_GAME_EXIT),
+  };
+  gameMenu.show(tr(STR_GAME_GAME_MENU), options, MENU_ITEM_COUNT, 0,
+                [this](const int index) { runMenuItem(static_cast<uint8_t>(index)); });
 }
 
 void SudokuGameActivity::handleInputGameMenu() {
-  constexpr int titleHeight = 28;
-  constexpr int rowHeight = 32;
-  constexpr int width = 320;
-  const Rect panel = gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), width, titleHeight,
-                                       rowHeight, MENU_ITEM_COUNT);
-  switch (gameHandleMenuInput(mappedInput, panel, titleHeight, rowHeight, MENU_ITEM_COUNT, menuSel)) {
-    case GameMenuInputResult::None:
-      return;
-    case GameMenuInputResult::SelectionChanged:
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Activated:
-      runMenuItem(menuSel);
-      requestUpdate();
-      return;
-    case GameMenuInputResult::Dismissed:
-      resumeFromMenu();
-      requestUpdate();
-      return;
-  }
+  gameMenu.handleInput(mappedInput, [this] { requestUpdate(); });
+  if (!gameMenu.isActive() && state == State::GameMenu) resumeFromMenu();
 }
 
 void SudokuGameActivity::runMenuItem(uint8_t i) {
@@ -433,7 +420,7 @@ void SudokuGameActivity::render(RenderLock&&) {
       break;
     case State::GameMenu:
       renderPlaying();
-      renderGameMenu();
+      if (gameMenu.processRender(renderer, mappedInput)) return;
       break;
     case State::Won:
       renderWon();
@@ -464,7 +451,7 @@ void SudokuGameActivity::renderPlaying() {
 void SudokuGameActivity::drawTitleBar() {
   const int w = renderer.getScreenWidth();
   // Bottom border at TITLE_BAR_H. 1px so plain drawLine is fine.
-  renderer.drawLine(0, TITLE_BAR_H, w, TITLE_BAR_H, true);
+  renderer.drawLine(0, TITLE_BAR_H, w - 1, TITLE_BAR_H, true);
 
   const int textH = renderer.getTextHeight(kStatusFont);
   const int y = gameCenterY(TITLE_BAR_H, textH);
@@ -723,29 +710,4 @@ void SudokuGameActivity::renderWon() {
   }
 
   drawFooter();
-}
-
-void SudokuGameActivity::renderGameMenu() {
-  // Compact modal sized for English; 7 rows × rowH + title.
-  constexpr int titleH = 28;
-  constexpr int rowH = 32;
-  const Rect panel =
-      gameMenuPanelRect(renderer.getScreenWidth(), renderer.getScreenHeight(), 320, titleH, rowH, MENU_ITEM_COUNT);
-  const char* hintNotes = notesMode ? tr(STR_SUDOKU_MODE_NOTES) : tr(STR_SUDOKU_MODE_NORMAL);
-  char hintHint[16];
-  if (hintsLeft > 0) {
-    snprintf(hintHint, sizeof(hintHint), tr(STR_SUDOKU_HINTS_LEFT), static_cast<int>(hintsLeft));
-  } else {
-    snprintf(hintHint, sizeof(hintHint), "%s", tr(STR_SUDOKU_NO_HINTS));
-  }
-  const GameMenuItem items[MENU_ITEM_COUNT] = {
-      {tr(STR_GAME_RESUME), ""},
-      {tr(STR_SUDOKU_TOGGLE_NOTES), hintNotes},
-      {tr(STR_SUDOKU_USE_HINT), hintHint},
-      {tr(STR_SUDOKU_CHECK_ERRORS), ""},
-      {tr(STR_SUDOKU_RESTART), ""},
-      {tr(STR_GAME_NEW_GAME), ""},
-      {tr(STR_GAME_EXIT), tr(STR_GAME_HOME)},
-  };
-  gameDrawMenu(renderer, panel, titleH, rowH, tr(STR_GAME_GAME_MENU), items, MENU_ITEM_COUNT, menuSel);
 }

--- a/src/activities/apps/sudoku/SudokuGameActivity.h
+++ b/src/activities/apps/sudoku/SudokuGameActivity.h
@@ -5,6 +5,7 @@
 #include "../../Activity.h"
 #include "../GameSaveDebouncer.h"
 #include "SudokuBoard.h"
+#include "components/OptionPopup.h"
 
 class SudokuGameActivity final : public Activity {
  public:
@@ -46,7 +47,6 @@ class SudokuGameActivity final : public Activity {
   // Drawing
   void renderGenerating();
   void renderPlaying();
-  void renderGameMenu();
   void renderWon();
   void drawTitleBar();
   void drawGrid(int x0, int y0);
@@ -74,7 +74,7 @@ class SudokuGameActivity final : public Activity {
   void useHint();
   void resetGame();
   void resumeFromMenu();  // state = Playing + reset timer base
-  uint8_t menuSel = 0;
+  OptionPopup gameMenu;
   static constexpr uint8_t MENU_ITEM_COUNT = 7;
 
   // Portrait layout. Single source of truth for fixed element sizes and vertical anchors.

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -7,6 +7,8 @@
 #include <Memory.h>
 #include <WiFi.h>
 
+#include <algorithm>
+
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
 #include "WifiSelectionActivity.h"
@@ -16,6 +18,7 @@
 
 namespace {
 constexpr const char* HOSTNAME = "crosspoint";
+constexpr int CONTENT_GAP = 6;
 }  // namespace
 
 void CalibreConnectActivity::onEnter() {
@@ -201,43 +204,51 @@ void CalibreConnectActivity::render(RenderLock&&) {
   } else if (state == CalibreConnectState::ERROR) {
     renderer.drawCenteredText(UI_12_FONT_ID, top, tr(STR_CONNECTION_FAILED), true, EpdFontFamily::BOLD);
   } else if (state == CalibreConnectState::SERVER_RUNNING) {
-    GUI.drawSubHeader(renderer, Rect{0, metrics.topPadding + metrics.headerHeight, pageWidth, metrics.tabBarHeight},
-                      connectedSSID.c_str(), (std::string(tr(STR_IP_ADDRESS_PREFIX)) + connectedIP).c_str());
+    const int subHeaderY = metrics.topPadding + metrics.headerHeight;
+    const int subHeaderBottom = subHeaderY + metrics.tabBarHeight;
+    const int contentBottom = pageHeight - metrics.buttonHintsHeight - CONTENT_GAP;
+    GUI.drawSubHeader(renderer, Rect{0, subHeaderY, pageWidth, metrics.tabBarHeight}, connectedSSID.c_str(),
+                      (std::string(tr(STR_IP_ADDRESS_PREFIX)) + connectedIP).c_str());
 
-    int y = metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight + metrics.verticalSpacing * 4;
-    const auto heightText12 = renderer.getTextHeight(UI_12_FONT_ID);
-    renderer.drawText(UI_12_FONT_ID, metrics.contentSidePadding, y, tr(STR_CALIBRE_SETUP), true, EpdFontFamily::BOLD);
-    y += heightText12 + metrics.verticalSpacing * 2;
+    {
+      const GfxRenderer::ClipScope clip(renderer, 0, subHeaderBottom, pageWidth,
+                                        std::max(0, contentBottom - subHeaderBottom));
+      const int lineHeight10 = renderer.getLineHeight(UI_10_FONT_ID);
+      const int lineHeight12 = renderer.getLineHeight(UI_12_FONT_ID);
+      const int textWidth = pageWidth - metrics.contentSidePadding * 2;
+      int y = subHeaderBottom + CONTENT_GAP;
 
-    renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y, tr(STR_CALIBRE_INSTRUCTION_1));
-    renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y + height, tr(STR_CALIBRE_INSTRUCTION_2));
-    renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y + height * 2, tr(STR_CALIBRE_INSTRUCTION_3));
-    renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y + height * 3, tr(STR_CALIBRE_INSTRUCTION_4));
+      renderer.drawText(UI_12_FONT_ID, metrics.contentSidePadding, y, tr(STR_CALIBRE_SETUP), true, EpdFontFamily::BOLD);
+      y += lineHeight12 + CONTENT_GAP;
 
-    y += height * 3 + metrics.verticalSpacing * 4;
-    renderer.drawText(UI_12_FONT_ID, metrics.contentSidePadding, y, tr(STR_CALIBRE_STATUS), true, EpdFontFamily::BOLD);
-    y += heightText12 + metrics.verticalSpacing * 2;
-
-    if (lastProgressTotal > 0 && lastProgressReceived <= lastProgressTotal) {
-      std::string label = tr(STR_CALIBRE_RECEIVING);
-      if (!currentUploadName.empty()) {
-        label += ": " + currentUploadName;
-        label = renderer.truncatedText(SMALL_FONT_ID, label.c_str(), pageWidth - metrics.contentSidePadding * 2,
-                                       EpdFontFamily::REGULAR);
+      const char* instructions[] = {tr(STR_CALIBRE_INSTRUCTION_1), tr(STR_CALIBRE_INSTRUCTION_2),
+                                    tr(STR_CALIBRE_INSTRUCTION_3), tr(STR_CALIBRE_INSTRUCTION_4)};
+      for (const char* instruction : instructions) {
+        renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y, instruction);
+        y += lineHeight10 + CONTENT_GAP;
       }
-      renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y, label.c_str());
-      GUI.drawProgressBar(renderer,
-                          Rect{metrics.contentSidePadding, y + height + metrics.verticalSpacing,
-                               pageWidth - metrics.contentSidePadding * 2, metrics.progressBarHeight},
-                          lastProgressReceived, lastProgressTotal);
-      y += height + metrics.verticalSpacing * 2 + metrics.progressBarHeight;
-    }
 
-    if (lastCompleteAt > 0 && (millis() - lastCompleteAt) < 6000) {
-      std::string msg = std::string(tr(STR_CALIBRE_RECEIVED)) + lastCompleteName;
-      msg = renderer.truncatedText(SMALL_FONT_ID, msg.c_str(), pageWidth - metrics.contentSidePadding * 2,
-                                   EpdFontFamily::REGULAR);
-      renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, y, msg.c_str());
+      y += CONTENT_GAP;
+      renderer.drawText(UI_12_FONT_ID, metrics.contentSidePadding, y, tr(STR_CALIBRE_STATUS), true,
+                        EpdFontFamily::BOLD);
+      y += lineHeight12 + CONTENT_GAP;
+
+      if (lastProgressTotal > 0 && lastProgressReceived <= lastProgressTotal) {
+        std::string label = tr(STR_CALIBRE_RECEIVING);
+        if (!currentUploadName.empty()) {
+          label += ": " + currentUploadName;
+          label = renderer.truncatedText(UI_10_FONT_ID, label.c_str(), textWidth, EpdFontFamily::REGULAR);
+        }
+        renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y, label.c_str());
+        GUI.drawProgressBar(
+            renderer,
+            Rect{metrics.contentSidePadding, y + lineHeight10 + CONTENT_GAP, textWidth, metrics.progressBarHeight},
+            lastProgressReceived, lastProgressTotal);
+      } else if (lastCompleteAt > 0 && (millis() - lastCompleteAt) < 6000) {
+        std::string msg = std::string(tr(STR_CALIBRE_RECEIVED)) + lastCompleteName;
+        msg = renderer.truncatedText(UI_10_FONT_ID, msg.c_str(), textWidth, EpdFontFamily::REGULAR);
+        renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, y, msg.c_str());
+      }
     }
 
     const auto labels = mappedInput.mapLabels(tr(STR_EXIT), "", "", "");

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -384,6 +384,14 @@ int KeyboardEntryActivity::lineBreakEnd(std::string& s, const int start, const i
   return best;
 }
 
+int KeyboardEntryActivity::inputStartY() const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  constexpr int MIN_HEADER_GAP = 6;
+  const int themedY =
+      metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing * 5 + metrics.keyboardVerticalOffset;
+  return std::max(themedY, metrics.topPadding + metrics.headerHeight + MIN_HEADER_GAP);
+}
+
 bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, size_t& position,
                                                     bool& passwordToggle) const {
   passwordToggle = false;
@@ -395,8 +403,7 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   const auto& metrics = UITheme::getInstance().getMetrics();
 
   const int lineHeight = renderer.getLineHeight(UI_12_FONT_ID);
-  const int inputStartY = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing +
-                          metrics.verticalSpacing * 4 + metrics.keyboardVerticalOffset;
+  const int inputY = inputStartY();
 
   int availableWidth = pageWidth;
   if (gpio.deviceIsX3()) {
@@ -414,7 +421,7 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   std::string displayText = displayTextForCurrentState();
 
   int lineStartIdx = 0;
-  int lineY = inputStartY;
+  int lineY = inputY;
   int lastLineStartIdx = 0;
   int lastLineEndIdx = static_cast<int>(displayText.length());
   int lastLineStartX = effectiveMargin;
@@ -472,7 +479,7 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   }
 
   const int underlineBottom = lineY + lineHeight + metrics.verticalSpacing + 8;
-  if (y >= inputStartY - metrics.verticalSpacing && y < underlineBottom && x >= effectiveMargin &&
+  if (y >= inputY - metrics.verticalSpacing && y < underlineBottom && x >= effectiveMargin &&
       x < effectiveMargin + maxLineWidth + toggleReserve) {
     position = x < lastLineStartX + lastLineWidth ? static_cast<size_t>(lastLineStartIdx)
                                                   : static_cast<size_t>(lastLineEndIdx);
@@ -712,8 +719,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, title.c_str());
 
   const int lineHeight = renderer.getLineHeight(UI_12_FONT_ID);
-  const int inputStartY = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing +
-                          metrics.verticalSpacing * 4 + metrics.keyboardVerticalOffset;
+  const int inputY = inputStartY();
   int inputHeight = 0;
 
   std::string displayText = displayTextForCurrentState();
@@ -742,7 +748,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   int lineStartIdx = 0;
   int textWidth = 0;
   int cursorPixelX = effectiveMargin;
-  int cursorLineY = inputStartY;
+  int cursorLineY = inputY;
   bool cursorDrawn = false;
 
   while (true) {
@@ -775,7 +781,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         } else {
           cursorPixelX = effectiveMargin + beforeWidth + kernOffset;
         }
-        cursorLineY = inputStartY + inputHeight;
+        cursorLineY = inputY + inputHeight;
         cursorDrawn = true;
         isCursorLine = true;
       }
@@ -786,17 +792,17 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         // displayText uses '*' for all chars; actual char may be wider than '*'.
         // Part 1: chars before cursor position
         const std::string part1 = displayText.substr(lineStartIdx, cursorPos - lineStartIdx);
-        renderer.drawText(UI_12_FONT_ID, lineStartX, inputStartY + inputHeight, part1.c_str());
+        renderer.drawText(UI_12_FONT_ID, lineStartX, inputY + inputHeight, part1.c_str());
         // Part 2: skip cursor slot (block + actual char drawn later)
         // Part 3: chars after cursor position (skip char under cursor), starting at cursorPixelX + cursorCharWidth
         const int afterStart = static_cast<int>(cursorPos) + (cursorPos < text.length() ? 1 : 0);
         const int afterEnd = lineEndIdx;
         if (afterStart < afterEnd) {
           const std::string part3 = displayText.substr(afterStart, afterEnd - afterStart);
-          renderer.drawText(UI_12_FONT_ID, cursorPixelX + cursorCharWidth, inputStartY + inputHeight, part3.c_str());
+          renderer.drawText(UI_12_FONT_ID, cursorPixelX + cursorCharWidth, inputY + inputHeight, part3.c_str());
         }
       } else {
-        renderer.drawText(UI_12_FONT_ID, lineStartX, inputStartY + inputHeight, lineText.c_str());
+        renderer.drawText(UI_12_FONT_ID, lineStartX, inputY + inputHeight, lineText.c_str());
       }
       if (lineEndIdx == static_cast<int>(displayText.length())) {
         break;
@@ -809,7 +815,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
 
   const int fieldWidth = (inputHeight > 0) ? maxLineWidth : textWidth;
   const int lineMargin = effectiveMargin;
-  GUI.drawTextField(renderer, Rect{0, inputStartY, pageWidth, inputHeight}, fieldWidth, cursorMode, lineMargin,
+  GUI.drawTextField(renderer, Rect{0, inputY, pageWidth, inputHeight}, fieldWidth, cursorMode, lineMargin,
                     pageWidth - 2 * lineMargin);
 
   if (cursorMode && !togglePos && cursorPos <= displayText.length()) {
@@ -835,7 +841,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
     const char* toggleLabel = passwordVisible ? "[***]" : "[abc]";
     const int toggleWidth = renderer.getTextWidth(UI_12_FONT_ID, toggleLabel);
     const int toggleX = pageWidth - effectiveMargin - toggleWidth;
-    const int toggleY = inputStartY + inputHeight;
+    const int toggleY = inputY + inputHeight;
     const bool toggleSelected = cursorMode && togglePos;
 
     if (toggleSelected) {
@@ -848,7 +854,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
 
   if (!mappedInput.hasTouch() && hintVisible && !text.empty()) {
     const int hintLh = renderer.getLineHeight(SMALL_FONT_ID);
-    const int underlineY = inputStartY + inputHeight + lineHeight + metrics.verticalSpacing;
+    const int underlineY = inputY + inputHeight + lineHeight + metrics.verticalSpacing;
     const int hintY = underlineY + 4;
     if (cursorMode) {
       int hintLineY = hintY;
@@ -874,7 +880,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   const fui::Rect kbRect = keyboardRect();
 
   const int tipsLh = renderer.getLineHeight(SMALL_FONT_ID);
-  const int underlineBottom = inputStartY + inputHeight + lineHeight + metrics.verticalSpacing + 4;
+  const int underlineBottom = inputY + inputHeight + lineHeight + metrics.verticalSpacing + 4;
   auto drawTip = [&](const char* tip, int y) { renderer.drawCenteredText(SMALL_FONT_ID, y, tip, true); };
 
   int tipCount = 0;

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -97,6 +97,7 @@ class KeyboardEntryActivity : public Activity {
 
   void onComplete(std::string text);
   void onCancel();
+  int inputStartY() const;
   bool cursorPositionFromPoint(int x, int y, size_t& position, bool& passwordToggle) const;
   std::string displayTextForCurrentState() const;
   // Advance of s[start, end) measured in place by temporarily null-terminating

--- a/test/game_ui/GameUiTest.cpp
+++ b/test/game_ui/GameUiTest.cpp
@@ -32,6 +32,9 @@ TEST(GameUiTouchGeometry, IntersectionUsesNearestPointAndRejectsOutside) {
 }
 
 TEST(GameUiTouchGeometry, ActionSlotsStayInsidePortraitAndLandscapeScreens) {
+  const Rect only = gameTouchActionRect(480, 800, 20, 0, 52, 0, 1);
+  EXPECT_EQ(only.width, 440);
+
   const Rect left = gameTouchActionRect(480, 800, 20, 8, 52, 0, 2);
   const Rect right = gameTouchActionRect(480, 800, 20, 8, 52, 1, 2);
   EXPECT_EQ(left.x, 20);
@@ -45,75 +48,15 @@ TEST(GameUiTouchGeometry, ActionSlotsStayInsidePortraitAndLandscapeScreens) {
   EXPECT_EQ(wide.y, 402);
   EXPECT_LT(wide.x, 776);
   EXPECT_LE(wide.x + wide.width, 776);
-}
 
-TEST(GameUiTouchGeometry, MenuPanelCentersAndRejectsInvalidGeometry) {
-  const Rect portrait = gameMenuPanelRect(480, 800, 320, 28, 32, 7);
-  EXPECT_EQ(portrait.x, 80);
-  EXPECT_EQ(portrait.y, 272);
-  EXPECT_EQ(portrait.width, 320);
-  EXPECT_EQ(portrait.height, 256);
+  const Rect inxLeft = gameTouchActionRect(480, 800, 20, 0, 52, 0, 2);
+  const Rect inxRight = gameTouchActionRect(480, 800, 20, 0, 52, 1, 2);
+  EXPECT_GE(inxRight.x - (inxLeft.x + inxLeft.width), 6);
 
-  const Rect landscape = gameMenuPanelRect(800, 480, 340, 28, 32, 5);
-  EXPECT_EQ(landscape.x, 230);
-  EXPECT_EQ(landscape.y, 144);
-  EXPECT_EQ(landscape.width, 340);
-  EXPECT_EQ(landscape.height, 192);
-
-  EXPECT_EQ(gameMenuPanelRect(480, 800, 0, 28, 32, 7).width, 0);
-  EXPECT_EQ(gameMenuPanelRect(480, 100, 320, 28, 32, 7).height, 0);
-}
-
-TEST(GameUiMenuInput, RejectsEmptyAndHandlesTouch) {
-  MappedInputManager input;
-  const Rect panel{80, 272, 320, 256};
-  uint8_t selected = 0;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 0, selected), GameMenuInputResult::None);
-
-  input.touch = MappedInputManager::RowTouch::Down;
-  input.touchedRow = 2;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
-  EXPECT_EQ(selected, 2);
-
-  input.touch = MappedInputManager::RowTouch::Tap;
-  input.touchedRow = 3;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Activated);
-  EXPECT_EQ(selected, 3);
-}
-
-TEST(GameUiMenuInput, WrapsSelectionAndReportsActions) {
-  MappedInputManager input;
-  const Rect panel{80, 272, 320, 256};
-  uint8_t selected = 0;
-
-  input.hasPressed = true;
-  input.pressed = MappedInputManager::Button::Up;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
-  EXPECT_EQ(selected, 3);
-
-  input.pressed = MappedInputManager::Button::Down;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::SelectionChanged);
-  EXPECT_EQ(selected, 0);
-
-  input.hasPressed = false;
-  input.hasReleased = true;
-  input.released = MappedInputManager::Button::Confirm;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Activated);
-  input.released = MappedInputManager::Button::Back;
-  EXPECT_EQ(gameHandleMenuInput(input, panel, 28, 32, 4, selected), GameMenuInputResult::Dismissed);
-}
-
-TEST(GameUiMenuDrawing, SkipsEmptyHints) {
-  GfxRenderer renderer;
-  const GameMenuItem items[] = {{"Resume", ""}, {"Exit", "Home"}};
-  gameDrawMenu(renderer, Rect{80, 300, 320, 96}, 28, 32, "Menu", items, 2, 1);
-
-  ASSERT_EQ(renderer.textCalls.size(), 4u);
-  EXPECT_EQ(renderer.textCalls[0].text, "Menu");
-  EXPECT_EQ(renderer.textCalls[1].text, "Resume");
-  EXPECT_EQ(renderer.textCalls[2].text, "Exit");
-  EXPECT_EQ(renderer.textCalls[3].text, "Home");
-  EXPECT_TRUE(renderer.textCalls[1].black);
-  EXPECT_FALSE(renderer.textCalls[2].black);
-  EXPECT_FALSE(renderer.textCalls[3].black);
+  const Rect first = gameTouchActionRect(800, 480, 24, 0, 54, 0, 3);
+  const Rect middle = gameTouchActionRect(800, 480, 24, 0, 54, 1, 3);
+  const Rect last = gameTouchActionRect(800, 480, 24, 0, 54, 2, 3);
+  EXPECT_GE(middle.x - (first.x + first.width), 6);
+  EXPECT_GE(last.x - (middle.x + middle.width), 6);
+  EXPECT_LE(last.x + last.width, 776);
 }


### PR DESCRIPTION
## Summary

- add touch navigation and paging to the app list while preserving logical-button behavior
- replace duplicated game menus with the shared `OptionPopup` and keep action hit geometry separated
- enforce and document a minimum 6 px visible gap between adjacent interactive controls
- fix Chinese Calibre instruction/status layout and keep keyboard input fields below the header across themes

## Validation

- `ctest --test-dir /tmp/crossmux-tests --output-on-failure`: 411/411 passed
- `pio check`: no defects found
- `pio run -e simulator -e simulator_x3 -e sticky`: all succeeded
- SDL emulator: six-theme password-page screenshots, INX Chinese Calibre flow, touch text entry, and logical-button confirm/back paths

## Remaining hardware validation

- Sticky long-press behavior, e-ink ghosting, touch feel, and heap watermark on a physical device
