### PR TITLE
feat: enable USB Drive on additional S3 boards

### DIFF
--- a/docs/engineering/murphy-m4.md
+++ b/docs/engineering/murphy-m4.md
@@ -100,6 +100,13 @@ and app at `0x10000` without overwriting NVS.
   share I²C1 without conflicts or bus/device recreation. Also verify concurrent
   4-bit SDMMC/display use, ADC9 battery, active-low GPIO43 charging, and RX8010
   power-loss retention/VLF handling.
+- Confirm USB Serial/JTAG logging and flashing still work after a normal boot. Open File Transfer > USB Drive and
+  verify a host can mount the SD card, copy, rename, delete, and read a large file. Safely eject or disconnect while
+  idle, then confirm the device reboots Home, remounts the SD card, and opens a transferred EPUB. Repeat three times.
+- Enter USB Drive without a connected host, cancel, and confirm the device reboots Home with the SD card mounted.
+  Also verify the five-minute host timeout. Record `ESP.getFreeHeap()`, `ESP.getMinFreeHeap()`, and
+  `ESP.getMaxAllocHeap()` before entry and after reboot; use external UART to record the same values while MSC is
+  active when available.
 - Measure GPIO47/48 at about 25 kHz / 10-bit and verify the gamma curve at
   0/1/5/50/100%, both color-temperature endpoints, off, and wake restoration.
 - Cycle deep sleep and confirm GPIO10/45 rails turn off, frontlight is off,

--- a/docs/engineering/waveshare-epaper-397.md
+++ b/docs/engineering/waveshare-epaper-397.md
@@ -96,6 +96,12 @@ AXP2101 shutdown path then removes system power.
 - Set the RTC, reboot and fully power-cycle, then confirm restored time.
 - Check battery percentage and charging; unplug USB, run on battery, shut down, then hold the side key until the first
   screen is visible before releasing it. Repeat three times and confirm the boot gesture never triggers shutdown.
+- Confirm USB Serial/JTAG logging and flashing still work after a normal boot. Open File Transfer > USB Drive and
+  verify a host can mount the SD card, copy, rename, delete, and read a large file. Safely eject or disconnect while
+  idle, then confirm the device reboots Home, remounts the SD card, and opens a transferred EPUB. Repeat three times.
+- Enter USB Drive without a connected host, cancel, and confirm the device reboots Home with the SD card mounted.
+  Record `ESP.getFreeHeap()`, `ESP.getMinFreeHeap()`, and `ESP.getMaxAllocHeap()` before entry and after reboot; use
+  external UART to record the same values while MSC is active when available.
 
 Automated builds and serial logs do not substitute for the visual, button, or
 battery checks above. Record incomplete checks as pending rather than accepted.

--- a/platformio.ini
+++ b/platformio.ini
@@ -346,7 +346,7 @@ build_flags =
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossMux_X4_Pro\"
+  -DUSB_PRODUCT=\"CrossMux-X4Pro\"
   -DUSB_MANUFACTURER=\"CrossMux\"
   ; X4 Pro SD is native SDMMC (1-bit), mounted through SdFat's block-device API.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
@@ -400,7 +400,7 @@ build_flags =
   -DFREEINK_DEVICE_X4CLASSIC=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossMux_X4_Classic\"
+  -DUSB_PRODUCT=\"CrossMux-X4Classic\"
   -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
@@ -480,7 +480,7 @@ build_flags =
   -DFREEINK_DEVICE_MURPHY_M4=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossMux_Murphy_M4\"
+  -DUSB_PRODUCT=\"CrossMux-Murphy-M4\"
   -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
@@ -528,7 +528,7 @@ build_flags =
   -DFREEINK_DEVICE_WAVESHARE_EPAPER_397=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossMux_Waveshare_ePaper_3_97\"
+  -DUSB_PRODUCT=\"CrossMux-Waveshare-ePaper397\"
   -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
