### PR TITLE
ci: pause daily nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,6 @@
 name: Firmware Release
 
 on:
-  schedule:
-    - cron: '0 23 * * *' # daily 07:00 Asia/Shanghai
   workflow_dispatch:
     inputs:
       notes_en:


### PR DESCRIPTION
## Summary

- remove the daily scheduled Nightly trigger
- preserve manual Nightly runs and SemVer tag-triggered Stable releases

## Verification

- YAML parse passed
- schedule and cron triggers are absent
- workflow_dispatch and tag triggers remain
- python3 -m unittest scripts.tests.test_nightly_release (27 tests passed)
- git diff --check passed

The schedule stops only after this PR is merged into the default branch.