### PR TITLE
fix: reserve Inx recent footer on touch devices

### DIFF
--- a/src/InxRecentLayout.h
+++ b/src/InxRecentLayout.h
@@ -6,6 +6,12 @@
 enum class InxRecentLayout : uint8_t { Flow, Grid, List, Icons, Cover, Count };
 
 namespace InxRecentGeometry {
+inline constexpr int footerReservedHeight = 40;
+
+constexpr int contentHeight(const int screenHeight, const int top, const int buttonHintsHeight) {
+  return std::max(0, screenHeight - top - std::max(buttonHintsHeight, footerReservedHeight));
+}
+
 constexpr int itemsPerPage(const InxRecentLayout layout) {
   switch (layout) {
     case InxRecentLayout::Flow:

--- a/src/activities/home/InxRecentActivity.cpp
+++ b/src/activities/home/InxRecentActivity.cpp
@@ -31,7 +31,7 @@ Rect contentRect(const GfxRenderer& renderer) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int top = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
   return Rect{0, top, renderer.getScreenWidth(),
-              renderer.getScreenHeight() - top - metrics.buttonHintsHeight - metrics.verticalSpacing};
+              InxRecentGeometry::contentHeight(renderer.getScreenHeight(), top, metrics.buttonHintsHeight)};
 }
 
 const char* titleOf(const RecentBook& book) { return book.title.empty() ? book.path.c_str() : book.title.c_str(); }

--- a/test/inx_navigation/InxNavigationTest.cpp
+++ b/test/inx_navigation/InxNavigationTest.cpp
@@ -145,6 +145,14 @@ TEST(InxNavigation, KeepsRecentPagesInsideBounds) {
   }
 }
 
+TEST(InxNavigation, ReservesRecentFooterWithOrWithoutButtonHints) {
+  EXPECT_EQ(InxRecentGeometry::footerReservedHeight, 40);
+  EXPECT_EQ(InxRecentGeometry::contentHeight(480, 66, 0), 374);
+  EXPECT_EQ(InxRecentGeometry::contentHeight(480, 66, 40), 374);
+  EXPECT_EQ(InxRecentGeometry::contentHeight(480, 66, 56), 358);
+  EXPECT_EQ(InxRecentGeometry::contentHeight(80, 60, 0), 0);
+}
+
 TEST(InxNavigation, FitsOriginalCoverRatioInsideBounds) {
   EXPECT_EQ(InxCoverGeometry::fit(0, 250).width, 0);
   EXPECT_EQ(InxCoverGeometry::fit(170, 250).width, 170);


### PR DESCRIPTION
## Summary

- reserve a 40 px footer in Inx recent-book layouts even when touch devices hide button hints
- keep drawing and touch hit-testing on the same bounded content rectangle
- clamp the shared content-height calculation for very small displays

## Root cause

Touch layouts reported a zero button-hint height, so recent-book Cover and Icons content extended into the footer battery area. The shared content rectangle now reserves the larger of the active button-hint height and the existing 40 px Inx footer.

## Validation

- InxNavigationTest: 18/18 passed
- git diff --check and staged diff check: passed
- PlatformIO sticky build: passed; RAM 65,068 bytes (19.9%), flash 5,637,323 bytes (86.0%)
- flashed firmware SHA-256: 5cbf0ba3d45093fce3f34f66eb57b1d735fc9b1a11201253fec740f16bc87472
- Sticky real-device acceptance: passed for all five recent-reading layouts; Cover and Icons no longer overlap the battery footer

The Sticky build and hardware run used the in-review SDK merge candidate HEAD 98974140 with MERGE_HEAD 7e87d76f. GitHub CI remains the validation gate for the repository-pinned SDK.

## Scope

No public API, persisted settings, cover ratio, pagination count, or heap allocation changes.