@@ -564,7 +564,7 @@ build_flags =
   -DFREEINK_CAP_USB_MSC=1
   ; The SSD1677 grayscale target planes are batched in PSRAM.
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossMux_Paper_Mono\"
+  -DUSB_PRODUCT=\"CrossMux-PaperMono\"
   -DUSB_MANUFACTURER=\"CrossMux\"
   ; Native 1-bit SDMMC is mounted through SdFat's block-device interface.
   -DUSE_BLOCK_DEVICE_INTERFACE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -478,7 +478,10 @@ board_build.arduino.memory_type = dio_opi
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_MURPHY_M4=1
+  -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
+  -DUSB_PRODUCT=\"CrossMux_Murphy_M4\"
+  -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:murphy_m4]
@@ -517,10 +520,16 @@ lib_deps =
 extends = sound_feedback_hardware
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
+; Keep this profile on the prebuilt TinyUSB-enabled variant so USB Drive can
+; switch the shared S3 PHY from Serial/JTAG to MSC and back.
+board_build.arduino.memory_type = dio_opi
 build_flags =
   ${sound_feedback_hardware.build_flags}
   -DFREEINK_DEVICE_WAVESHARE_EPAPER_397=1
+  -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
+  -DUSB_PRODUCT=\"CrossMux_Waveshare_ePaper_3_97\"
+  -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:waveshare_epaper_397]

--- a/platformio.ini
+++ b/platformio.ini
@@ -346,8 +346,8 @@ build_flags =
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossPoint_X4_Pro\"
-  -DUSB_MANUFACTURER=\"CrossPoint\"
+  -DUSB_PRODUCT=\"CrossMux_X4_Pro\"
+  -DUSB_MANUFACTURER=\"CrossMux\"
   ; X4 Pro SD is native SDMMC (1-bit), mounted through SdFat's block-device API.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
@@ -400,8 +400,8 @@ build_flags =
   -DFREEINK_DEVICE_X4CLASSIC=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossPoint_X4_Classic\"
-  -DUSB_MANUFACTURER=\"CrossPoint\"
+  -DUSB_PRODUCT=\"CrossMux_X4_Classic\"
+  -DUSB_MANUFACTURER=\"CrossMux\"
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:x4c]
@@ -564,8 +564,8 @@ build_flags =
   -DFREEINK_CAP_USB_MSC=1
   ; The SSD1677 grayscale target planes are batched in PSRAM.
   -DBOARD_HAS_PSRAM
-  -DUSB_PRODUCT=\"CrossPoint_Paper_Mono\"
-  -DUSB_MANUFACTURER=\"CrossPoint\"
+  -DUSB_PRODUCT=\"CrossMux_Paper_Mono\"
+  -DUSB_MANUFACTURER=\"CrossMux\"
   ; Native 1-bit SDMMC is mounted through SdFat's block-device interface.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 

--- a/src/activities/network/UsbDriveActivity.cpp
+++ b/src/activities/network/UsbDriveActivity.cpp
@@ -140,11 +140,11 @@ void UsbDriveActivity::buildDriveScreen(UiScreen& screen) const {
       static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), static_cast<int16_t>(metrics.contentSidePadding),
       static_cast<int16_t>(metrics.buttonHintsHeight), static_cast<int16_t>(metrics.contentSidePadding)});
 
-  auto messageStyle = screen.theme().smallText;
+  auto messageStyle = screen.theme().titleText;
   messageStyle.align = fui::TextAlign::Center;
   messageStyle.bold = true;
   messageStyle.maxLines = 2;
-  auto detailStyle = screen.theme().smallText;
+  auto detailStyle = screen.theme().bodyText;
   detailStyle.align = fui::TextAlign::Center;
   detailStyle.maxLines = 3;
 


### PR DESCRIPTION
## Summary

- enable the existing SDMMC-backed USB Drive flow for Murphy M4 and Waveshare ePaper 3.97
- rename USB MSC product/manufacturer descriptors from CrossPoint to CrossMux across all supported MSC boards
- enlarge the USB Drive status and detail text using existing theme styles
- document physical USB/SD and heap acceptance checks for the newly enabled boards

## Validation

- pio run -e x4pro -e x4c -e murphy_m4 -e waveshare_epaper_397 -e papermono
- confirmed all five ELF files contain their corresponding CrossMux device product string and no CrossPoint USB product string
- confirmed Murphy M4 and Waveshare ELFs link UsbMassStorage, UsbDriveActivity, and USB OTG-to-Serial/JTAG handoff implementations
- git diff --check origin/main...HEAD

## Hardware validation pending

- normal USB Serial/JTAG logging and flashing
- host mount, write, rename, delete, and large-file reads
- status/detail text layout across USB Drive states and translations
- safe eject/disconnect, reboot, SD remount, repeated cycles, and runtime heap metrics