### PR TITLE
fix: remove Chinese settings pseudo-bold

### DIFF
--- a/docs/engineering/chinese-build.md
+++ b/docs/engineering/chinese-build.md
@@ -280,8 +280,8 @@ repository.
 
 ## Known limitations
 
-- **No bold/italic CJK glyphs**: the bitmaps come from a single NotoSansSC-Regular subset. The Settings page gives its four top-level Chinese category labels a fixed one-pixel synthetic bold; other UI elements that pass `EpdFontFamily::Style::Bold` render the regular weight under CN.
-- **Offline reader fallback is 12pt only**: install an SD `.cpfont` family for other reading sizes and styles. The INX Settings categories also remain at the theme-defined 12pt because the unified firmware has no resident 16pt CJK UI face.
+- **No bold/italic CJK glyphs**: the bitmaps come from a single NotoSansSC-Regular subset. UI elements that pass `EpdFontFamily::Style::Bold` render the regular weight under CN.
+- **Offline reader fallback is 12pt only**: install an SD `.cpfont` family for other reading sizes and styles.
 - **Rare characters render as □ in reader at SMALL until an SD font is installed**: the 12pt bitmap uses the complete 3500-char pool plus required glyphs. It omits classical/scientific rarities, Traditional Chinese variants, and uncommon names outside that set; for example, `璟` is intentionally absent. The reader offers the complete-font downloader on the first detected missing glyph.
 - **No Traditional Chinese UI locale**: only `ZH_CN` is present; broader CJK book coverage depends on the selected SD font.
 

--- a/src/activities/UiTabListActivity.cpp
+++ b/src/activities/UiTabListActivity.cpp
@@ -103,7 +103,7 @@ void UiTabListActivity::syncTabListViewport(UiScreen& screen, fui::ListProps& pr
   props.selectedIndex = static_cast<int16_t>(n.selected - 1);  // -1 = tab band focused
 }
 
-void UiTabListActivity::buildTabBar(UiScreen& screen, const bool boldLabels) {
+void UiTabListActivity::buildTabBar(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
 
   // Tabs. The selected pill dims to a dither when the selection is down in
@@ -162,7 +162,6 @@ void UiTabListActivity::buildTabBar(UiScreen& screen, const bool boldLabels) {
     tabProps.tabInset = tabsFocused ? fui::Insets{2, 0, 4, 0} : fui::Insets{2, 0, 0, 0};
     tabProps.contentInset = fui::Insets{2, 8, 2, 8};
   }
-  if (boldLabels) tabProps.text.bold = true;
   const int16_t tabLineHeight = screen.target().lineHeight(tabProps.text.font);
   const int16_t tabBand =
       static_cast<int16_t>(metrics.tabBarHeight > tabLineHeight + 10 ? metrics.tabBarHeight : tabLineHeight + 10);

--- a/src/activities/UiTabListActivity.h
+++ b/src/activities/UiTabListActivity.h
@@ -56,7 +56,7 @@ class UiTabListActivity : public UiListActivity {
   // --- screen helpers --------------------------------------------------------
   // The shared tab band: theme-driven pill treatment (label-hugging Lyra vs
   // full-slot RoundedRaff), Lyra focused band wash, always-on divider.
-  void buildTabBar(UiScreen& screen, bool boldLabels = false);
+  void buildTabBar(UiScreen& screen);
   // Ring-aware counterpart of syncListViewport: measures rows, applies the
   // one-shot follow to the remembered row, clamps, and writes
   // props.selectedIndex = ring - 1. hasSubtitle: see syncListViewport().

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -898,7 +898,6 @@ std::string SettingsActivity::settingValueText(const SettingInfo& setting) {
 
 void SettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  const bool boldChineseCategories = I18N.getLanguage() == Language::ZH_CN;
   // Content below the GUI.drawHeader band, above the button hints.
   screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
                                       static_cast<int16_t>(metrics.buttonHintsHeight), 0});
@@ -920,23 +919,11 @@ void SettingsActivity::buildScreen(UiScreen& screen) {
     props.valueText = screen.theme().bodyText;
     syncListViewport(screen, props);
     if (!showMainTabContentSelection()) props.selectedIndex = -1;
-    if (boldChineseCategories) {
-      props.labelText.bold = false;
-      props.valueText.bold = false;
-    }
-    GfxRenderer::SyntheticBoldScope syntheticBold(renderer, boldChineseCategories
-                                                                ? CrossPointSettings::SYNTHETIC_BOLD_STANDARD
-                                                                : CrossPointSettings::SYNTHETIC_BOLD_OFF);
     screen.list(props);
     return;
   }
 
-  {
-    GfxRenderer::SyntheticBoldScope syntheticBold(renderer, boldChineseCategories
-                                                                ? CrossPointSettings::SYNTHETIC_BOLD_STANDARD
-                                                                : CrossPointSettings::SYNTHETIC_BOLD_OFF);
-    buildTabBar(screen, boldChineseCategories);
-  }
+  buildTabBar(screen);
 
   // rowItems_ (label/actionValue) was built by rebuildRowItems() when the
   // category was last selected/rebuilt; only the live value text needs


### PR DESCRIPTION
## Summary

- Reverts `ff302e3b` because the synthetic bold degrades Chinese settings category rendering.
- Removes the Chinese-only synthetic-bold scopes and restores the original `buildTabBar(UiScreen&)` interface.
- Restores the Chinese build documentation to describe the regular-weight fallback.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, media feature, browser, or PDF feature.
- [x] This is a focused UI cleanup with no SDK, HAL, bootloader, OTA, or recovery changes.

## Verification

- [x] `./bin/clang-format-fix --check`
- [x] `pio run` (`default`: SUCCESS; RAM 55,204 B, Flash 5,894,055 B)
- [x] The four reverted files match the parent of `ff302e3b`.
- [ ] Verify the Simplified Chinese settings categories on device.

## Additional Context

No new allocation, dependency, setting, or binary format change.

### AI Usage

Did you use AI tools to help write this code? **YES**