### PR TITLE
refactor: normalize application include paths

### DIFF
--- a/src/activities/apps/2048/Game2048Activity.cpp
+++ b/src/activities/apps/2048/Game2048Activity.cpp
@@ -5,10 +5,10 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../../util/ConfirmationActivity.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "activities/util/ConfirmationActivity.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "Game2048Store.h"
 
 namespace {

--- a/src/activities/apps/2048/Game2048Activity.cpp
+++ b/src/activities/apps/2048/Game2048Activity.cpp
@@ -5,11 +5,11 @@
 
 #include <cstdio>
 
+#include "Game2048Store.h"
 #include "activities/apps/GameUi.h"
 #include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "Game2048Store.h"
 
 namespace {
 

--- a/src/activities/apps/2048/Game2048Activity.h
+++ b/src/activities/apps/2048/Game2048Activity.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
+#include "Game2048Board.h"
 #include "activities/Activity.h"
 #include "activities/apps/GameSaveDebouncer.h"
-#include "Game2048Board.h"
 
 // Classic 2048: swipe to slide and merge tiles. Single-Activity app (no menu) — entering
 // resumes any in-progress game; Confirm starts a fresh game in place. Auto-saves with a

--- a/src/activities/apps/2048/Game2048Activity.h
+++ b/src/activities/apps/2048/Game2048Activity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "Game2048Board.h"
 
 // Classic 2048: swipe to slide and merge tiles. Single-Activity app (no menu) — entering

--- a/src/activities/apps/AppsMenuActivity.cpp
+++ b/src/activities/apps/AppsMenuActivity.cpp
@@ -6,12 +6,12 @@
 #include <cstdint>
 #include <string>
 
-#include "components/UITheme.h"
-#include "components/UiAppHelpers.h"
-#include "components/icons/inx_apps.h"
 #include "CrossPointSettings.h"
 #include "InxItemLayout.h"
 #include "OpdsServerStore.h"
+#include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
+#include "components/icons/inx_apps.h"
 #include "fontIds.h"
 
 namespace fui = freeink::ui;

--- a/src/activities/apps/AppsMenuActivity.cpp
+++ b/src/activities/apps/AppsMenuActivity.cpp
@@ -6,9 +6,9 @@
 #include <cstdint>
 #include <string>
 
-#include "../../components/UITheme.h"
-#include "../../components/UiAppHelpers.h"
-#include "../../components/icons/inx_apps.h"
+#include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
+#include "components/icons/inx_apps.h"
 #include "CrossPointSettings.h"
 #include "InxItemLayout.h"
 #include "OpdsServerStore.h"

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -4,9 +4,9 @@
 #include <cstdint>
 #include <string>
 
-#include "activities/Activity.h"
 #include "AirPageConnection.h"
 #include "AirPageImageStore.h"
+#include "activities/Activity.h"
 #include "components/OptionPopup.h"
 #include "components/UiAppHost.h"
 #include "util/ButtonNavigator.h"

--- a/src/activities/apps/airpage/AirPageActivity.h
+++ b/src/activities/apps/airpage/AirPageActivity.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "AirPageConnection.h"
 #include "AirPageImageStore.h"
 #include "components/OptionPopup.h"

--- a/src/activities/apps/avatar/UglyAvatarActivity.h
+++ b/src/activities/apps/avatar/UglyAvatarActivity.h
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 
 class UglyAvatarActivity final : public Activity {
  public:

--- a/src/activities/apps/buddy/BuddyActivity.h
+++ b/src/activities/apps/buddy/BuddyActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "activities/Activity.h"
 #include "BuddyGenerator.h"
+#include "activities/Activity.h"
 
 class BuddyActivity final : public Activity {
  public:

--- a/src/activities/apps/buddy/BuddyActivity.h
+++ b/src/activities/apps/buddy/BuddyActivity.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "BuddyGenerator.h"
 
 class BuddyActivity final : public Activity {

--- a/src/activities/apps/calculator/CalculatorActivity.cpp
+++ b/src/activities/apps/calculator/CalculatorActivity.cpp
@@ -5,8 +5,8 @@
 #include <algorithm>
 #include <array>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 

--- a/src/activities/apps/calculator/CalculatorActivity.h
+++ b/src/activities/apps/calculator/CalculatorActivity.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "activities/Activity.h"
 #include "CalculatorState.h"
+#include "activities/Activity.h"
 
 class CalculatorActivity final : public Activity {
  public:

--- a/src/activities/apps/calculator/CalculatorActivity.h
+++ b/src/activities/apps/calculator/CalculatorActivity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "CalculatorState.h"
 
 class CalculatorActivity final : public Activity {

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -6,9 +6,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "ChineseChessMenuActivity.h"
 
 namespace {

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.cpp
@@ -6,10 +6,10 @@
 
 #include <cstdio>
 
+#include "ChineseChessMenuActivity.h"
 #include "activities/apps/GameUi.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "ChineseChessMenuActivity.h"
 
 namespace {
 

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "ChineseChessAI.h"
 #include "ChineseChessBoard.h"
 #include "ChineseChessStore.h"

--- a/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessGameActivity.h
@@ -2,11 +2,11 @@
 
 #include <cstdint>
 
-#include "activities/Activity.h"
-#include "activities/apps/GameSaveDebouncer.h"
 #include "ChineseChessAI.h"
 #include "ChineseChessBoard.h"
 #include "ChineseChessStore.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "components/OptionPopup.h"
 
 class ChineseChessGameActivity final : public Activity {

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
@@ -5,9 +5,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "ChineseChessGameActivity.h"
 
 ChineseChessMenuActivity::ChineseChessMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.cpp
@@ -5,10 +5,10 @@
 
 #include <cstdio>
 
+#include "ChineseChessGameActivity.h"
 #include "activities/apps/GameUi.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "ChineseChessGameActivity.h"
 
 ChineseChessMenuActivity::ChineseChessMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
     : Activity("ChineseChessMenu", renderer, mappedInput) {}

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
 #include "ChineseChessStore.h"
+#include "activities/Activity.h"
 #include "components/OptionPopup.h"
+#include "util/ButtonNavigator.h"
 
 class ChineseChessMenuActivity final : public Activity {
  public:

--- a/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
+++ b/src/activities/apps/chinese-chess/ChineseChessMenuActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "../../../util/ButtonNavigator.h"
-#include "../../Activity.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 #include "ChineseChessStore.h"
 #include "components/OptionPopup.h"
 

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -6,9 +6,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "GomokuAI.h"
 #include "GomokuMenuActivity.h"
 

--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -6,11 +6,11 @@
 
 #include <cstdio>
 
+#include "GomokuAI.h"
+#include "GomokuMenuActivity.h"
 #include "activities/apps/GameUi.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "GomokuAI.h"
-#include "GomokuMenuActivity.h"
 
 namespace {
 

--- a/src/activities/apps/gomoku/GomokuGameActivity.h
+++ b/src/activities/apps/gomoku/GomokuGameActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "GomokuBoard.h"
 #include "GomokuStore.h"
 #include "components/OptionPopup.h"

--- a/src/activities/apps/gomoku/GomokuGameActivity.h
+++ b/src/activities/apps/gomoku/GomokuGameActivity.h
@@ -2,10 +2,10 @@
 
 #include <cstdint>
 
-#include "activities/Activity.h"
-#include "activities/apps/GameSaveDebouncer.h"
 #include "GomokuBoard.h"
 #include "GomokuStore.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "components/OptionPopup.h"
 
 class GomokuGameActivity final : public Activity {

--- a/src/activities/apps/gomoku/GomokuMenuActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.cpp
@@ -5,10 +5,10 @@
 
 #include <cstdio>
 
+#include "GomokuGameActivity.h"
 #include "activities/apps/GameUi.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "GomokuGameActivity.h"
 
 GomokuMenuActivity::GomokuMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
     : Activity("GomokuMenu", renderer, mappedInput) {}

--- a/src/activities/apps/gomoku/GomokuMenuActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.cpp
@@ -5,9 +5,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "GomokuGameActivity.h"
 
 GomokuMenuActivity::GomokuMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)

--- a/src/activities/apps/gomoku/GomokuMenuActivity.h
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.h
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
 #include "GomokuStore.h"
+#include "activities/Activity.h"
 #include "components/OptionPopup.h"
+#include "util/ButtonNavigator.h"
 
 class GomokuMenuActivity final : public Activity {
  public:

--- a/src/activities/apps/gomoku/GomokuMenuActivity.h
+++ b/src/activities/apps/gomoku/GomokuMenuActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "../../../util/ButtonNavigator.h"
-#include "../../Activity.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 #include "GomokuStore.h"
 #include "components/OptionPopup.h"
 

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -7,9 +7,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "MinesweeperGenerator.h"
 #include "MinesweeperMenuActivity.h"
 #include "MinesweeperStore.h"

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -7,12 +7,12 @@
 
 #include <cstdio>
 
-#include "activities/apps/GameUi.h"
-#include "components/UITheme.h"
-#include "fontIds.h"
 #include "MinesweeperGenerator.h"
 #include "MinesweeperMenuActivity.h"
 #include "MinesweeperStore.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
+#include "MinesweeperBoard.h"
 #include "activities/Activity.h"
 #include "activities/apps/GameSaveDebouncer.h"
-#include "MinesweeperBoard.h"
 #include "components/OptionPopup.h"
 
 class MinesweeperGameActivity final : public Activity {

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "MinesweeperBoard.h"
 #include "components/OptionPopup.h"
 

--- a/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
@@ -5,7 +5,7 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
+#include "components/UITheme.h"
 #include "MinesweeperGameActivity.h"
 
 namespace {

--- a/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperMenuActivity.cpp
@@ -5,8 +5,8 @@
 
 #include <cstdio>
 
-#include "components/UITheme.h"
 #include "MinesweeperGameActivity.h"
+#include "components/UITheme.h"
 
 namespace {
 

--- a/src/activities/apps/minesweeper/MinesweeperMenuActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperMenuActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "../../../util/ButtonNavigator.h"
-#include "../../Activity.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 #include "MinesweeperBoard.h"
 #include "MinesweeperStore.h"
 

--- a/src/activities/apps/minesweeper/MinesweeperMenuActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperMenuActivity.h
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
 #include "MinesweeperBoard.h"
 #include "MinesweeperStore.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 
 class MinesweeperMenuActivity final : public Activity {
  public:

--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.cpp
@@ -10,12 +10,12 @@
 #include <cstdio>
 #include <string>
 
-#include "../../../NetworkStartup.h"
-#include "../../../WifiCredentialStore.h"
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../../network/WifiSelectionActivity.h"
-#include "../airpage/AirPageDeviceId.h"
+#include "NetworkStartup.h"
+#include "WifiCredentialStore.h"
+#include "activities/apps/airpage/AirPageDeviceId.h"
+#include "activities/network/WifiSelectionActivity.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 

--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.h
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.h
@@ -5,7 +5,7 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "PixelSwitchState.h"
 
 class PixelSwitchActivity final : public Activity {

--- a/src/activities/apps/pixel-switch/PixelSwitchActivity.h
+++ b/src/activities/apps/pixel-switch/PixelSwitchActivity.h
@@ -5,8 +5,8 @@
 
 #include <cstdint>
 
-#include "activities/Activity.h"
 #include "PixelSwitchState.h"
+#include "activities/Activity.h"
 
 class PixelSwitchActivity final : public Activity {
  public:

--- a/src/activities/apps/reading-stats/AchievementsActivity.h
+++ b/src/activities/apps/reading-stats/AchievementsActivity.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "AchievementsStore.h"
 #include "util/ButtonNavigator.h"
 

--- a/src/activities/apps/reading-stats/AchievementsActivity.h
+++ b/src/activities/apps/reading-stats/AchievementsActivity.h
@@ -2,8 +2,8 @@
 
 #include <vector>
 
-#include "activities/Activity.h"
 #include "AchievementsStore.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 class AchievementsActivity final : public Activity {

--- a/src/activities/apps/reading-stats/BookReadingAdjustmentActivity.h
+++ b/src/activities/apps/reading-stats/BookReadingAdjustmentActivity.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 class BookReadingAdjustmentActivity final : public Activity {

--- a/src/activities/apps/reading-stats/ReadingDateSelectionActivity.h
+++ b/src/activities/apps/reading-stats/ReadingDateSelectionActivity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 class ReadingDateSelectionActivity final : public Activity {

--- a/src/activities/apps/reading-stats/ReadingHeatmapActivity.h
+++ b/src/activities/apps/reading-stats/ReadingHeatmapActivity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 class ReadingHeatmapActivity final : public Activity {

--- a/src/activities/apps/reading-stats/ReadingProfileActivity.h
+++ b/src/activities/apps/reading-stats/ReadingProfileActivity.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 
 struct ReadingProfileAxisSummary {
   StrId labelId = StrId::STR_NONE_OPT;

--- a/src/activities/apps/reading-stats/ReadingStatsActivity.h
+++ b/src/activities/apps/reading-stats/ReadingStatsActivity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 struct ReadingBookStats;

--- a/src/activities/apps/reading-stats/ReadingStatsDetailActivity.h
+++ b/src/activities/apps/reading-stats/ReadingStatsDetailActivity.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 struct ReadingStatsDetailContext {

--- a/src/activities/apps/reading-stats/ReadingStatsExtendedActivity.h
+++ b/src/activities/apps/reading-stats/ReadingStatsExtendedActivity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
 class ReadingStatsExtendedActivity final : public Activity {

--- a/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include <string>
 
-#include "../../../CrossPointSettings.h"
-#include "../../../components/UITheme.h"
+#include "CrossPointSettings.h"
+#include "components/UITheme.h"
 #include "AchievementsActivity.h"
 #include "AppMetricCard.h"
 #include "ReadingHeatmapActivity.h"

--- a/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
+++ b/src/activities/apps/reading-stats/ReadingStatsMenuActivity.cpp
@@ -5,13 +5,13 @@
 #include <memory>
 #include <string>
 
-#include "CrossPointSettings.h"
-#include "components/UITheme.h"
 #include "AchievementsActivity.h"
 #include "AppMetricCard.h"
+#include "CrossPointSettings.h"
 #include "ReadingHeatmapActivity.h"
 #include "ReadingProfileActivity.h"
 #include "ReadingStatsActivity.h"
+#include "components/UITheme.h"
 
 namespace {
 

--- a/src/activities/apps/reading-stats/ReadingStatsMenuActivity.h
+++ b/src/activities/apps/reading-stats/ReadingStatsMenuActivity.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../../util/ButtonNavigator.h"
-#include "../../Activity.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 
 // Sub-menu hub for the Reading Analytics suite. Reached from the Apps menu via
 // ActivityManager::goToReadingStatsMenu(); lists the suite's screens and pushes

--- a/src/activities/apps/sokoban/SokobanGameActivity.cpp
+++ b/src/activities/apps/sokoban/SokobanGameActivity.cpp
@@ -6,9 +6,9 @@
 #include <algorithm>
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 constexpr int kMaxCellSize = 48;

--- a/src/activities/apps/sokoban/SokobanGameActivity.h
+++ b/src/activities/apps/sokoban/SokobanGameActivity.h
@@ -2,10 +2,10 @@
 
 #include <cstdint>
 
-#include "activities/Activity.h"
-#include "activities/apps/GameSaveDebouncer.h"
 #include "SokobanBoard.h"
 #include "SokobanStore.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "levels_data.h"
 
 class SokobanGameActivity final : public Activity {

--- a/src/activities/apps/sokoban/SokobanGameActivity.h
+++ b/src/activities/apps/sokoban/SokobanGameActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "SokobanBoard.h"
 #include "SokobanStore.h"
 #include "levels_data.h"

--- a/src/activities/apps/standby/ChineseCalendarFace.cpp
+++ b/src/activities/apps/standby/ChineseCalendarFace.cpp
@@ -10,10 +10,10 @@
 #include <cstdio>
 #include <cstring>
 
-#include "util/TimeUtils.h"
 #include "ChineseAlmanac.h"
 #include "I18nKeys.h"
 #include "fontIds.h"
+#include "util/TimeUtils.h"
 
 // CN font-coverage rule (drives every fontId choice in this file):
 //

--- a/src/activities/apps/standby/ChineseCalendarFace.cpp
+++ b/src/activities/apps/standby/ChineseCalendarFace.cpp
@@ -10,7 +10,7 @@
 #include <cstdio>
 #include <cstring>
 
-#include "../../../util/TimeUtils.h"
+#include "util/TimeUtils.h"
 #include "ChineseAlmanac.h"
 #include "I18nKeys.h"
 #include "fontIds.h"

--- a/src/activities/apps/standby/StandbyActivity.cpp
+++ b/src/activities/apps/standby/StandbyActivity.cpp
@@ -18,10 +18,10 @@
 #include <algorithm>
 #include <string>
 
-#include "../../../util/PaginationDots.h"
-#include "../../../util/TimeUtils.h"
-#include "../../ActivityResult.h"
-#include "../../network/WifiSelectionActivity.h"
+#include "activities/ActivityResult.h"
+#include "activities/network/WifiSelectionActivity.h"
+#include "util/PaginationDots.h"
+#include "util/TimeUtils.h"
 #include "CrossPointSettings.h"
 #include "NetworkStartup.h"
 #ifdef ENABLE_CHINESE_VERSION

--- a/src/activities/apps/standby/StandbyActivity.cpp
+++ b/src/activities/apps/standby/StandbyActivity.cpp
@@ -18,12 +18,12 @@
 #include <algorithm>
 #include <string>
 
+#include "CrossPointSettings.h"
+#include "NetworkStartup.h"
 #include "activities/ActivityResult.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "util/PaginationDots.h"
 #include "util/TimeUtils.h"
-#include "CrossPointSettings.h"
-#include "NetworkStartup.h"
 #ifdef ENABLE_CHINESE_VERSION
 #include "ChineseCalendarFace.h"
 #endif

--- a/src/activities/apps/standby/StandbyActivity.h
+++ b/src/activities/apps/standby/StandbyActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <memory>
 
-#include "activities/Activity.h"
 #include "StandbyFace.h"
+#include "activities/Activity.h"
 
 struct ActivityResult;
 

--- a/src/activities/apps/standby/StandbyActivity.h
+++ b/src/activities/apps/standby/StandbyActivity.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <memory>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 #include "StandbyFace.h"
 
 struct ActivityResult;

--- a/src/activities/apps/standby/StandbyTime.cpp
+++ b/src/activities/apps/standby/StandbyTime.cpp
@@ -2,7 +2,7 @@
 
 #include <Arduino.h>
 
-#include "../../../util/TimeUtils.h"
+#include "util/TimeUtils.h"
 
 namespace standby_time {
 namespace {

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -6,12 +6,12 @@
 
 #include <cstdio>
 
-#include "activities/apps/GameUi.h"
-#include "components/UITheme.h"
-#include "fontIds.h"
 #include "SudokuGenerator.h"
 #include "SudokuMenuActivity.h"
 #include "SudokuStore.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 

--- a/src/activities/apps/sudoku/SudokuGameActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuGameActivity.cpp
@@ -6,9 +6,9 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
-#include "../GameUi.h"
+#include "activities/apps/GameUi.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "SudokuGenerator.h"
 #include "SudokuMenuActivity.h"
 #include "SudokuStore.h"

--- a/src/activities/apps/sudoku/SudokuGameActivity.h
+++ b/src/activities/apps/sudoku/SudokuGameActivity.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
+#include "SudokuBoard.h"
 #include "activities/Activity.h"
 #include "activities/apps/GameSaveDebouncer.h"
-#include "SudokuBoard.h"
 #include "components/OptionPopup.h"
 
 class SudokuGameActivity final : public Activity {

--- a/src/activities/apps/sudoku/SudokuGameActivity.h
+++ b/src/activities/apps/sudoku/SudokuGameActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
-#include "../GameSaveDebouncer.h"
+#include "activities/Activity.h"
+#include "activities/apps/GameSaveDebouncer.h"
 #include "SudokuBoard.h"
 #include "components/OptionPopup.h"
 

--- a/src/activities/apps/sudoku/SudokuMenuActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuMenuActivity.cpp
@@ -5,9 +5,9 @@
 
 #include <cstdio>
 
+#include "SudokuGameActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "SudokuGameActivity.h"
 
 SudokuMenuActivity::SudokuMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
     : Activity("SudokuMenu", renderer, mappedInput) {}

--- a/src/activities/apps/sudoku/SudokuMenuActivity.cpp
+++ b/src/activities/apps/sudoku/SudokuMenuActivity.cpp
@@ -5,8 +5,8 @@
 
 #include <cstdio>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "SudokuGameActivity.h"
 
 SudokuMenuActivity::SudokuMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)

--- a/src/activities/apps/sudoku/SudokuMenuActivity.h
+++ b/src/activities/apps/sudoku/SudokuMenuActivity.h
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
 #include "SudokuBoard.h"
 #include "SudokuStore.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 
 class SudokuMenuActivity final : public Activity {
  public:

--- a/src/activities/apps/sudoku/SudokuMenuActivity.h
+++ b/src/activities/apps/sudoku/SudokuMenuActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "../../../util/ButtonNavigator.h"
-#include "../../Activity.h"
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
 #include "SudokuBoard.h"
 #include "SudokuStore.h"
 

--- a/src/activities/apps/weread/webapi/WeReadActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadActivity.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "../WeReadBackend.h"
+#include "activities/apps/weread/WeReadBackend.h"
 #include "activities/Activity.h"
 #include "components/OptionPopup.h"
 #include "components/themes/BaseTheme.h"

--- a/src/activities/apps/weread/webapi/WeReadActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadActivity.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "activities/apps/weread/WeReadBackend.h"
 #include "activities/Activity.h"
+#include "activities/apps/weread/WeReadBackend.h"
 #include "components/OptionPopup.h"
 #include "components/themes/BaseTheme.h"
 #include "util/ButtonNavigator.h"

--- a/src/activities/apps/weread/webapi/WeReadBrowseActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadBrowseActivity.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "activities/apps/weread/WeReadBackend.h"
 #include "activities/Activity.h"
+#include "activities/apps/weread/WeReadBackend.h"
 #include "util/ButtonNavigator.h"
 
 struct Rect;

--- a/src/activities/apps/weread/webapi/WeReadBrowseActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadBrowseActivity.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#include "../WeReadBackend.h"
+#include "activities/apps/weread/WeReadBackend.h"
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <string>
 
-#include "../WeReadBackend.h"
-#include "../WeReadProgressContext.h"
+#include "activities/apps/weread/WeReadBackend.h"
+#include "activities/apps/weread/WeReadProgressContext.h"
 #include "activities/Activity.h"
 
 class Epub;

--- a/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
+++ b/src/activities/apps/weread/webapi/WeReadProgressSyncActivity.h
@@ -3,9 +3,9 @@
 #include <cstdint>
 #include <string>
 
+#include "activities/Activity.h"
 #include "activities/apps/weread/WeReadBackend.h"
 #include "activities/apps/weread/WeReadProgressContext.h"
-#include "activities/Activity.h"
 
 class Epub;
 struct CrossPointPosition;

--- a/src/activities/apps/woodfish/WoodfishActivity.cpp
+++ b/src/activities/apps/woodfish/WoodfishActivity.cpp
@@ -10,10 +10,10 @@
 #include <cstdio>
 #include <cstring>
 
-#include "components/UITheme.h"
-#include "fontIds.h"
 #include "WoodfishAssets.h"
 #include "WoodfishStore.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 
 namespace {
 

--- a/src/activities/apps/woodfish/WoodfishActivity.cpp
+++ b/src/activities/apps/woodfish/WoodfishActivity.cpp
@@ -10,8 +10,8 @@
 #include <cstdio>
 #include <cstring>
 
-#include "../../../components/UITheme.h"
-#include "../../../fontIds.h"
+#include "components/UITheme.h"
+#include "fontIds.h"
 #include "WoodfishAssets.h"
 #include "WoodfishStore.h"
 

--- a/src/activities/apps/woodfish/WoodfishActivity.h
+++ b/src/activities/apps/woodfish/WoodfishActivity.h
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 
-#include "../../Activity.h"
+#include "activities/Activity.h"
 
 struct Rect;
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -19,7 +19,6 @@
 #include <iterator>
 #include <limits>
 
-#include "util/BookmarkFile.h"
 #include "AchievementsStore.h"
 #include "BookmarkEntry.h"
 #include "CrossPointSettings.h"
@@ -44,6 +43,7 @@
 #include "SdCardFontSystem.h"
 #include "activities/settings/TextSettingsActivity.h"
 #include "util/BookCacheUtils.h"
+#include "util/BookmarkFile.h"
 #include "util/ReadingBackground.h"
 #include "util/ReadingGuideLine.h"
 #ifdef ENABLE_CHINESE_VERSION

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -19,7 +19,7 @@
 #include <iterator>
 #include <limits>
 
-#include "../../util/BookmarkFile.h"
+#include "util/BookmarkFile.h"
 #include "AchievementsStore.h"
 #include "BookmarkEntry.h"
 #include "CrossPointSettings.h"

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include "../../util/BookmarkFile.h"
+#include "util/BookmarkFile.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
 #include "components/UiAppHelpers.h"

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -5,11 +5,11 @@
 
 #include <algorithm>
 
-#include "util/BookmarkFile.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
 #include "components/UiAppHelpers.h"
 #include "fontIds.h"
+#include "util/BookmarkFile.h"
 
 namespace fui = freeink::ui;
 

--- a/src/activities/reader/EpubReaderBookmarksActivity.h
+++ b/src/activities/reader/EpubReaderBookmarksActivity.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "../../BookmarkEntry.h"
+#include "BookmarkEntry.h"
 #include "activities/UiListActivity.h"
 #include "components/OptionPopup.h"
 

--- a/src/util/BookmarkFile.h
+++ b/src/util/BookmarkFile.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include "../BookmarkEntry.h"
+#include "BookmarkEntry.h"
 
 // Per-book bookmark persistence. Takes the book's path; bookmark-file path
 // derivation (BookmarkUtil) and directory creation are hidden inside.

--- a/test/time_utils/CMakeLists.txt
+++ b/test/time_utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(TimeUtilsTest
 
 target_include_directories(TimeUtilsTest PRIVATE
   stubs
+  ${REPO_ROOT}/src
   ${REPO_ROOT}/src/util
   ${REPO_ROOT}/src/activities/apps/standby
 )


### PR DESCRIPTION
## Summary
- replace 94 parent-directory includes under `src` with project-root include paths
- add the `src` include root to `TimeUtilsTest` for the standalone `StandbyTime` build
- leave project libraries and vendored sources unchanged

## Verification
- `pio run -e default`
- `pio run -e simulator`
- `pio run -t unit-tests` (464/464 passed)
- `git diff --check`