### PR TITLE
fix: restore Waveshare WeRead shelf navigation

### DIFF
--- a/src/activities/apps/weread/webapi/WeReadActivity.cpp
+++ b/src/activities/apps/weread/webapi/WeReadActivity.cpp
@@ -1611,7 +1611,7 @@ void WeReadActivity::handleShelfInput() {
       } else {
         break;
       }
-      return;
+      [[fallthrough]];
     case ShelfNavigationGesture::PreviousPressed:
     case ShelfNavigationGesture::NextPressed:
     case ShelfNavigationGesture::PreviousPageHandled:


### PR DESCRIPTION
## Summary

* **Goal:** Restore shelf cursor movement in WeRead on Waveshare ePaper 3.97.
* Let the shelf navigation state machine consume a same-frame direction press/release instead of returning after the press edge.
* Preserve the existing held-button page navigation and orientation-aware logical mapping.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This fixes an input regression in an existing supported device/app path; stock firmware does not address CrossMux behavior.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

Waveshare short Left/Right gestures emit pressed and released in the same input snapshot. The shelf state machine previously returned after observing pressed, so it discarded released and reset without moving on the next frame.

Validation:

* Waveshare input host tests: 14/14 passed.
* `pio run -e waveshare_epaper_397`: passed.
* Hardware verification remains pending.
* No memory or flash impact beyond the control-flow change.

---

### AI Usage

Did you use AI tools to help write this code? **YES**