### PR TITLE
ci: disable daily upstream sync schedule

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,6 +1,6 @@
 name: Sync upstream master
 
-# Daily: keep a standing PR that merges upstream master into main.
+# Manually maintain a standing PR that merges upstream master into main.
 # - Clean merge  -> push the merge to chore/sync-upstream and open/refresh the PR.
 # - Conflicts    -> reset the branch, open/refresh the PR, label it
 #                   `needs-claude-resolution` and list the conflicted files.
@@ -9,8 +9,6 @@ name: Sync upstream master
 # clicks merge on the PR.
 
 on:
-  schedule:
-    - cron: '0 0 * * *'   # 00:00 UTC = 08:00 Asia/Shanghai
   workflow_dispatch:
 
 permissions:
@@ -106,7 +104,7 @@ jobs:
             n="$(find_open_pr)"
             if [ -z "$n" ]; then
               body="$(printf '%s\n' \
-                "Automated daily merge of upstream \`master\` into \`${BASE}\`." \
+                "Manually triggered merge of upstream \`master\` into \`${BASE}\`." \
                 "" \
                 "Maintained by \`.github/workflows/sync-upstream.yml\`. Review and merge when green." \
                 "Conflicts (if any) are resolved automatically by the scheduled Claude routine.")"

--- a/docs/engineering/upstream-merge-policy.md
+++ b/docs/engineering/upstream-merge-policy.md
@@ -1,7 +1,7 @@
 # Upstream-Merge Policy for `CLAUDE.md` / `.skills/SKILL.md`
 
 > How to resolve conflicts on the development guide when syncing upstream into
-> `main`. This is the rule the daily sync routine and any human resolver must
+> `main`. This is the rule the manual sync routine and any human resolver must
 > follow. Read it whenever `.skills/SKILL.md` appears in a sync PR's conflict list.
 
 ## The structural invariant


### PR DESCRIPTION
## Summary
- remove the daily schedule from the upstream sync workflow
- preserve manual workflow dispatch and existing sync behavior
- update stale daily-sync wording

## Validation
- workflow YAML parses successfully
- sync workflow has no schedule or cron trigger
- workflow_dispatch remains available
- git diff --check passes