### PR TITLE
fix: handle tiny images and touch sleep covers

### DIFF
--- a/lib/Epub/Epub/converters/PixelCache.h
+++ b/lib/Epub/Epub/converters/PixelCache.h
@@ -57,6 +57,9 @@ struct PixelCache {
 
   static constexpr int MIN_BAND_ROWS = 16;
   static constexpr size_t MAX_BAND_BYTES = 24 * 1024;  // band working-set ceiling
+  static constexpr int requiredBandRows(int imageHeight, int maxBlockDstRows) {
+    return imageHeight < maxBlockDstRows ? imageHeight : maxBlockDstRows;
+  }
 
   // Open the cache file, write the header, and allocate a band buffer big enough
   // to hold the tallest single decode block (maxBlockDstRows output rows).
@@ -78,11 +81,11 @@ struct PixelCache {
     if (maxRowsByMem < 1) maxRowsByMem = 1;
     if ((size_t)wantRows > maxRowsByMem) wantRows = (int)maxRowsByMem;
 
-    // A single decode block must fit inside the band, otherwise streaming would
-    // drop rows. This only fails for pathological upscales that could not be
-    // cached at all; fall back to the no-cache path.
-    if (wantRows < maxBlockDstRows) {
-      LOG_ERR("IMG", "Cache band too small (%d < %d rows) for %dx%d", wantRows, maxBlockDstRows, w, h);
+    // A single decode block must fit inside the band, except when the complete
+    // image is shorter than that block. Otherwise streaming would drop rows.
+    const int requiredRows = requiredBandRows(h, maxBlockDstRows);
+    if (wantRows < requiredRows) {
+      LOG_ERR("IMG", "Cache band too small (%d < %d rows) for %dx%d", wantRows, requiredRows, w, h);
       return false;
     }
     bandRows = wantRows;
@@ -185,3 +188,6 @@ struct PixelCache {
     }
   }
 };
+
+static_assert(8 >= PixelCache::requiredBandRows(8, 12));
+static_assert(8 < PixelCache::requiredBandRows(100, 12));

--- a/src/activities/util/ImageViewerActivity.cpp
+++ b/src/activities/util/ImageViewerActivity.cpp
@@ -19,6 +19,13 @@ constexpr const char* TRANSPARENT_PREVIEW_PATH = "/.crosspoint/image_preview.tra
 constexpr const char* SLEEP_IMAGE_PATH = "/sleep.bmp";
 constexpr const char* SLEEP_IMAGE_PART_PATH = "/sleep.bmp.part";
 constexpr const char* SLEEP_IMAGE_BACKUP_PATH = "/sleep.bmp.bak";
+
+Rect sleepCoverActionRect(const GfxRenderer& renderer) {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  return Rect(metrics.contentSidePadding,
+              renderer.getScreenHeight() - metrics.contentSidePadding - metrics.menuRowHeight,
+              renderer.getScreenWidth() - metrics.contentSidePadding * 2, metrics.menuRowHeight);
+}
 }  // namespace
 
 ImageViewerActivity::ImageViewerActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string path)
@@ -131,6 +138,9 @@ void ImageViewerActivity::onEnter() {
 
       // Draw UI hints on the base layer
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+      if (mappedInput.hasTouch()) {
+        GUI.drawActionButton(renderer, sleepCoverActionRect(renderer), tr(STR_SET_SLEEP_COVER));
+      }
       // Single pass for non-grayscale images
 
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);
@@ -283,6 +293,15 @@ void ImageViewerActivity::loop() {
   if (swipe == MappedInputManager::SwipeDir::Right) {
     openSibling(-1);
     return;
+  }
+
+  if (mappedInput.hasTouch()) {
+    const Rect sleepCoverAction = sleepCoverActionRect(renderer);
+    if (mappedInput.wasTapInRect(sleepCoverAction.x, sleepCoverAction.y, sleepCoverAction.width,
+                                 sleepCoverAction.height)) {
+      showSleepCoverOptions();
+      return;
+    }
   }
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Fix the two image-workflow defects exposed by a Seeed Sticky crash report: a false cache-band rejection for an EPUB image shorter than one decoder block, and the missing discoverable sleep-cover action on touch devices.
* **What changes are included?**
  * Accept a cache band when it can hold `min(imageHeight, maxBlockDstRows)` rows, with compile-time regression checks for the reported `118x8` case.
  * Show the existing translated "set sleep cover" action in the image viewer on every touch device, using one shared rectangle for drawing and hit testing.
  * Preserve the existing Confirm-button flow and PNG normal/transparent choices.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This fixes a reproducible boundary error in CrossMux's shared EPUB image cache and restores access to an existing CrossMux sleep-cover capability. It does not add a new sleep-screen mode or touch the SDK/HAL.

## Additional Context

The report came from a Seeed Sticky running `1.5.7-sticky-rc+35db7a5`. Its last image errors were:

```text
[4361] [ERR] [IMG] Cache band too small (8 < 12 rows) for 118x8
[4361] [ERR] [JPG] Failed to start cache stream
[4361] [ERR] [IMG] Failed to decode image: /.crosspoint/epub_3278348869/img_4_0.jpg
```

An 8-row band can hold the complete 8-row image even though the JPEG decoder's theoretical output block is 12 rows high. This is a confirmed cache-boundary defect. The report has an empty panic reason and stack, so it does **not** prove that this error caused the eventual reboot. Uploading a transparent-cover image is incident context, not a confirmed trigger.

Transparent sleep-cover rendering and settings are already device-independent. Touch devices hid physical-button hints while the image viewer only opened the cover options through the Confirm action, leaving Sticky without a discoverable on-screen entry.

No public API or cache-format changes. No new heap allocation or device-specific branch. The reported `118x8` case uses the existing 270-byte band allocation; the 24 KB ceiling is unchanged.

### Verification

- `./bin/clang-format-fix --check`
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` — no defects
- `pio run -e default -e sticky -e x4pro -e papermono -e eego_a4 -e murphy_m4 -e waveshare_epaper_397` — all seven environments succeeded
- `cmake -S test -B build/test -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build/test`
- `ctest --test-dir build/test --output-on-failure -j` — 448/448 passed
- Targeted `PixelCache` host check for `118x8`, `maxBlockDstRows=12` — accepted an 8-row band and generated a 244-byte `.pxc`

The `./bin/ci-check` wrapper itself could not pass its initial submodule precondition because cloning the nested lucide icon submodule failed with a TLS early EOF. Its formatting, cppcheck, firmware-build, and host-test commands were run individually as listed above.

### Draft hardware checklist

- [ ] On Sticky, open a PNG and tap the visible sleep-cover action.
- [ ] Confirm PNG offers normal/transparent while BMP remains normal-only.
- [ ] Confirm transparent sleep preserves the previous frame and overlays the non-transparent pixels.
- [ ] Repeat sleep, long-press wake, image upload, transparent-cover setup, and EPUB reading.
- [ ] If the device still reboots, collect the serial watchdog/reset banner and panic backtrace as a separate diagnosis.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
