### PR TITLE
fix(waveshare): keep the 3.97 awake on a USB-powered cold boot

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -568,13 +568,17 @@ void setup() {
     case HalGPIO::WakeupReason::AfterUSBPower:
       // Most devices return to sleep after a USB-powered cold boot.
       LOG_DBG("MAIN", "Wakeup reason: After USB Power");
-#if FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_EEGO_A4
+#if FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_EEGO_A4 || \
+    FREEINK_DEVICE_WAVESHARE_EPAPER_397
       // X4 Pro must stay awake so USB Serial/JTAG remains available after leaving
       // USB Drive and reconnecting the cable. Paper Mono has no armable GPIO wake
       // (its button is behind the PMIC). EEGO A4's post-flash reset reads as
       // POWERON (native-USB), so a flash would otherwise be misclassified as a
-      // USB-power cold boot and sleep. Sleeping any of these here would strand
-      // the device in a USB-replug boot loop (or sleep right after a flash).
+      // USB-power cold boot and sleep. Waveshare 3.97 hits both: its side key is
+      // behind the AXP2101 (input.power == PIN_UNASSIGNED) and it is a native-USB
+      // S3, so startDeepSleep() there is a PMIC shutdown on every cabled boot.
+      // Sleeping any of these here would strand the device in a USB-replug boot
+      // loop (or sleep right after a flash).
       break;
 #else
       powerManager.startDeepSleep(gpio);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop the Waveshare ePaper 3.97 from powering itself off partway through boot whenever it is started with USB attached.
* **What changes are included?** One compile-time condition: add `FREEINK_DEVICE_WAVESHARE_EPAPER_397` to the `AfterUSBPower` stay-awake list in `setup()`, with a comment explaining why this board qualifies.

### The bug

`WakeupReason::AfterUSBPower` calls `powerManager.startDeepSleep()` for every device not on the exemption list. On the 3.97 that call is not a sleep at all: it runs `logSerial.end()` and then `Waveshare397Power::shutdown()`, which has the AXP2101 cut system power.

And `AfterUSBPower` is exactly how this board's ordinary use is classified: powering on with the cable attached is `ESP_RST_POWERON` with VBUS present. So every cabled boot powers the device off at `src/main.cpp:584`, before `setupDisplayAndFonts()` at `src/main.cpp:609`, without drawing anything. The e-paper keeps its previous frame and the USB port disappears.

The exemption list already carries four boards for closely related reasons -- Paper Mono's power button sits behind its PMIC, EEGO A4's native-USB reset is misclassified as a USB-power cold boot -- and the 3.97, whose side key is likewise behind the AXP2101 (`input.power == PIN_UNASSIGNED`), was simply never added.

### Reproduction

1. Flash the firmware and power on with no SD card inserted. `Storage.begin()` fails, the firmware draws "SD card error" (`src/main.cpp:517`) and returns at `src/main.cpp:529`, short of the wakeup switch. The device stays powered up.
2. Insert a working SD card and reboot. `Storage.begin()` now succeeds, so execution continues past that early return, reaches `AfterUSBPower`, and the device powers itself off before drawing anything. The panel still shows the frame from step 1.
3. Every subsequent power-on with the cable attached repeats step 2. The panel is never redrawn, so the device appears permanently stuck on an SD card error even though the card is fine.

### Verification

Bench-tested on real 3.97 hardware (16 MiB flash, AXP2101 and PCF85063A). Before the change the port disappeared within about a second of every USB-powered cold boot. After the change:

```
rst:0x15,boot:0x2a (SPI_FAST_FLASH_BOOT)
[32]    [PWR] AXP2101 ready: external=1
[87]    [SD] SDMMC card mounted
[131]   [MAIN] Starting CrossPoint version 1.5.8-waveshare-epaper-397-rc
[286]   [MAIN] Display initialized
[2085]  [ACT] Entering activity: InxRecent
[10025] [MEM] Free: 262428 bytes
[20062] [MEM] Free: 262428 bytes
```

The port was still enumerated after 25 s, with the memory heartbeat running.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well. This is a board-bringup defect in CrossPoint's own boot path, not a feature.
- [ ] Not applicable. This PR touches only `src/main.cpp`.

## Additional Context

* **Memory and flash impact:** none. The change is a compile-time `#if`, and only the 3.97 build is affected.
* **Behavioural trade-off:** attaching USB to a powered-off 3.97 now boots it fully instead of powering it off. The inactivity timer in `loop()` still puts it to sleep afterwards. This is the same trade-off already accepted for X4 Pro, X4 Classic, Paper Mono, and EEGO A4.
* **Risk:** low. No behaviour changes on any other board.
* This is the fifth device on this list (Paper Mono, X4 Pro, EEGO A4, X4 Classic, and now the 3.97). Deriving the condition from board capabilities rather than a hand-maintained device list may be worthwhile, but that is a larger refactor and out of scope here.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
