### PR TITLE
fix(weread): restore imported EPUB covers

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -473,11 +473,13 @@ location is not migrated or read.
   `<bookId>/chapters/NNNNNN.images`, and transient `<bookId>/images.work`
   indexes start with a 12-byte little-endian header:
   `uint32 magic`, `uint16 version`, `uint16 recordSize`, `uint32 recordCount`.
-  Their magic values are `WRS5` (`0x35535257`) and `WRT2` (`0x32545257`);
+  Their magic values are `WRS6` (`0x36535257`) and `WRT2` (`0x32545257`);
   image indexes use `WRI2` (`0x32495257`) and image work indexes use `WIP1`
   (`0x31504957`). Version is currently `1`.
-- Shelf records contain fixed `bookId[64]`, `title[192]`, and `author[96]`
-  fields followed by `uint32 readUpdateTime`. TOC records contain fixed
+- Shelf records contain fixed `bookId[64]`, `title[192]`, `author[96]`, and
+  validated HTTPS `coverUrl[512]` fields followed by `uint32 readUpdateTime`.
+  Cover URLs use a JPEG/PNG suffix or an extensionless path whose downloaded
+  bytes must identify as JPEG/PNG. TOC records contain fixed
   `chapterUid[64]`, `title[192]`, `uint32 wordCount`,
   `uint32 chapterIdx`, and a paid flag.
 - `WRI2` records contain a generated EPUB-relative `href[64]` and the original
@@ -557,6 +559,12 @@ location is not migrated or read.
   generated EPUB's `cover-image`; only source `.part` files and `cover.v2.bmp.part`
   are transient. The pre-v2 `<bookId>/cover.bmp` is not read or migrated. A failed
   fetch or conversion does not replace an existing v2 BMP.
+- A directly returned complete EPUB remains unchanged. When its validated WeRead
+  cover source is available, the source is atomically copied to the EPUB's
+  path-keyed cache directory as `cover.override`. The EPUB loader identifies
+  JPEG or PNG from the file signature, prefers the EPUB's internal cover, and
+  uses the override only as a fallback. A valid override makes an earlier empty
+  thumbnail marker retryable.
 - The WeRead menu's cache-clear action preserves `session.bin`,
   `disclaimer.accepted`, `/WeRead/*.epub`, and the reader caches
   for those EPUB files. It recursively removes every other entry below
@@ -570,10 +578,12 @@ Writers use `.part` plus atomic replacement, so a damaged or interrupted index
 is never exposed as current data.
 
 `WRA1` replaces the pre-release `WRD3` session marker after the application
-rename. `WRS5` rejects `WRS4` shelves because shelf records now include
-`readUpdateTime`; a successful sync rewrites them in descending timestamp
-order while preserving server order for ties. Existing per-book detail,
-cover, and EPUB files are retained. `WRS4` rejected `WRS3` shelves whose book
+rename. `WRS6` rejects `WRS5` shelves because shelf records now include a
+validated cover URL; a successful sync rebuilds the shelf index while retaining
+existing per-book detail, cover, EPUB, and reading-progress files. `WRS5`
+rejected `WRS4` shelves because shelf records added `readUpdateTime`; records
+are rewritten in descending timestamp order while preserving server order for
+ties. `WRS4` rejected `WRS3` shelves whose book
 titles could be overwritten by nested category titles. A cached chapter
 without a valid `WRI2` index is downloaded again so pre-image-support chapter
 caches cannot silently lose figures. `WRI2` also rejects chapters generated

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -9,32 +9,41 @@
 #include <Utf8.h>
 #include <ZipFile.h>
 
