### PR TITLE
fix: use current release environment in upstream sync

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -92,7 +92,7 @@ explicitly authorized:
 - Simulator: its host compatibility self-test, all four CrossMux simulator
   environments, and the CrossMux CMake/CTest host suite.
 - CrossMux: index/conflict-marker checks, `git diff --check`, `pio run`,
-  `pio run -e gh_release_cn`, and extra build environments.
+  `pio run -e gh_release`, and extra build environments.
 
 Report local checks, dependency Draft PRs, CrossMux Draft PR, CI, deployment,
 and physical-device acceptance separately.

--- a/.claude/skills/sync-upstream/scripts/sync_upstream.py
+++ b/.claude/skills/sync-upstream/scripts/sync_upstream.py
@@ -678,7 +678,7 @@ def run_crossmux_builds(
         print("Skipping PlatformIO builds because --skip-builds was passed.")
         return
     run(["pio", "run"], cwd=root, capture=False)
-    run(["pio", "run", "-e", "gh_release_cn"], cwd=root, capture=False)
+    run(["pio", "run", "-e", "gh_release"], cwd=root, capture=False)
     for env in extra_envs:
         run(["pio", "run", "-e", env], cwd=root, capture=False)
 

--- a/.claude/skills/sync-upstream/tests/test_sync_upstream.py
+++ b/.claude/skills/sync-upstream/tests/test_sync_upstream.py
@@ -101,6 +101,21 @@ class PinUpdateTest(unittest.TestCase):
         self.assertEqual(pins, (sha, sha))
 
 
+class BuildValidationTest(unittest.TestCase):
+    def test_crossmux_uses_current_release_environment(self):
+        with patch.object(sync_upstream, "run") as run:
+            sync_upstream.run_crossmux_builds(Path("/tmp/crossmux"), False, ["extra"])
+
+        self.assertEqual(
+            [invocation.args[0] for invocation in run.call_args_list],
+            [
+                ["pio", "run"],
+                ["pio", "run", "-e", "gh_release"],
+                ["pio", "run", "-e", "extra"],
+            ],
+        )
+
+
 class ReviewGateTest(unittest.TestCase):
     def test_pr_body_pairs_each_review_item_with_its_decision(self):
         state = {


### PR DESCRIPTION
## Summary

- use the existing `gh_release` PlatformIO environment for CrossMux validation
- keep the sync-upstream instructions aligned with the executable workflow
- cover the default, release, and extra-environment command sequence

## Validation

- `python3 -m unittest discover -v -s .claude/skills/sync-upstream/tests` (14/14)
- `quick_validate.py .claude/skills/sync-upstream`
- `git diff --check`