+#include <cstring>
+
 #include "Epub/parsers/ContainerParser.h"
 #include "Epub/parsers/ContentOpfParser.h"
 #include "Epub/parsers/TocNavParser.h"
 #include "Epub/parsers/TocNcxParser.h"
 
 namespace {
-template <typename JpegConvert, typename PngConvert>
-bool convertExtractedCover(const Epub& epub, const std::string& coverHref, const std::string& outputPath,
-                           const char* outputKind, JpegConvert jpegConvert, PngConvert pngConvert) {
-  const bool isJpeg = FsHelpers::hasJpgExtension(coverHref);
-  const char* format = isJpeg ? "JPG" : "PNG";
-  const std::string tempPath = epub.getCachePath() + (isJpeg ? "/.cover.jpg" : "/.cover.png");
+enum class CoverImageType : uint8_t { None, Jpeg, Png };
 
-  LOG_DBG("EBP", "Generating %s BMP from %s cover image", outputKind, format);
-  if (!epub.extractItemToFile(coverHref, tempPath)) {
-    LOG_ERR("EBP", "Failed to extract %s cover image for %s", format, outputKind);
-    return false;
+CoverImageType coverImageType(const std::string& path) {
+  HalFile file;
+  uint8_t prefix[8] = {};
+  if (!Storage.openFileForRead("EBP", path, file) || file.fileSize64() <= sizeof(prefix) ||
+      file.read(prefix, sizeof(prefix)) != static_cast<int>(sizeof(prefix))) {
+    return CoverImageType::None;
   }
-  const ScopedCleanup removeTemp{[&tempPath] { Storage.remove(tempPath.c_str()); }};
+  static constexpr uint8_t kPngMagic[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+  if (memcmp(prefix, kPngMagic, sizeof(kPngMagic)) == 0) return CoverImageType::Png;
+  return prefix[0] == 0xFF && prefix[1] == 0xD8 && prefix[2] == 0xFF ? CoverImageType::Jpeg : CoverImageType::None;
+}
+
+template <typename JpegConvert, typename PngConvert>
+bool convertCoverFile(const std::string& sourcePath, const CoverImageType type, const std::string& outputPath,
+                      const char* outputKind, JpegConvert jpegConvert, PngConvert pngConvert) {
+  if (type == CoverImageType::None) return false;
+  const char* format = type == CoverImageType::Jpeg ? "JPG" : "PNG";
+  LOG_DBG("EBP", "Generating %s BMP from %s cover image", outputKind, format);
 
   bool success = false;
   {
     HalFile source;
     HalFile output;
-    if (Storage.openFileForRead("EBP", tempPath, source) && Storage.openFileForWrite("EBP", outputPath, output)) {
-      success = isJpeg ? jpegConvert(source, output) : pngConvert(source, output);
+    if (Storage.openFileForRead("EBP", sourcePath, source) && Storage.openFileForWrite("EBP", outputPath, output)) {
+      success = type == CoverImageType::Jpeg ? jpegConvert(source, output) : pngConvert(source, output);
     }
   }
   if (!success) {
@@ -42,6 +51,28 @@ bool convertExtractedCover(const Epub& epub, const std::string& coverHref, const
     Storage.remove(outputPath.c_str());
   }
   return success;
+}
+
+template <typename JpegConvert, typename PngConvert>
+bool convertExtractedCover(const Epub& epub, const std::string& coverHref, const std::string& outputPath,
+                           const char* outputKind, JpegConvert jpegConvert, PngConvert pngConvert) {
+  const bool isJpeg = FsHelpers::hasJpgExtension(coverHref);
+  const std::string tempPath = epub.getCachePath() + (isJpeg ? "/.cover.jpg" : "/.cover.png");
+
+  if (!epub.extractItemToFile(coverHref, tempPath)) {
+    LOG_ERR("EBP", "Failed to extract cover image for %s", outputKind);
+    return false;
+  }
+  const ScopedCleanup removeTemp{[&tempPath] { Storage.remove(tempPath.c_str()); }};
+  return convertCoverFile(tempPath, isJpeg ? CoverImageType::Jpeg : CoverImageType::Png, outputPath, outputKind,
+                          jpegConvert, pngConvert);
+}
+
+template <typename JpegConvert, typename PngConvert>
+bool convertOverrideCover(const Epub& epub, const std::string& outputPath, const char* outputKind,
+                          JpegConvert jpegConvert, PngConvert pngConvert) {
+  const std::string sourcePath = epub.getCoverOverridePath();
+  return convertCoverFile(sourcePath, coverImageType(sourcePath), outputPath, outputKind, jpegConvert, pngConvert);
 }
 }  // namespace
 
@@ -599,6 +630,10 @@ const std::string& Epub::getLanguage() const {
   return bookMetadataCache->coreMetadata.language;
 }
 
+std::string Epub::getCoverOverridePath() const { return cachePath + "/cover.override"; }
+
+bool Epub::hasCoverOverride() const { return coverImageType(getCoverOverridePath()) != CoverImageType::None; }
+
 std::string Epub::getCoverBmpPath(bool cropped) const {
   const auto coverFileName = std::string("cover") + (cropped ? "_crop" : "");
   return cachePath + "/" + coverFileName + ".bmp";
@@ -616,25 +651,29 @@ bool Epub::generateCoverBmp(bool cropped) const {
   }
 
   const auto coverImageHref = bookMetadataCache->coreMetadata.coverItemHref;
-  if (coverImageHref.empty()) {
-    LOG_ERR("EBP", "No known cover image");
-    return false;
-  }
-
   if (FsHelpers::hasJpgExtension(coverImageHref) || FsHelpers::hasPngExtension(coverImageHref)) {
     const std::string outputPath = getCoverBmpPath(cropped);
-    return convertExtractedCover(
-        *this, coverImageHref, outputPath, cropped ? "cropped cover" : "cover",
-        [cropped](HalFile& source, HalFile& output) {
-          return JpegToBmpConverter::jpegFileToBmpStream(source, output, cropped);
-        },
-        [cropped](HalFile& source, HalFile& output) {
-          return PngToBmpConverter::pngFileToBmpStream(source, output, cropped);
-        });
+    if (convertExtractedCover(
+            *this, coverImageHref, outputPath, cropped ? "cropped cover" : "cover",
+            [cropped](HalFile& source, HalFile& output) {
+              return JpegToBmpConverter::jpegFileToBmpStream(source, output, cropped);
+            },
+            [cropped](HalFile& source, HalFile& output) {
+              return PngToBmpConverter::pngFileToBmpStream(source, output, cropped);
+            })) {
+      return true;
+    }
   }
 
-  LOG_ERR("EBP", "Cover image is not a supported format, skipping");
-  return false;
+  const std::string outputPath = getCoverBmpPath(cropped);
+  return convertOverrideCover(
+      *this, outputPath, cropped ? "cropped cover" : "cover",
+      [cropped](HalFile& source, HalFile& output) {
+        return JpegToBmpConverter::jpegFileToBmpStream(source, output, cropped);
+      },
+      [cropped](HalFile& source, HalFile& output) {
+        return PngToBmpConverter::pngFileToBmpStream(source, output, cropped);
+      });
 }
 
 std::string Epub::getThumbBmpPath() const { return cachePath + "/thumb_[HEIGHT].bmp"; }
@@ -652,21 +691,29 @@ bool Epub::generateThumbBmp(int height) const {
   }
 
   const auto coverImageHref = bookMetadataCache->coreMetadata.coverItemHref;
-  if (coverImageHref.empty()) {
-    LOG_DBG("EBP", "No known cover image for thumbnail");
-  } else if (FsHelpers::hasJpgExtension(coverImageHref) || FsHelpers::hasPngExtension(coverImageHref)) {
-    const int targetWidth = height * 3 / 5;
-    const std::string outputPath = getThumbBmpPath(height);
-    return convertExtractedCover(
-        *this, coverImageHref, outputPath, "thumbnail",
-        [targetWidth, height](HalFile& source, HalFile& output) {
-          return JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
-        },
-        [targetWidth, height](HalFile& source, HalFile& output) {
-          return PngToBmpConverter::pngFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
-        });
-  } else {
-    LOG_ERR("EBP", "Cover image is not a supported format, skipping thumbnail");
+  const int targetWidth = height * 3 / 5;
+  const std::string outputPath = getThumbBmpPath(height);
+  if (FsHelpers::hasJpgExtension(coverImageHref) || FsHelpers::hasPngExtension(coverImageHref)) {
+    if (convertExtractedCover(
+            *this, coverImageHref, outputPath, "thumbnail",
+            [targetWidth, height](HalFile& source, HalFile& output) {
+              return JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
+            },
+            [targetWidth, height](HalFile& source, HalFile& output) {
+              return PngToBmpConverter::pngFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
+            })) {
+      return true;
+    }
+  }
+  if (convertOverrideCover(
+          *this, outputPath, "thumbnail",
+          [targetWidth, height](HalFile& source, HalFile& output) {
+            return JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
+          },
+          [targetWidth, height](HalFile& source, HalFile& output) {
+            return PngToBmpConverter::pngFileTo1BitBmpStreamWithSize(source, output, targetWidth, height);
+          })) {
+    return true;
   }
 
   // Write an empty bmp file to avoid generation attempts in the future

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -52,6 +52,8 @@ class Epub {
   const std::string& getTitle() const;
   const std::string& getAuthor() const;
   const std::string& getLanguage() const;
+  std::string getCoverOverridePath() const;
+  bool hasCoverOverride() const;
   std::string getCoverBmpPath(bool cropped = false) const;
   bool generateCoverBmp(bool cropped = false) const;
   std::string getThumbBmpPath() const;

--- a/lib/WeReadWebApi/src/WeReadClient.cpp
+++ b/lib/WeReadWebApi/src/WeReadClient.cpp
@@ -3,6 +3,7 @@
 #ifdef ENABLE_CHINESE_VERSION
 
 #include <Arduino.h>
+#include <Epub.h>
 #include <HalClock.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
@@ -80,6 +81,20 @@ bool equalsIgnoreCase(const char* left, const char* right) {
     ++right;
   }
   return *left == '\0' && *right == '\0';
+}
+
+const char* imageTypeName(const WeReadProtocol::ImageType type) {
+  switch (type) {
+    case WeReadProtocol::ImageType::None:
+      return "none";
+    case WeReadProtocol::ImageType::Detect:
+      return "detect";
+    case WeReadProtocol::ImageType::Jpeg:
+      return "jpeg";
+    case WeReadProtocol::ImageType::Png:
+      return "png";
+  }
+  return "invalid";
 }
 
 bool md5Hex(const uint8_t* data, const size_t len, char out[33]) {
@@ -487,7 +502,7 @@ bool feedRemoteProgress(void* raw, const uint8_t* data, const size_t len) {
   return static_cast<WeReadProtocol::RemoteProgressParser*>(raw)->feed(data, len);
 }
 
-enum class ShelfField : uint8_t { None, Books, BookId, Title, Author, ReadUpdateTime, ErrorCode };
+enum class ShelfField : uint8_t { None, Books, BookId, Title, Author, Cover, ReadUpdateTime, ErrorCode };
 
 struct ShelfJsonContext {
   StreamingJsonParser* parser = nullptr;
@@ -514,6 +529,8 @@ void shelfKey(void* raw, const char* key, size_t) {
     ctx.field = ShelfField::Title;
   } else if (strcmp(key, "author") == 0) {
     ctx.field = ShelfField::Author;
+  } else if (strcmp(key, "cover") == 0) {
+    ctx.field = ShelfField::Cover;
   } else if (strcmp(key, "readUpdateTime") == 0) {
     ctx.field = ShelfField::ReadUpdateTime;
   } else if (strcmp(key, "errcode") == 0 || strcmp(key, "errCode") == 0) {
@@ -535,6 +552,18 @@ void shelfValue(void* raw, const char* value, const size_t len) {
         break;
       case ShelfField::Author:
         copyDecoded(value, len, ctx.current.author, sizeof(ctx.current.author));
+        break;
+      case ShelfField::Cover:
+        copyDecoded(value, len, ctx.current.coverUrl, sizeof(ctx.current.coverUrl));
+        {
+          char normalized[sizeof(ctx.current.coverUrl)] = {};
+          if (WeReadProtocol::normalizeCoverImageUrl(ctx.current.coverUrl, normalized, sizeof(normalized)) ==
+              WeReadProtocol::ImageType::None) {
+            ctx.current.coverUrl[0] = '\0';
+          } else {
+            memcpy(ctx.current.coverUrl, normalized, sizeof(ctx.current.coverUrl));
+          }
+        }
         break;
       case ShelfField::ReadUpdateTime:
         ctx.current.readUpdateTime = WeReadProtocol::parseUint32OrZero(value, len);
@@ -793,7 +822,7 @@ struct DetailJsonContext {
   WeReadProtocol::JsonStringDecoder* introDecoder = nullptr;
   WeReadStore::BookDetailWriter writer;
   WeReadStore::BookDetailHeader header;
-  const WeReadStore::ShelfRecord* book = nullptr;
+  const WeReadStore::BookRecord* book = nullptr;
   const std::string* bookDir = nullptr;
   DetailField field = DetailField::None;
   int depth = 0;
@@ -886,7 +915,7 @@ void detailString(void* raw, const char* value, const size_t len) {
       copyDecoded(value, len, ctx.header.coverUrl, sizeof(ctx.header.coverUrl));
       {
         char normalized[sizeof(ctx.header.coverUrl)] = {};
-        if (WeReadProtocol::normalizeImageUrl(ctx.header.coverUrl, normalized, sizeof(normalized)) ==
+        if (WeReadProtocol::normalizeCoverImageUrl(ctx.header.coverUrl, normalized, sizeof(normalized)) ==
             WeReadProtocol::ImageType::None) {
           ctx.header.coverUrl[0] = '\0';
         } else {
@@ -1202,8 +1231,8 @@ bool validImageWorkRecord(const WeReadStore::ImageWorkRecord& record) {
 bool validImageFile(const std::string& path, const WeReadProtocol::ImageType type) {
   HalFile file;
   uint8_t prefix[8] = {};
-  if (type == WeReadProtocol::ImageType::None || !Storage.openFileForRead("WR", path, file) || file.fileSize64() == 0 ||
-      file.fileSize64() > kMaxImageBytes) {
+  if ((type != WeReadProtocol::ImageType::Jpeg && type != WeReadProtocol::ImageType::Png) ||
+      !Storage.openFileForRead("WR", path, file) || file.fileSize64() == 0 || file.fileSize64() > kMaxImageBytes) {
     return false;
   }
   const size_t wanted = type == WeReadProtocol::ImageType::Png ? sizeof(prefix) : 3;
@@ -1574,7 +1603,7 @@ bool combineAndDecode(const std::string* shards, const size_t shardCount, const 
   return true;
 }
 
-Error writePackageFiles(const std::string& bookDir, const WeReadStore::ShelfRecord& book, const std::string& tocPath,
+Error writePackageFiles(const std::string& bookDir, const WeReadStore::BookRecord& book, const std::string& tocPath,
                         const uint32_t chapterCount, const uint32_t firstChapter, const uint32_t lastChapter,
                         const WeReadStore::ImagePolicy imagePolicy, const std::string& workPath,
                         const WeReadProtocol::ImageType coverType, std::string& navPath, std::string& opfPath,
@@ -1677,7 +1706,7 @@ Error writePackageFiles(const std::string& bookDir, const WeReadStore::ShelfReco
   return Error::Ok;
 }
 
-Error packageBook(const WeReadStore::ShelfRecord& book, const std::string& bookDir, const std::string& tocPath,
+Error packageBook(const WeReadStore::BookRecord& book, const std::string& bookDir, const std::string& tocPath,
                   const uint32_t chapterCount, const uint32_t firstChapter, const uint32_t lastChapter,
                   const WeReadStore::ImagePolicy imagePolicy, const std::string& workPath, uint8_t* buffer,
                   const size_t bufferSize, const std::string& finalPartPath, const WeReadStore::WorkCallback callback,
@@ -1686,6 +1715,8 @@ Error packageBook(const WeReadStore::ShelfRecord& book, const std::string& bookD
   std::string opfPath;
   std::string coverSourcePath;
   const WeReadProtocol::ImageType coverType = findCoverSource(bookDir, coverSourcePath);
+  LOG_INF("WR_COVER", "book=%08x source=epub kind=generated cover=%s result=ready",
+          static_cast<unsigned>(WeReadProtocol::hashAppId(book.bookId, strlen(book.bookId))), imageTypeName(coverType));
   const Error packageFilesError =
       writePackageFiles(bookDir, book, tocPath, chapterCount, firstChapter, lastChapter, imagePolicy, workPath,
                         coverType, navPath, opfPath, callback, callbackContext);
@@ -1919,6 +1950,7 @@ void Operation::reset() {
   tocPath_.clear();
   outputPath_.clear();
   finalPartPath_.clear();
+  if (shelfCoverUrl_) shelfCoverUrl_[0] = '\0';
 }
 
 bool Operation::begin(const Kind kind, const WeReadStore::ShelfRecord* book, const DownloadOptions options,
@@ -1949,7 +1981,24 @@ bool Operation::begin(const Kind kind, const WeReadStore::ShelfRecord* book, con
       }
       options_ = options;
     }
-    book_ = *book;
+    if (!memchr(book->coverUrl, '\0', sizeof(book->coverUrl))) {
+      error_ = Error::Protocol;
+      phase_ = Phase::Failed;
+      return false;
+    }
+    book_ = WeReadStore::bookRecord(*book);
+    if (kind == Kind::Detail && book->coverUrl[0]) {
+      if (!shelfCoverUrl_) {
+        shelfCoverUrl_ = makeUniqueNoThrow<char[]>(kUrlSize);
+        if (!shelfCoverUrl_) {
+          LOG_ERR("WR", "OOM: %u-byte shelf cover URL", static_cast<unsigned>(kUrlSize));
+          error_ = Error::OutOfMemory;
+          phase_ = Phase::Failed;
+          return false;
+        }
+      }
+      memcpy(shelfCoverUrl_.get(), book->coverUrl, strlen(book->coverUrl) + 1);
+    }
   }
   WeReadStore::loadSession(session_);
   Phase first = Phase::SyncShelf;
@@ -1984,7 +2033,7 @@ bool Operation::beginBrowseCache(const WeReadStore::ShelfRecord& book) {
     return false;
   }
   kind_ = Kind::Browse;
-  book_ = book;
+  book_ = WeReadStore::bookRecord(book);
   browseKind_ = WeReadBrowse::Kind::PopularHighlights;
   browseCursor_ = {};
   WeReadStore::loadSession(session_);
@@ -2302,10 +2351,13 @@ Error Operation::organizeShelfOnce() {
 }
 
 bool Operation::loadShelfCoverBook(ShelfCoverAction& action) {
+  WeReadStore::ShelfRecord shelf;
   if (!indexFile_.isOpen() || workCursor_ >= workCount_ ||
-      !WeReadStore::readShelfRecord(indexFile_, workCursor_, book_)) {
+      !WeReadStore::readShelfRecord(indexFile_, workCursor_, shelf)) {
     return false;
   }
+  book_ = WeReadStore::bookRecord(shelf);
+  if (shelfCoverUrl_) shelfCoverUrl_[0] = '\0';
 
   bookDir_ = WeReadStore::bookDirectory(book_.bookId);
   url_[0] = '\0';
@@ -2316,10 +2368,9 @@ bool Operation::loadShelfCoverBook(ShelfCoverAction& action) {
   if (!hasCurrentBmp && !hasSource) {
     WeReadStore::BookDetailHeader cached;
     HalFile detail;
-    if (WeReadStore::openBookDetail(bookDir_, cached, detail) && cached.coverUrl[0]) {
-      coverType_ = WeReadProtocol::normalizeImageUrl(cached.coverUrl, url_, sizeof(url_));
-      hasUrl = coverType_ != WeReadProtocol::ImageType::None;
-    }
+    const bool hasDetail = WeReadStore::openBookDetail(bookDir_, cached, detail);
+    coverType_ = selectCoverUrl(hasDetail ? cached.coverUrl : "", shelf.coverUrl, url_, sizeof(url_));
+    hasUrl = url_[0] != '\0';
   }
   action = shelfCoverAction(hasCurrentBmp, hasSource, hasUrl);
   return true;
@@ -2581,9 +2632,18 @@ Error Operation::fetchDetailOnce() {
     context.writer.abort();
     return Error::Protocol;
   }
+  const bool hasDetailCover = context.header.coverUrl[0] != '\0';
+  coverType_ = selectCoverUrl(context.header.coverUrl, shelfCoverUrl_ ? shelfCoverUrl_.get() : "", url_, sizeof(url_));
+  if (!url_[0]) {
+    context.header.coverUrl[0] = '\0';
+  } else {
+    memcpy(context.header.coverUrl, url_, strlen(url_) + 1);
+  }
+  LOG_INF("WR_COVER", "book=%08x source=%s type=%s result=%s",
+          static_cast<unsigned>(WeReadProtocol::hashAppId(book_.bookId, strlen(book_.bookId))),
+          !url_[0] ? "none" : (hasDetailCover ? "detail" : "shelf"), imageTypeName(coverType_),
+          url_[0] ? "selected" : "missing");
   if (!context.writer.finish(context.header)) return Error::SdCard;
-  coverType_ = WeReadProtocol::normalizeImageUrl(context.header.coverUrl, url_, sizeof(url_));
-  if (coverType_ == WeReadProtocol::ImageType::None) url_[0] = '\0';
   logMemory("detail parsed");
   return WeReadStore::saveSession(session_) ? Error::Ok : Error::SdCard;
 }
@@ -2905,6 +2965,63 @@ Error Operation::fetchShardOnce(const char* endpoint, const std::string& destina
                      sizeof(cookie_), url_, sizeof(url_), ioBuffer_, sizeof(ioBuffer_), &bookSession_);
 }
 
+bool Operation::persistCoverOverride() {
+  std::string source;
+  const WeReadProtocol::ImageType type = findCoverSource(bookDir_, source);
+  const uint32_t bookKey = WeReadProtocol::hashAppId(book_.bookId, strlen(book_.bookId));
+  if (type == WeReadProtocol::ImageType::None) {
+    LOG_INF("WR_COVER", "stage=override book=%08x source=none result=skipped", static_cast<unsigned>(bookKey));
+    return true;
+  }
+
+  const Epub epub(outputPath_, "/.crosspoint");
+  if (!Storage.ensureDirectoryExists(epub.getCachePath().c_str())) {
+    LOG_INF("WR_COVER", "stage=override book=%08x source=%s result=cache-dir", static_cast<unsigned>(bookKey),
+            imageTypeName(type));
+    return false;
+  }
+  const std::string destination = epub.getCoverOverridePath();
+  const std::string part = destination + ".part";
+  if (Storage.exists(part.c_str()) && !Storage.remove(part.c_str())) {
+    LOG_INF("WR_COVER", "stage=override book=%08x source=%s result=part-remove", static_cast<unsigned>(bookKey),
+            imageTypeName(type));
+    return false;
+  }
+
+  bool copied = false;
+  uint64_t sourceBytes = 0;
+  {
+    HalFile input;
+    HalFile output;
+    if (Storage.openFileForRead("WR", source, input) && Storage.openFileForWrite("WR", part, output)) {
+      sourceBytes = input.fileSize64();
+      uint64_t remaining = sourceBytes;
+      copied = remaining > 0;
+      while (copied && remaining > 0) {
+        const size_t wanted = static_cast<size_t>(std::min<uint64_t>(remaining, sizeof(ioBuffer_)));
+        const int read = input.read(ioBuffer_, wanted);
+        copied = read == static_cast<int>(wanted) && output.write(ioBuffer_, wanted) == wanted;
+        remaining -= copied ? wanted : 0;
+      }
+    }
+  }
+  if (!copied) {
+    if (Storage.exists(part.c_str())) Storage.remove(part.c_str());
+    LOG_INF("WR_COVER", "stage=override book=%08x source=%s bytes=%llu result=copy", static_cast<unsigned>(bookKey),
+            imageTypeName(type), static_cast<unsigned long long>(sourceBytes));
+    return false;
+  }
+  if (!WeReadStore::atomicReplace(part, destination)) {
+    LOG_INF("WR_COVER", "stage=override book=%08x source=%s bytes=%llu result=replace", static_cast<unsigned>(bookKey),
+            imageTypeName(type), static_cast<unsigned long long>(sourceBytes));
+    return false;
+  }
+
+  LOG_INF("WR_COVER", "stage=override book=%08x source=%s bytes=%llu result=ready", static_cast<unsigned>(bookKey),
+          imageTypeName(type), static_cast<unsigned long long>(sourceBytes));
+  return true;
+}
+
 Operation::Event Operation::finishWholeBook(const std::string& source) {
   bookSession_.reset();
   if (!wholeChapterRange(firstChapterIndex_, lastChapterIndex_, chapterCount_)) {
@@ -2925,6 +3042,7 @@ Operation::Event Operation::finishWholeBook(const std::string& source) {
     }
     return fail(Error::SdCard);
   }
+  if (!persistCoverOverride()) LOG_ERR("WR", "Failed to persist EPUB cover override");
   cleanupTransient(bookDir_, "");
   if (!WeReadStore::saveSession(session_)) return fail(Error::SdCard);
   persistInitialProgress();
@@ -2993,10 +3111,12 @@ Error Operation::prepareImageWork(const WeReadStore::WorkCallback callback, void
 }
 
 Error Operation::requestImage(WeReadStore::ImageRecord& image, WeReadStore::ImageWorkState& state, uint8_t& attempts,
-                              uint8_t& redirects, const bool trackProgress) {
+                              uint8_t& redirects, const bool trackProgress, WeReadProtocol::ImageType* detectedType) {
   const WeReadProtocol::ImageType type = imageTypeFromHref(image.href);
   const std::string destination = bookDir_ + "/" + image.href;
+  if (detectedType) *detectedType = WeReadProtocol::ImageType::None;
   if (validImageFile(destination, type)) {
+    if (detectedType) *detectedType = type;
     state = WeReadStore::ImageWorkState::Complete;
     if (trackProgress) {
       ++workCached_;
@@ -3059,6 +3179,14 @@ Error Operation::requestImage(WeReadStore::ImageRecord& image, WeReadStore::Imag
       WeReadHttpClient::request(bookSession_, referer_.c_str(), options, onData, onHeader, responseStatus_);
   if (file.file.isOpen()) finishFile(&file);
 
+  WeReadProtocol::ImageType magicType = WeReadProtocol::ImageType::None;
+  static constexpr uint8_t kPngMagic[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+  if (file.prefixSize >= sizeof(kPngMagic) && memcmp(file.prefix, kPngMagic, sizeof(kPngMagic)) == 0) {
+    magicType = WeReadProtocol::ImageType::Png;
+  } else if (file.prefixSize >= 3 && file.prefix[0] == 0xFF && file.prefix[1] == 0xD8 && file.prefix[2] == 0xFF) {
+    magicType = WeReadProtocol::ImageType::Jpeg;
+  }
+
   if (file.failure == FileSink::Failure::Cancelled) {
     if (Storage.exists(partPath.c_str())) Storage.remove(partPath.c_str());
     return Error::Cancelled;
@@ -3116,17 +3244,15 @@ Error Operation::requestImage(WeReadStore::ImageRecord& image, WeReadStore::Imag
     return Error::Ok;
   }
 
-  static constexpr uint8_t kPng[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
-  const bool validMagic =
-      type == WeReadProtocol::ImageType::Png
-          ? file.prefixSize >= sizeof(kPng) && memcmp(file.prefix, kPng, sizeof(kPng)) == 0
-          : file.prefixSize >= 3 && file.prefix[0] == 0xFF && file.prefix[1] == 0xD8 && file.prefix[2] == 0xFF;
+  const bool validMagic = detectedType ? magicType != WeReadProtocol::ImageType::None : magicType == type;
   if (!validMagic || file.size == 0) {
     recoverableFailure(false);
     return Error::Ok;
   }
 
-  if (!WeReadStore::atomicReplace(partPath, destination)) return Error::SdCard;
+  const std::string finalDestination = detectedType ? bookDir_ + "/" + coverSourceName(magicType) : destination;
+  if (!WeReadStore::atomicReplace(partPath, finalDestination)) return Error::SdCard;
+  if (detectedType) *detectedType = magicType;
   state = WeReadStore::ImageWorkState::Complete;
   if (trackProgress) {
     ++workCompleted_;
@@ -3141,17 +3267,24 @@ Error Operation::fetchCoverSource(CoverWorkResult& workResult) {
     return Error::Ok;
   }
 
+  const bool detectType = coverType_ == WeReadProtocol::ImageType::Detect;
   WeReadStore::ImageRecord image;
-  const char* href = coverSourceName(coverType_);
+  const char* href = coverSourceName(detectType ? WeReadProtocol::ImageType::Jpeg : coverType_);
   memcpy(image.href, href, strlen(href) + 1);
   memcpy(image.url, url_, strlen(url_) + 1);
   if (!WeReadHttpClient::extractHttpsHost(image.url, imageHost_, sizeof(imageHost_))) {
     return Error::Ok;
   }
 
-  const Error error = requestImage(image, coverState_, coverAttempts_, coverRedirects_, false);
+  WeReadProtocol::ImageType detectedType = WeReadProtocol::ImageType::None;
+  const Error error =
+      requestImage(image, coverState_, coverAttempts_, coverRedirects_, false, detectType ? &detectedType : nullptr);
   if (image.url[0]) memcpy(url_, image.url, strlen(image.url) + 1);
   if (error != Error::Ok) return error;
+  if (coverState_ == WeReadStore::ImageWorkState::Complete && detectType) {
+    if (detectedType == WeReadProtocol::ImageType::None) return Error::Protocol;
+    coverType_ = detectedType;
+  }
 
   switch (coverState_) {
     case WeReadStore::ImageWorkState::Pending:
@@ -3495,8 +3628,8 @@ Operation::Event Operation::step(const WeReadStore::WorkCallback callback, void*
             phase_ = Phase::ConvertCover;
             return detailCompletionEvent(true);
           case CoverCacheAction::FetchSource:
-            coverType_ = WeReadProtocol::normalizeImageUrl(cached.coverUrl, url_, sizeof(url_));
-            if (coverType_ == WeReadProtocol::ImageType::None) {
+            coverType_ = selectCoverUrl(cached.coverUrl, "", url_, sizeof(url_));
+            if (!url_[0]) {
               phase_ = Phase::Complete;
               return Event::Complete;
             }

--- a/lib/WeReadWebApi/src/WeReadClient.h
+++ b/lib/WeReadWebApi/src/WeReadClient.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "WeReadBrowse.h"
@@ -258,6 +259,18 @@ class Operation {
   }
   static constexpr bool imageAttemptPending(const uint8_t attempts) { return attempts < 2; }
   static constexpr bool imageRedirectAllowed(const uint8_t redirects) { return redirects < kMaxImageRedirects; }
+  static WeReadProtocol::ImageType selectCoverUrl(const char* detailUrl, const char* shelfUrl, char* output,
+                                                  const size_t outputSize) {
+    if (!output || outputSize == 0) return WeReadProtocol::ImageType::None;
+    output[0] = '\0';
+    WeReadProtocol::ImageType type = WeReadProtocol::normalizeCoverImageUrl(detailUrl, output, outputSize);
+    if (type != WeReadProtocol::ImageType::None) return type;
+    output[0] = '\0';
+    type = WeReadProtocol::normalizeCoverImageUrl(shelfUrl, output, outputSize);
+    if (type != WeReadProtocol::ImageType::None) return type;
+    output[0] = '\0';
+    return type;
+  }
   static constexpr bool validChapterRange(const uint32_t first, const uint32_t last, const uint32_t count) {
     return count > 0 && first <= last && last < count;
   }
@@ -343,11 +356,12 @@ class Operation {
   Event inspectPrimary();
   Event decodeChapter(bool plainText);
   Event finishWholeBook(const std::string& source);
+  bool persistCoverOverride();
   Event cancelNow();
   Error prepareImageWork(WeReadStore::WorkCallback callback, void* callbackContext);
   Event downloadNextImage();
   Error requestImage(WeReadStore::ImageRecord& image, WeReadStore::ImageWorkState& state, uint8_t& attempts,
-                     uint8_t& redirects, bool trackProgress);
+                     uint8_t& redirects, bool trackProgress, WeReadProtocol::ImageType* detectedType = nullptr);
 
   Phase phase_ = Phase::Idle;
   Phase resumePhase_ = Phase::Idle;
@@ -360,7 +374,8 @@ class Operation {
   ProgressSyncMode progressSyncMode_ = ProgressSyncMode::Compare;
   ProgressSyncResult progressSyncResult_;
   WeReadStore::Session session_;
-  WeReadStore::ShelfRecord book_;
+  WeReadStore::BookRecord book_;
+  std::unique_ptr<char[]> shelfCoverUrl_;
   WeReadStore::TocRecord chapter_;
   WeReadHttpClient::Session bookSession_;
   HalFile indexFile_;

--- a/lib/WeReadWebApi/src/WeReadProtocol.cpp
+++ b/lib/WeReadWebApi/src/WeReadProtocol.cpp
@@ -462,29 +462,32 @@ bool extractImageAttributes(const char* tag, char* source, const size_t sourceSi
   return source[0] != '\0';
 }
 
-ImageType normalizeImageUrl(const char* source, char* output, const size_t outputSize) {
-  if (!source || !output || outputSize < 10) return ImageType::None;
+namespace {
+
+bool normalizeHttpsUrl(const char* source, char* output, const size_t outputSize, const char*& path,
+                       const char*& pathEnd) {
+  if (!source || !output || outputSize < 10) return false;
   size_t written = 0;
   if (source[0] == '/' && source[1] == '/') {
     static constexpr char kScheme[] = "https:";
-    if (sizeof(kScheme) - 1 >= outputSize) return ImageType::None;
+    if (sizeof(kScheme) - 1 >= outputSize) return false;
     memcpy(output, kScheme, sizeof(kScheme) - 1);
     written = sizeof(kScheme) - 1;
   } else {
     static constexpr char kScheme[] = "https://";
     for (size_t i = 0; i < sizeof(kScheme) - 1; ++i) {
-      if (!source[i] || std::tolower(static_cast<unsigned char>(source[i])) != kScheme[i]) return ImageType::None;
+      if (!source[i] || std::tolower(static_cast<unsigned char>(source[i])) != kScheme[i]) return false;
       output[written++] = kScheme[i];
     }
     source += sizeof(kScheme) - 1;
   }
 
   while (*source && *source != '#') {
-    if (written + 1 >= outputSize) return ImageType::None;
+    if (written + 1 >= outputSize) return false;
     const unsigned char value = static_cast<unsigned char>(*source);
     if (value <= 0x20 || value == 0x7F || value == '"' || value == '\'' || value == '<' || value == '>' ||
         value == '\\') {
-      return ImageType::None;
+      return false;
     }
     if (strncmp(source, "&amp;", 5) == 0) {
       output[written++] = '&';
@@ -496,17 +499,21 @@ ImageType normalizeImageUrl(const char* source, char* output, const size_t outpu
   output[written] = '\0';
 
   const char* host = output + 8;
-  const char* path = strchr(host, '/');
-  if (!path || path == host || host[0] == '.' || path[-1] == '.') return ImageType::None;
+  path = strchr(host, '/');
+  if (!path || path == host || host[0] == '.' || path[-1] == '.') return false;
   bool previousDot = false;
   for (const char* cursor = host; cursor < path; ++cursor) {
     const unsigned char value = static_cast<unsigned char>(*cursor);
-    if (!std::isalnum(value) && value != '.' && value != '-') return ImageType::None;
-    if (value == '.' && previousDot) return ImageType::None;
+    if (!std::isalnum(value) && value != '.' && value != '-') return false;
+    if (value == '.' && previousDot) return false;
     previousDot = value == '.';
   }
-  const char* pathEnd = strchr(path, '?');
+  pathEnd = strchr(path, '?');
   if (!pathEnd) pathEnd = output + written;
+  return pathEnd > path && pathEnd[-1] != '/';
+}
+
+ImageType imageTypeFromPath(const char* path, const char* pathEnd) {
   const char* extension = pathEnd;
   while (extension > path && extension[-1] != '.') --extension;
   if (extension == path || extension[-1] != '.') return ImageType::None;
@@ -520,6 +527,28 @@ ImageType normalizeImageUrl(const char* source, char* output, const size_t outpu
   };
   if (extensionIs("jpg") || extensionIs("jpeg")) return ImageType::Jpeg;
   return extensionIs("png") ? ImageType::Png : ImageType::None;
+}
+
+}  // namespace
+
+ImageType normalizeImageUrl(const char* source, char* output, const size_t outputSize) {
+  const char* path = nullptr;
+  const char* pathEnd = nullptr;
+  if (!normalizeHttpsUrl(source, output, outputSize, path, pathEnd)) return ImageType::None;
+  return imageTypeFromPath(path, pathEnd);
+}
+
+ImageType normalizeCoverImageUrl(const char* source, char* output, const size_t outputSize) {
+  const char* path = nullptr;
+  const char* pathEnd = nullptr;
+  if (!normalizeHttpsUrl(source, output, outputSize, path, pathEnd)) return ImageType::None;
+  const ImageType type = imageTypeFromPath(path, pathEnd);
+  if (type != ImageType::None) return type;
+  const char* filename = pathEnd;
+  while (filename > path && filename[-1] != '/') --filename;
+  return filename < pathEnd && memchr(filename, '.', static_cast<size_t>(pathEnd - filename)) == nullptr
+             ? ImageType::Detect
+             : ImageType::None;
 }
 
 bool PsvtsExtractor::reset() {

--- a/lib/WeReadWebApi/src/WeReadProtocol.h
+++ b/lib/WeReadWebApi/src/WeReadProtocol.h
@@ -12,7 +12,7 @@ using Md5Function = bool (*)(const uint8_t* data, size_t len, char out[33]);
 using ByteSink = bool (*)(void* ctx, const uint8_t* data, size_t len);
 
 enum class ChapterResponse : uint8_t { Content, AuthenticationRequired, Retryable, Error };
-enum class ImageType : uint8_t { None, Jpeg, Png };
+enum class ImageType : uint8_t { None, Detect, Jpeg, Png };
 
 ChapterResponse classifyChapterResponse(int status, bool emptyObject);
 bool isEmptyJsonObject(const uint8_t* data, size_t len);
@@ -22,6 +22,7 @@ bool isAllowedXhtmlTag(const char* name);
 size_t safeXhtmlTextRunLength(const uint8_t* data, size_t len, bool plainText);
 bool extractImageAttributes(const char* tag, char* source, size_t sourceSize, char* alt, size_t altSize);
 ImageType normalizeImageUrl(const char* source, char* output, size_t outputSize);
+ImageType normalizeCoverImageUrl(const char* source, char* output, size_t outputSize);
 uint32_t parseUint32OrZero(const char* value, size_t len);
 uint32_t hashAppId(const char* value, size_t len);
 bool hasUsablePclts(const char* value);

--- a/lib/WeReadWebApi/src/WeReadStore.cpp
+++ b/lib/WeReadWebApi/src/WeReadStore.cpp
@@ -614,11 +614,22 @@ std::string detailPath(const std::string& bookDir) { return bookDir + "/detail.b
 
 std::string coverPath(const std::string& bookDir) { return bookDir + "/cover.v2.bmp"; }
 
-std::string finalBookPath(const ShelfRecord& book) {
+BookRecord bookRecord(const ShelfRecord& shelf) {
+  BookRecord book;
+  memcpy(book.bookId, shelf.bookId, sizeof(book.bookId));
+  memcpy(book.title, shelf.title, sizeof(book.title));
+  memcpy(book.author, shelf.author, sizeof(book.author));
+  book.readUpdateTime = shelf.readUpdateTime;
+  return book;
+}
+
+std::string finalBookPath(const BookRecord& book) {
   const std::string title = StringUtils::sanitizeFilename(book.title, 80);
   const std::string id = StringUtils::sanitizeFilename(book.bookId, 40);
   return "/WeRead/" + title + "-" + id + ".epub";
 }
+
+std::string finalBookPath(const ShelfRecord& book) { return finalBookPath(bookRecord(book)); }
 
 bool findBookIdForPath(const std::string& path, char* bookId, const size_t bookIdSize) {
   if (!bookId || bookIdSize == 0) return false;

--- a/lib/WeReadWebApi/src/WeReadStore.h
+++ b/lib/WeReadWebApi/src/WeReadStore.h
@@ -14,7 +14,7 @@ constexpr const char* kRoot = "/.crosspoint/weread";
 constexpr const char* kDisclaimerAcceptancePath = "/.crosspoint/weread/disclaimer.accepted";
 constexpr const char* kSessionPath = "/.crosspoint/weread/session.bin";
 constexpr const char* kShelfPath = "/.crosspoint/weread/shelf.bin";
-constexpr uint32_t kShelfMagic = 0x35535257;            // WRS5
+constexpr uint32_t kShelfMagic = 0x36535257;            // WRS6
 constexpr uint32_t kTocMagic = 0x32545257;              // WRT2
 constexpr uint32_t kImageMagic = 0x32495257;            // WRI2
 constexpr uint32_t kImageWorkMagic = 0x31504957;        // WIP1
@@ -66,9 +66,20 @@ struct ShelfRecord {
   char bookId[64] = {};
   char title[192] = {};
   char author[96] = {};
+  char coverUrl[512] = {};
   uint32_t readUpdateTime = 0;
 };
-static_assert(sizeof(ShelfRecord) == 356);
+static_assert(sizeof(ShelfRecord) == 868);
+
+struct BookRecord {
+  char bookId[64] = {};
+  char title[192] = {};
+  char author[96] = {};
+  uint32_t readUpdateTime = 0;
+};
+static_assert(sizeof(BookRecord) == 356);
+
+BookRecord bookRecord(const ShelfRecord& shelf);
 
 enum class ShelfSortResult : uint8_t {
   Ok,
@@ -194,6 +205,7 @@ std::string initialProgressPath(const char* bookId);
 std::string detailPath(const std::string& bookDir);
 std::string coverPath(const std::string& bookDir);
 std::string finalBookPath(const ShelfRecord& book);
+std::string finalBookPath(const BookRecord& book);
 bool findBookIdForPath(const std::string& path, char* bookId, size_t bookIdSize);
 bool parseGeneratedChapterHref(const std::string& href, uint32_t& tocIndex);
 bool mapFractionToChapter(const std::string& path, float fraction, TocRecord& chapter, uint32_t& chapterOffset);

--- a/src/util/BookCoverLoader.cpp
+++ b/src/util/BookCoverLoader.cpp
@@ -55,7 +55,7 @@ std::string ensureThumbnail(const std::string& bookPath, const int height, bool*
   if (FsHelpers::hasEpubExtension(bookPath)) {
     Epub epub(bookPath, "/.crosspoint");
     const std::string path = epub.getThumbBmpPath(height);
-    return ensureCachedCover(path, true, generated, [&]() {
+    return ensureCachedCover(path, !epub.hasCoverOverride(), generated, [&]() {
       if (!epub.load(true, true)) return false;
       epub.setupCacheDir();
       return epub.generateThumbBmp(height);

--- a/test/book_cover_loader/BookCoverLoaderTest.cpp
+++ b/test/book_cover_loader/BookCoverLoaderTest.cpp
@@ -23,6 +23,7 @@ class BookCoverLoaderTest : public ::testing::Test {
     ASSERT_TRUE(Storage.begin());
     cover_stub::epubThumbnailGenerations = 0;
     cover_stub::fullCoverGenerations = 0;
+    cover_stub::overrideConversions = 0;
   }
 
   void TearDown() override {
@@ -35,6 +36,13 @@ class BookCoverLoaderTest : public ::testing::Test {
     std::ofstream output(root / (path + 1), std::ios::binary | std::ios::trunc);
     ASSERT_TRUE(output.good());
     output << "book";
+  }
+
+  void writeOverride(const std::initializer_list<uint8_t> bytes) {
+    ASSERT_TRUE(Storage.ensureDirectoryExists("/.crosspoint/epub"));
+    std::ofstream output(hostPath("/.crosspoint/epub/cover.override"), std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output.good());
+    for (const uint8_t byte : bytes) output.put(static_cast<char>(byte));
   }
 
   std::filesystem::path hostPath(const char* path) const { return root / (path + 1); }
@@ -121,6 +129,60 @@ TEST_F(BookCoverLoaderTest, PreservesCoverlessEpubMarker) {
 
   EXPECT_TRUE(BookCoverLoader::ensureThumbnail("/coverless.epub", 226, &generated).empty());
   EXPECT_EQ(cover_stub::epubThumbnailGenerations, 1);
+}
+
+TEST_F(BookCoverLoaderTest, UsesOverrideAfterInternalEpubCoverFails) {
+  writeBook("/coverless.epub");
+  writeOverride({0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0});
+
+  bool generated = false;
+  EXPECT_EQ(BookCoverLoader::ensureThumbnail("/coverless.epub", 226, &generated), "/.crosspoint/epub/thumb_226.bmp");
+  EXPECT_TRUE(generated);
+  EXPECT_EQ(cover_stub::epubThumbnailGenerations, 1);
+  EXPECT_EQ(cover_stub::overrideConversions, 1);
+}
+
+TEST_F(BookCoverLoaderTest, PrefersInternalEpubCoverOverOverride) {
+  writeBook("/book.epub");
+  writeOverride({0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0});
+
+  EXPECT_FALSE(BookCoverLoader::ensureThumbnail("/book.epub", 226).empty());
+  EXPECT_EQ(cover_stub::epubThumbnailGenerations, 1);
+  EXPECT_EQ(cover_stub::overrideConversions, 0);
+}
+
+TEST_F(BookCoverLoaderTest, RetriesEmptyMarkerWhenOverrideAppears) {
+  writeBook("/coverless.epub");
+  bool generated = true;
+  EXPECT_TRUE(BookCoverLoader::ensureThumbnail("/coverless.epub", 226, &generated).empty());
+  writeOverride({0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0});
+
+  EXPECT_EQ(BookCoverLoader::ensureThumbnail("/coverless.epub", 226, &generated), "/.crosspoint/epub/thumb_226.bmp");
+  EXPECT_TRUE(generated);
+  EXPECT_EQ(cover_stub::epubThumbnailGenerations, 2);
+  EXPECT_EQ(cover_stub::overrideConversions, 1);
+}
+
+TEST_F(BookCoverLoaderTest, IgnoresInvalidOverrideAfterEmptyMarker) {
+  writeBook("/coverless.epub");
+  EXPECT_TRUE(BookCoverLoader::ensureThumbnail("/coverless.epub", 226).empty());
+  writeOverride({'n', 'o', 't', '-', 'a', 'n', '-', 'i', 'm', 'a', 'g', 'e'});
+
+  EXPECT_TRUE(BookCoverLoader::ensureThumbnail("/coverless.epub", 226).empty());
+  EXPECT_EQ(cover_stub::epubThumbnailGenerations, 1);
+  EXPECT_EQ(cover_stub::overrideConversions, 0);
+}
+
+TEST_F(BookCoverLoaderTest, UsesOverrideForFullEpubCover) {
+  writeBook("/coverless.epub");
+  writeOverride({0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0});
+
+  std::string title;
+  std::string author;
+  EXPECT_EQ(BookCoverLoader::ensureFullCover("/coverless.epub", &title, &author), "/.crosspoint/epub/cover.bmp");
+  EXPECT_EQ(title, "EPUB title");
+  EXPECT_EQ(author, "EPUB author");
+  EXPECT_EQ(cover_stub::overrideConversions, 1);
 }
 
 TEST_F(BookCoverLoaderTest, RejectsMissingBook) {

--- a/test/book_cover_loader/stubs/CoverStub.h
+++ b/test/book_cover_loader/stubs/CoverStub.h
@@ -8,6 +8,7 @@
 namespace cover_stub {
 inline int epubThumbnailGenerations = 0;
 inline int fullCoverGenerations = 0;
+inline int overrideConversions = 0;
 
 inline bool writeBmp(const std::string& path) {
   std::array<uint8_t, 66> bytes{};
@@ -25,7 +26,6 @@ inline bool writeBmp(const std::string& path) {
   bytes[58] = 0xFF;
   bytes[59] = 0xFF;
   bytes[60] = 0xFF;
-
   HalFile file;
   return Storage.openFileForWrite("TEST", path, file) && file.write(bytes.data(), bytes.size()) == bytes.size();
 }

--- a/test/book_cover_loader/stubs/Epub.h
+++ b/test/book_cover_loader/stubs/Epub.h
@@ -10,16 +10,34 @@ class Epub {
 
   bool load(bool buildIfMissing, bool) const { return buildIfMissing && path.find("load-fail") == std::string::npos; }
   void setupCacheDir() const { Storage.mkdir("/.crosspoint/epub"); }
+  bool hasCoverOverride() const {
+    HalFile file;
+    uint8_t prefix[8] = {};
+    if (!Storage.openFileForRead("TEST", "/.crosspoint/epub/cover.override", file) ||
+        file.read(prefix, sizeof(prefix)) != static_cast<int>(sizeof(prefix))) {
+      return false;
+    }
+    static constexpr uint8_t png[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+    return memcmp(prefix, png, sizeof(png)) == 0 || (prefix[0] == 0xFF && prefix[1] == 0xD8 && prefix[2] == 0xFF);
+  }
   std::string getThumbBmpPath(int height) const { return "/.crosspoint/epub/thumb_" + std::to_string(height) + ".bmp"; }
   std::string getCoverBmpPath(bool = false) const { return "/.crosspoint/epub/cover.bmp"; }
   bool generateThumbBmp(int height) const {
     ++cover_stub::epubThumbnailGenerations;
     const std::string output = getThumbBmpPath(height);
-    return path.find("coverless") == std::string::npos ? cover_stub::writeBmp(output)
-                                                       : (cover_stub::writeEmpty(output) && false);
+    if (path.find("coverless") == std::string::npos) return cover_stub::writeBmp(output);
+    if (hasCoverOverride()) {
+      ++cover_stub::overrideConversions;
+      return cover_stub::writeBmp(output);
+    }
+    return cover_stub::writeEmpty(output) && false;
   }
   bool generateCoverBmp(bool = false) const {
     ++cover_stub::fullCoverGenerations;
+    if (path.find("coverless") != std::string::npos) {
+      if (!hasCoverOverride()) return false;
+      ++cover_stub::overrideConversions;
+    }
     return cover_stub::writeBmp(getCoverBmpPath());
   }
   const std::string& getTitle() const {

--- a/test/weread_webapi/WeReadProtocolTest.cpp
+++ b/test/weread_webapi/WeReadProtocolTest.cpp
@@ -52,6 +52,10 @@ struct OperationTestPeer {
   }
   static bool imageAttemptPending(const uint8_t attempts) { return Operation::imageAttemptPending(attempts); }
   static bool imageRedirectAllowed(const uint8_t redirects) { return Operation::imageRedirectAllowed(redirects); }
+  static WeReadProtocol::ImageType selectCoverUrl(const char* detailUrl, const char* shelfUrl, char* output,
+                                                  const size_t outputSize) {
+    return Operation::selectCoverUrl(detailUrl, shelfUrl, output, outputSize);
+  }
   static bool validChapterRange(const uint32_t first, const uint32_t last, const uint32_t count) {
     return Operation::validChapterRange(first, last, count);
   }
@@ -285,6 +289,39 @@ TEST(WeReadProtocol, NormalizesOnlyBoundedHttpsJpegAndPngUrls) {
             ImageType::None);
   const std::string tooLong = "https://cdn.example/" + std::string(600, 'a') + ".png";
   EXPECT_EQ(WeReadProtocol::normalizeImageUrl(tooLong.c_str(), normalized, sizeof(normalized)), ImageType::None);
+}
+
+TEST(WeReadProtocol, PrefersDetailCoverAndFallsBackToShelfCover) {
+  char output[512] = {};
+  const auto select = WeReadClient::OperationTestPeer::selectCoverUrl;
+
+  EXPECT_EQ(select("https://detail.example/cover.png", "https://shelf.example/cover.jpg", output, sizeof(output)),
+            WeReadProtocol::ImageType::Png);
+  EXPECT_STREQ(output, "https://detail.example/cover.png");
+
+  EXPECT_EQ(select("", "//shelf.example/cover.jpg", output, sizeof(output)), WeReadProtocol::ImageType::Jpeg);
+  EXPECT_STREQ(output, "https://shelf.example/cover.jpg");
+
+  EXPECT_EQ(select("https://detail.example/cover.webp", "https://shelf.example/cover.gif", output, sizeof(output)),
+            WeReadProtocol::ImageType::None);
+  EXPECT_STREQ(output, "");
+}
+
+TEST(WeReadProtocol, AcceptsOnlySafeExtensionlessCoverUrlsForTypeDetection) {
+  char output[512] = {};
+
+  EXPECT_EQ(WeReadProtocol::normalizeCoverImageUrl("//cdn.example/path/cover-id", output, sizeof(output)),
+            WeReadProtocol::ImageType::Detect);
+  EXPECT_STREQ(output, "https://cdn.example/path/cover-id");
+  EXPECT_EQ(WeReadProtocol::normalizeCoverImageUrl("https://cdn.example/path/cover.webp", output, sizeof(output)),
+            WeReadProtocol::ImageType::None);
+  EXPECT_EQ(WeReadProtocol::normalizeCoverImageUrl("http://cdn.example/path/cover-id", output, sizeof(output)),
+            WeReadProtocol::ImageType::None);
+
+  EXPECT_EQ(WeReadClient::OperationTestPeer::selectCoverUrl("https://detail.example/cover-id",
+                                                            "https://shelf.example/cover.jpg", output, sizeof(output)),
+            WeReadProtocol::ImageType::Detect);
+  EXPECT_STREQ(output, "https://detail.example/cover-id");
 }
 
 TEST(WeReadProtocol, RejectsUnsafeOrOversizedRuntimeCookiesWithoutMutation) {

--- a/test/weread_webapi/WeReadStoreTest.cpp
+++ b/test/weread_webapi/WeReadStoreTest.cpp
@@ -102,10 +102,17 @@ class WeReadStoreTest : public ::testing::Test {
 TEST_F(WeReadStoreTest, StreamsLargeShelfAndTocIndexesAndRejectsCorruption) {
   ASSERT_TRUE(WeReadStore::ensureRoot());
   {
-    constexpr uint32_t kLegacyShelfMagic = 0x34535257;  // WRS4
+    struct LegacyShelfRecord {
+      char bookId[64] = {};
+      char title[192] = {};
+      char author[96] = {};
+      uint32_t readUpdateTime = 0;
+    };
+    static_assert(sizeof(LegacyShelfRecord) == 356);
+    constexpr uint32_t kLegacyShelfMagic = 0x35535257;  // WRS5
     WeReadStore::IndexWriter legacyShelf;
-    ASSERT_TRUE(legacyShelf.begin(WeReadStore::kShelfPath, kLegacyShelfMagic, sizeof(WeReadStore::ShelfRecord)));
-    WeReadStore::ShelfRecord record;
+    ASSERT_TRUE(legacyShelf.begin(WeReadStore::kShelfPath, kLegacyShelfMagic, sizeof(LegacyShelfRecord)));
+    LegacyShelfRecord record;
     strcpy(record.bookId, "legacy-book");
     ASSERT_TRUE(legacyShelf.append(&record));
     ASSERT_TRUE(legacyShelf.finish());
@@ -122,6 +129,7 @@ TEST_F(WeReadStoreTest, StreamsLargeShelfAndTocIndexesAndRejectsCorruption) {
     snprintf(record.bookId, sizeof(record.bookId), "book-%03u", i);
     snprintf(record.title, sizeof(record.title), "标题-%03u", i);
     snprintf(record.author, sizeof(record.author), "作者-%03u", i);
+    snprintf(record.coverUrl, sizeof(record.coverUrl), "https://cdn.example/cover-%03u.jpg", i);
     ASSERT_TRUE(shelf.append(&record));
   }
   ASSERT_EQ(shelf.count(), 600U);
@@ -135,6 +143,7 @@ TEST_F(WeReadStoreTest, StreamsLargeShelfAndTocIndexesAndRejectsCorruption) {
   ASSERT_TRUE(WeReadStore::readShelfRecord(shelfFile, 599, shelfRecord));
   EXPECT_STREQ(shelfRecord.bookId, "book-599");
   EXPECT_STREQ(shelfRecord.title, "标题-599");
+  EXPECT_STREQ(shelfRecord.coverUrl, "https://cdn.example/cover-599.jpg");
 
   const std::string tocPath = WeReadStore::tocPath("book-599");
   ASSERT_TRUE(Storage.ensureDirectoryExists(WeReadStore::bookDirectory("book-599").c_str()));


### PR DESCRIPTION
## Summary\n\n- preserve WeRead shelf cover URLs in the WRS6 shelf cache and prefer detail covers with shelf fallback\n- accept safe extensionless HTTPS cover URLs, then determine JPEG or PNG from the downloaded file signature\n- keep generated EPUB covers embedded and add one atomic cover.override sidecar for direct EPUB downloads\n- centralize internal-cover-first and override fallback behavior in Epub; keep BookCoverLoader limited to thumbnail cache state\n\n## Root cause\n\nImported books can expose a valid cover on the shelf endpoint while the detail cover is absent or uses an extensionless URL. The firmware discarded the shelf cover and only accepted URLs ending in JPEG or PNG. Directly downloaded EPUBs also had no shared fallback when their internal metadata did not identify a cover.\n\n## Verification\n\n- git diff --check\n- ./bin/clang-format-fix --check\n- full ./bin/ci-check before final rebase: cppcheck, all supported firmware environments, and 423 host tests\n- latest origin/main: 423 of 423 host tests passed\n- latest origin/main: pio run -e default passed\n  - DRAM: 122,195 bytes\n  - PlatformIO RAM: 55,204 bytes\n  - Flash: 5,887,601 bytes\n\n## Device validation\n\nValidated on an Xteink X4 with app-only firmware upload; no erase or filesystem upload.\n\n- cleared temporary WeRead cache while preserving downloaded books and reading progress\n- resynced the shelf and confirmed the imported book cover\n- cached 当书法穿越唐朝.epub and confirmed the generated EPUB embedded OEBPS/cover.jpg\n- confirmed the cover on the system home screen and recent-reading screen\n- confirmed persistence after the automatic software restart\n\nThe tested book used the generated EPUB path. The direct EPUB cover.override path is covered by host tests for internal-cover priority, valid override fallback, invalid override rejection, and empty-thumbnail-marker retry.