### PR TITLE
fix(reader): bound memory use on devices without PSRAM

### DIFF
--- a/docs/engineering/sd-card-font-cache.md
+++ b/docs/engineering/sd-card-font-cache.md
@@ -18,6 +18,18 @@ released with the font, is never used by UI fallback sizes, and does not change
 the persistent cache format. Allocation failure leaves the existing Flash/SD
 path unchanged.
 
+On no-PSRAM targets, optional advance-table and page prewarm allocations must
+leave 16 KiB free heap and 8 KiB contiguous headroom. Their budgets include
+simultaneously live collection, mapping, staging and replacement buffers; old
+caches are already charged against the live heap. A rejected prewarm keeps
+on-demand font reads available and is not reported as missing glyph coverage.
+Page cache growth acquires all replacement buffers before discarding valid data;
+temporary mappings remain RAII-owned on every exit. The no-PSRAM preparation
+path does not run the PSRAM path's later capacity-growth checks. Its budget
+pre-read uses one stack glyph instead of another heap array of glyph metadata.
+Between chapter parsing batches, the reader releases rebuildable font caches
+when free heap is below 48 KiB or the largest block is below 16 KiB.
+
 The canonical byte layout is documented in
 [file-formats.md](../file-formats.md#sd-card-font-cache).
 

--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -100,6 +100,95 @@ pio run -t upload && pio device monitor
    - Add `vTaskDelay(1)` in tight loops
    - Check for blocking I/O operations
 
+### EPUB memory fallback on devices without PSRAM
+
+Styled chapter parsing stops below 48 KiB free heap or 16 KiB largest block.
+Allocation failures also stop parsing, including table and trailing-page layout.
+The reader discards the failed build and retries once with embedded CSS disabled
+for that reading session, retaining the selected font and content offset. XML
+and I/O errors do not trigger this retry. A failed basic build shows the existing
+index-failed popup. No failed build may become a complete or partial cache.
+
+`EpubReaderActivity::handleBuildFailure()` owns the retry decision, reader
+resource cleanup and failure latch for foreground and background builds. Callers
+pass `Section::BuildError` explicitly, including `OutOfMemory` when the Section
+object itself could not be allocated. The
+error popup only draws. `Section::releaseBuildResources()` closes and removes
+uncommitted resources without deciding whether an existing cache is valid:
+initialization failures preserve it, while `abandonBuild()` invalidates it after
+a parse failure. Cleanup leaves `BuildError` available to the reader.
+
+Before starting or continuing a chapter, low-heap no-PSRAM builds reclaim
+rebuildable font caches. Optional font prewarm must leave 16 KiB free heap and
+8 KiB contiguous headroom; a skipped cache uses on-demand reads. Basic layout
+keeps the 320-token soft-flush threshold instead of reverting to 750 tokens.
+
+Build and run the `ChapterHtmlSlimParserTest`, `SdCardFontMemoryTest`, `PageLinkTest`,
+`footnote_list_test`, and `CssParserTest` host targets for fault injection,
+text/offset preservation, and cache capability checks. These include each mini-cache
+replacement allocation failing, initialization failures preserving an existing
+complete/partial cache, and a pre-refactor mixed-text cache/LUT digest. The digest
+uses the host page-serialization stub; it does not establish pixel equivalence.
+`ReaderBuildFailureTest` compiles the actual failure-handling method with
+lightweight collaborators for no-PSRAM and PSRAM policies. It covers allocation
+failure before a Section exists, one CSS retry, target preservation and repeated
+failures; it is not a full Activity or device-lifecycle integration test.
+Build firmware with
+`pio run -e default -e simulator_x3 -e murphy_m4`.
+
+Hardware acceptance still requires **both X3 and X4**: open the reported EPUB
+with a cold section cache using LXGW WenKai size 18, turn across chapters, and
+reopen it. Check text against the source for missing or reordered words/lines.
+Capture `SCT` cache-reclaim, `SDCF` prewarm-budget, `EHP` failure-stage and
+`ERS` fallback/ready/error logs, including
+`free/min/maxAlloc`. Under additional pressure, basic styling or an index error
+is acceptable; a restart or silently incomplete text is not. Exit and reopen to
+confirm the next session attempts the user's embedded-style setting again.
+Compilation and simulator checks do not establish hardware acceptance.
+
+### September 6, 2026: reader memory hardening checkpoint
+
+This checkpoint is **not full hardware acceptance**. The preceding X4 candidate
+application had SHA256
+`7b030e735aa636b96360ce5c7b34d0152526f00edbde601496a9a8800c4b23fa`.
+Application readback matched that candidate and the then-current build byte for
+byte; the indexing failure was not an older firmware image.
+
+With the reported Jobs biography, LXGW WenKai size 18 and Flash font reads:
+
+| Observation | Result |
+| --- | --- |
+| Ordinary reopen at spine 41, saved page 2 | CSS retry occurred; basic layout failed after page 6 |
+| Failing line-break workspace | 334 tokens, 2,672 bytes requested; maxAlloc 2,036 bytes |
+| Free heap after CSS-retry cleanup in failing session | 36,756 bytes |
+| Same candidate after a commanded reset | Spine 41 completed all 11 pages; restored offset 390/page 2 and continued into spine 42 |
+| Free heap after CSS-retry cleanup following reset | 55,808 bytes |
+
+The 19,052-byte difference identifies a session-dependent memory baseline, not
+its owner. Standby clock synchronization/network lifetime is a hypothesis for
+follow-up, not a confirmed leak or a fix included in this checkpoint. A reset
+that permits reading does not resolve the ordinary-reopen failure.
+
+The phase-closing candidate application has SHA256
+`e64b85aa5c8b0f297526a75cdcf66c143211ad7a753ee9ba0bf0b0d9b9cd3da3`
+and is 5,905,008 bytes. Its production source is recorded in commit `ef006bf0`;
+use the binary hash to identify it, since the build began before that commit.
+All 63 targeted host checks, clang-format checks, and the `default`,
+`simulator_x3`, and `murphy_m4` builds passed. The hardware builds reported an
+existing WebSockets dependency warning about deprecated `NetworkClient::flush()`.
+X4 application flashing and hash verification succeeded; a separate capture
+started for this candidate. Reading/visual acceptance remains incomplete and
+must not inherit the preceding candidate's results.
+
+Keep X3 acceptance, SD-direct font mode, and physical text completeness separate.
+For subsequent candidates, record the new application hash and repeat cold-cache
+opening, spine 5 and 41, cross-chapter turns, TOC navigation, exit/reopen, and
+standby/clock-sync followed by reading. An index error during ordinary use fails
+acceptance; safe error handling is acceptable only in additional-pressure tests.
+Do not infer hardware acceptance from host serialization stubs or successful
+firmware builds. Binary images, original books and device-specific raw logs are
+local artifacts and are not committed to the repository.
+
 ### Distinguishing TCP Stalls, Watchdogs, and Restarts
 
 - A task-watchdog failure prints the task watchdog banner and subscribed task

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -100,9 +100,9 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Versions 60 / 61
+### Versions 64 / 65
 
-> Unified firmware uses the CJK-capable cache version **61**. Version 60 is the
+> Unified firmware uses the CJK-capable cache version **65**. Version 64 is the
 > Latin-build counter; its layout is identical, but font metrics differ,
 > so old pagination caches are deliberately invalidated.
 >
@@ -140,6 +140,15 @@ if (parsedSize != fileSize) {
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Versions 62/63 add `collectTouchLinks` to the header cache key. Devices without
+touch input neither construct nor hydrate link geometry; button footnotes and
+anchors remain available. Partial-cache sentinels change in lockstep to 218/217 for versions 64/65.
+Versions 64/65 also invalidate pagination produced before bounded no-PSRAM
+soft flushing; disabling embedded styles no longer enlarges the token window.
+On devices without PSRAM, a low-memory styled build is discarded and retried
+once without embedded CSS for the reading session. The cache records the actual
+`embeddedStyle=false`; user settings and the selected font are unchanged.
 
 Versions 60/61 append the internal-link rectangles produced during text layout
 to each serialized page. The reader uses these rectangles for touch navigation;
@@ -187,8 +196,8 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define LATIN_VERSION 58
-#define CHINESE_VERSION 59
+#define LATIN_VERSION 64
+#define CHINESE_VERSION 65
 #define MAX_STRING_LENGTH 65535
 #define FOOTNOTE_NUMBER_LEN 32
 #define FOOTNOTE_HREF_LEN 256
@@ -312,12 +321,22 @@ struct FootnoteEntry {
     char href[FOOTNOTE_HREF_LEN];
 };
 
+struct PageLink {
+    char href[FOOTNOTE_HREF_LEN];
+    s16 x;
+    s16 y;
+    s16 width;
+    s16 height;
+};
+
 struct Page {
     u16 elementCount;
     PageElement elements[elementCount] [[inline]];
 
     u16 footnoteCount;
     FootnoteEntry footnotes[footnoteCount];
+    u16 linkCount; // at most 32; zero when collectTouchLinks=false
+    PageLink links[linkCount];
 };
 
 struct AnchorEntry {
@@ -351,6 +370,7 @@ struct SectionBin {
     bool embeddedStyle;
     u8 imageRendering;
     bool focusReadingEnabled;
+    bool collectTouchLinks;
 
     u16 pageCount;
     u32 pageLutOffset;

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -1140,8 +1140,13 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   if (glyphBytes && !glyphs) return growthFailed();
   auto bitmap = newBitmapBytes ? makeUniqueNoThrow<uint8_t[]>(bitmapBytes) : nullptr;
   if (newBitmapBytes && !bitmap) return growthFailed();
-  auto preparedMappings = makeUniqueNoThrow<CpGlyphMapping[]>(cpCount);
-  if (!preparedMappings) return growthFailed();
+#endif
+  auto mappings = makeUniqueNoThrow<CpGlyphMapping[]>(cpCount);
+  if (!mappings) {
+    LOG_ERR("SDCF", "Failed to allocate mapping array for style %u", styleIdx);
+    return -1;
+  }
+#ifndef BOARD_HAS_PSRAM
   // No more cache allocations are needed before glyph data is written.
   s.epdFont.data = &s.stubData;
   if (intervals) {
@@ -1159,15 +1164,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
     s.miniBitmap = bitmap.release();
     s.miniBitmapCapacity = bitmapBytes;
   }
-  // Existing C-style cleanup below owns this buffer on every exit path.
-  CpGlyphMapping* mappings = preparedMappings.release();
-#else
-  CpGlyphMapping* mappings = new (std::nothrow) CpGlyphMapping[cpCount];
 #endif
-  if (!mappings) {
-    LOG_ERR("SDCF", "Failed to allocate mapping array for style %u", styleIdx);
-    return -1;
-  }
 
   uint32_t validCount = 0;
   for (uint32_t i = 0; i < cpCount; i++) {
@@ -1182,7 +1179,6 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
 
   if (validCount == 0) {
     freeStyleMiniData(s);
-    delete[] mappings;
     s.epdFont.data = &s.stubData;
     return missed;
   }
@@ -1199,12 +1195,12 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   memset(&s.miniData, 0, sizeof(s.miniData));
   s.epdFont.data = &s.stubData;
 
+#ifdef BOARD_HAS_PSRAM
   if (!ensureArrayCapacity(s.miniIntervals, s.miniIntervalCapacity, validCount)) {
     LOG_ERR("SDCF", "Failed to allocate mini intervals for style %u", styleIdx);
-    delete[] mappings;
     return -1;
   }
-
+#endif
   s.miniIntervalCount = 0;
   uint32_t rangeStart = 0;
   for (uint32_t i = 1; i <= validCount; i++) {
@@ -1218,12 +1214,13 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   }
 
   // Mini glyph array (reused across pages when it fits)
+#ifdef BOARD_HAS_PSRAM
   if (!ensureArrayCapacity(s.miniGlyphs, s.miniGlyphCapacity, validCount)) {
     LOG_ERR("SDCF", "Failed to allocate mini glyphs for style %u", styleIdx);
-    delete[] mappings;
     freeStyleMiniData(s);
     return -1;
   }
+#endif
   s.miniGlyphCount = validCount;
 
   FontFile file(filePath_, &useFlash_, flashPayloadSize_);
@@ -1251,7 +1248,6 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
         break;
       case GlyphReadResult::Failed:
         LOG_ERR("SDCF", "Prewarm: failed to read glyph %d (style %u)", gIdx, styleIdx);
-        delete[] mappings;
         freeStyleMiniData(s);
         return -1;
     }
@@ -1268,12 +1264,13 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
       totalBitmapSize += s.miniGlyphs[i].dataLength;
     }
 
+#ifdef BOARD_HAS_PSRAM
     if (!ensureArrayCapacity(s.miniBitmap, s.miniBitmapCapacity, totalBitmapSize)) {
       LOG_ERR("SDCF", "Failed to allocate mini bitmap (%u bytes) for style %u", totalBitmapSize, styleIdx);
-      delete[] mappings;
       freeStyleMiniData(s);
       return -1;
     }
+#endif
     s.miniBitmapUsed = totalBitmapSize;  // underuse-hysteresis signal for resetStyleMiniData
 
     uint32_t miniBitmapOffset = 0;
@@ -1299,7 +1296,6 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
           break;
         case GlyphReadResult::Failed:
           LOG_ERR("SDCF", "Prewarm: failed to read bitmap (style %u)", styleIdx);
-          delete[] mappings;
           freeStyleMiniData(s);
           return -1;
       }
@@ -1311,7 +1307,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   }
 
   uint32_t sdTime = millis() - sdStart;
-  delete[] mappings;
+  mappings.reset();
 
   // Full render prewarm: load the persistent kern classes + ligatures (one-time
   // per style, small — the big matrix is NOT loaded here) and then build the

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -138,6 +138,23 @@ bool ensureArrayCapacity(T*& buf, CapT& capacity, const uint32_t needed) {
 
 }  // namespace
 
+bool SdCardFont::hasCacheHeadroom(const size_t bytes, const size_t largest) {
+#ifndef BOARD_HAS_PSRAM
+  // Reserve space for XML/layout, the grayscale strip and on-demand glyphs.
+  // Existing allocations are already deducted from the live free-heap reading.
+  if (!memory::hasAllocationHeadroom(ESP.getFreeHeap(), ESP.getMaxAllocHeap(), bytes, largest, 16 * 1024, 8 * 1024)) {
+    if (!cacheBudgetSkipped_) {
+      LOG_DBG("SDCF", "Skipping cache prewarm (need=%u, largest=%u, free=%u, maxAlloc=%u)",
+              static_cast<unsigned>(bytes), static_cast<unsigned>(largest), static_cast<unsigned>(ESP.getFreeHeap()),
+              static_cast<unsigned>(ESP.getMaxAllocHeap()));
+      cacheBudgetSkipped_ = true;
+    }
+    return false;
+  }
+#endif
+  return true;
+}
+
 SdCardFont::~SdCardFont() { freeAll(); }
 
 #if defined(BOARD_HAS_PSRAM) && !defined(SIMULATOR) && !defined(CROSSPOINT_EMULATED)
@@ -297,6 +314,10 @@ void SdCardFont::freeStyleKernLigatureData(PerStyle& s) {
   s.kernRightClasses = nullptr;
   delete[] s.ligaturePairs;
   s.ligaturePairs = nullptr;
+  s.stubData.ligaturePairs = nullptr;
+  s.stubData.ligaturePairCount = 0;
+  s.miniData.ligaturePairs = nullptr;
+  s.miniData.ligaturePairCount = 0;
   s.kernLigLoaded = false;
 }
 
@@ -401,6 +422,11 @@ bool SdCardFont::loadStyleKernLigatureData(PerStyle& s) {
     s.kernLigLoaded = true;
     return true;
   }
+
+  const size_t leftBytes = s.header.kernLeftEntryCount * sizeof(EpdKernClassEntry);
+  const size_t rightBytes = s.header.kernRightEntryCount * sizeof(EpdKernClassEntry);
+  const size_t ligBytes = s.header.ligaturePairCount * sizeof(EpdLigaturePair);
+  if (!hasCacheHeadroom(leftBytes + rightBytes + ligBytes, std::max({leftBytes, rightBytes, ligBytes}))) return false;
 
   FontFile file(filePath_, &useFlash_, flashPayloadSize_);
   if (!file) {
@@ -548,6 +574,13 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
   // per-page sizes vary by a few entries, which as free+realloc churn was punching
   // non-coalescing holes in the heap every page turn).
   const uint32_t matrixBytes = static_cast<uint32_t>(numLeft) * numRight;
+  const size_t leftBytes = miniLeftCount > s.miniKernLeftCapacity ? miniLeftCount * sizeof(EpdKernClassEntry) : 0;
+  const size_t rightBytes = miniRightCount > s.miniKernRightCapacity ? miniRightCount * sizeof(EpdKernClassEntry) : 0;
+  const size_t newMatrixBytes = matrixBytes > s.miniKernMatrixCapacity ? matrixBytes : 0;
+  if (!hasCacheHeadroom(leftBytes + rightBytes + newMatrixBytes, std::max({leftBytes, rightBytes, newMatrixBytes}))) {
+    resetMiniKernCounts();
+    return false;
+  }
   if (!ensureArrayCapacity(s.miniKernLeftClasses, s.miniKernLeftCapacity, miniLeftCount) ||
       !ensureArrayCapacity(s.miniKernRightClasses, s.miniKernRightCapacity, miniRightCount) ||
       !ensureArrayCapacity(s.miniKernMatrix, s.miniKernMatrixCapacity, matrixBytes)) {
@@ -937,7 +970,10 @@ int SdCardFont::prewarm(TextGetter getter, const void* ctx, uint32_t textCount, 
   // Keep the bounded array sorted so duplicate checks stay logarithmic and every
   // downstream interval/glyph walk can consume it without another sort.
   // Heap-allocated: MAX_PAGE_GLYPHS * 4 = 2048 bytes, too large for stack (limit < 256 bytes)
-  std::unique_ptr<uint32_t[]> codepoints(new (std::nothrow) uint32_t[MAX_PAGE_GLYPHS]);
+  if (!hasCacheHeadroom(MAX_PAGE_GLYPHS * sizeof(uint32_t), MAX_PAGE_GLYPHS * sizeof(uint32_t))) {
+    return PREWARM_SKIPPED;
+  }
+  auto codepoints = makeUniqueNoThrow<uint32_t[]>(MAX_PAGE_GLYPHS);
   if (!codepoints) {
     LOG_ERR("SDCF", "Failed to allocate codepoint buffer (%u bytes)", MAX_PAGE_GLYPHS * 4);
     return -1;
@@ -982,7 +1018,9 @@ int SdCardFont::prewarm(TextGetter getter, const void* ctx, uint32_t textCount, 
   int totalMissed = 0;
   for (uint8_t si = 0; si < MAX_STYLES; si++) {
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
-    totalMissed += prewarmStyle(si, codepoints.get(), cpCount, metadataOnly, loadKernLig);
+    const int result = prewarmStyle(si, codepoints.get(), cpCount, metadataOnly, loadKernLig);
+    if (result < 0) return result;
+    totalMissed += result;
   }
 
   stats_.prewarmTotalMs = millis() - startMs;
@@ -1033,7 +1071,9 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   std::unique_ptr<uint32_t[]> unionCps;
   if (s.miniGlyphCount > 0 && s.miniIntervalCount > 0) {
     const uint32_t unionMax = s.miniGlyphCount + cpCount;
-    unionCps = makeUniqueNoThrow<uint32_t[]>(unionMax);
+    if (hasCacheHeadroom(unionMax * sizeof(uint32_t), unionMax * sizeof(uint32_t))) {
+      unionCps = makeUniqueNoThrow<uint32_t[]>(unionMax);
+    }
     if (unionCps) {
       uint32_t count = 0;
       for (uint32_t iv = 0; iv < s.miniIntervalCount && count <= MAX_PAGE_GLYPHS; iv++) {
@@ -1061,10 +1101,72 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
     uint32_t codepoint;
     int32_t globalIndex;
   };
+#ifndef BOARD_HAS_PSRAM
+  // Read metadata once before growing anything, so all replacement buffers can
+  // be budgeted and acquired while the old mini-cache is still valid. The
+  // temporary glyph is 16 bytes; the replacement arrays take over existing
+  // cache ownership, adding no permanent allocation.
+  uint32_t bitmapBytes = 0;
+  uint32_t coveredCount = 0;
+  {
+    FontFile file(filePath_, &useFlash_, flashPayloadSize_);
+    EpdGlyph glyph{};
+    for (uint32_t i = 0; i < cpCount; ++i) {
+      const int32_t index = findGlobalGlyphIndex(s, codepoints[i]);
+      if (index < 0) continue;
+      ++coveredCount;
+      if (readGlyphMetadata(file, styleIdx, static_cast<uint32_t>(index), glyph, true) == GlyphReadResult::Failed) {
+        LOG_ERR("SDCF", "Failed to read prewarm budget metadata (glyph=%d, style=%u)", index, styleIdx);
+        return -1;
+      }
+      if (!metadataOnly) bitmapBytes += glyph.dataLength;
+    }
+  }
+  const size_t intervalBytes = coveredCount > s.miniIntervalCapacity ? coveredCount * sizeof(EpdUnicodeInterval) : 0;
+  const size_t glyphBytes = coveredCount > s.miniGlyphCapacity ? coveredCount * sizeof(EpdGlyph) : 0;
+  const size_t newBitmapBytes = bitmapBytes > s.miniBitmapCapacity ? bitmapBytes : 0;
+  const size_t mappingBytes = cpCount * sizeof(CpGlyphMapping);
+  if (!hasCacheHeadroom(mappingBytes + intervalBytes + glyphBytes + newBitmapBytes,
+                        std::max({mappingBytes, intervalBytes, glyphBytes, newBitmapBytes}))) {
+    return PREWARM_SKIPPED;
+  }
+  const auto growthFailed = [] {
+    LOG_ERR("SDCF", "Failed to grow mini cache; keeping previous glyphs");
+    return -1;
+  };
+  auto intervals = intervalBytes ? makeUniqueNoThrow<EpdUnicodeInterval[]>(coveredCount) : nullptr;
+  if (intervalBytes && !intervals) return growthFailed();
+  auto glyphs = glyphBytes ? makeUniqueNoThrow<EpdGlyph[]>(coveredCount) : nullptr;
+  if (glyphBytes && !glyphs) return growthFailed();
+  auto bitmap = newBitmapBytes ? makeUniqueNoThrow<uint8_t[]>(bitmapBytes) : nullptr;
+  if (newBitmapBytes && !bitmap) return growthFailed();
+  auto preparedMappings = makeUniqueNoThrow<CpGlyphMapping[]>(cpCount);
+  if (!preparedMappings) return growthFailed();
+  // No more cache allocations are needed before glyph data is written.
+  s.epdFont.data = &s.stubData;
+  if (intervals) {
+    delete[] s.miniIntervals;
+    s.miniIntervals = intervals.release();
+    s.miniIntervalCapacity = coveredCount;
+  }
+  if (glyphs) {
+    delete[] s.miniGlyphs;
+    s.miniGlyphs = glyphs.release();
+    s.miniGlyphCapacity = coveredCount;
+  }
+  if (bitmap) {
+    delete[] s.miniBitmap;
+    s.miniBitmap = bitmap.release();
+    s.miniBitmapCapacity = bitmapBytes;
+  }
+  // Existing C-style cleanup below owns this buffer on every exit path.
+  CpGlyphMapping* mappings = preparedMappings.release();
+#else
   CpGlyphMapping* mappings = new (std::nothrow) CpGlyphMapping[cpCount];
+#endif
   if (!mappings) {
     LOG_ERR("SDCF", "Failed to allocate mapping array for style %u", styleIdx);
-    return static_cast<int>(cpCount);
+    return -1;
   }
 
   uint32_t validCount = 0;
@@ -1100,7 +1202,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   if (!ensureArrayCapacity(s.miniIntervals, s.miniIntervalCapacity, validCount)) {
     LOG_ERR("SDCF", "Failed to allocate mini intervals for style %u", styleIdx);
     delete[] mappings;
-    return static_cast<int>(cpCount);
+    return -1;
   }
 
   s.miniIntervalCount = 0;
@@ -1120,7 +1222,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
     LOG_ERR("SDCF", "Failed to allocate mini glyphs for style %u", styleIdx);
     delete[] mappings;
     freeStyleMiniData(s);
-    return static_cast<int>(cpCount);
+    return -1;
   }
   s.miniGlyphCount = validCount;
 
@@ -1151,7 +1253,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
         LOG_ERR("SDCF", "Prewarm: failed to read glyph %d (style %u)", gIdx, styleIdx);
         delete[] mappings;
         freeStyleMiniData(s);
-        return static_cast<int>(cpCount);
+        return -1;
     }
   }
   stats_.glyphPrepareTimeUs += micros() - glyphPrepareStartUs;
@@ -1170,7 +1272,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
       LOG_ERR("SDCF", "Failed to allocate mini bitmap (%u bytes) for style %u", totalBitmapSize, styleIdx);
       delete[] mappings;
       freeStyleMiniData(s);
-      return static_cast<int>(cpCount);
+      return -1;
     }
     s.miniBitmapUsed = totalBitmapSize;  // underuse-hysteresis signal for resetStyleMiniData
 
@@ -1199,7 +1301,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
           LOG_ERR("SDCF", "Prewarm: failed to read bitmap (style %u)", styleIdx);
           delete[] mappings;
           freeStyleMiniData(s);
-          return static_cast<int>(cpCount);
+          return -1;
       }
 
       glyph.dataOffset = miniBitmapOffset;
@@ -1310,6 +1412,7 @@ void SdCardFont::mergeIntoAdvanceTable(uint8_t styleIdx, const AdvanceEntry* sor
   uint32_t mergedCap = oldSize + newCount;
   if (mergedCap > ADVANCE_CACHE_LIMIT) mergedCap = ADVANCE_CACHE_LIMIT;
 
+  if (!hasCacheHeadroom(mergedCap * sizeof(AdvanceEntry), mergedCap * sizeof(AdvanceEntry))) return;
   AdvanceEntry* merged = new (std::nothrow) AdvanceEntry[mergedCap];
   if (!merged) {
     LOG_ERR("SDCF", "mergeIntoAdvanceTable: alloc failed (%u entries) style %u", mergedCap, styleIdx);
@@ -1406,6 +1509,12 @@ int SdCardFont::fetchAdvancesForCodepoints(uint32_t* codepoints, uint32_t cpCoun
       uint32_t codepoint;
       int32_t glyphIndex;
     };
+    const size_t mappingBytes = cpCount * sizeof(CpIdx);
+    const size_t stagingBytes = cpCount * sizeof(AdvanceEntry);
+    const size_t mergedBytes = std::min(ADVANCE_CACHE_LIMIT, advanceTableSize_[si] + cpCount) * sizeof(AdvanceEntry);
+    if (!hasCacheHeadroom(mappingBytes + stagingBytes + mergedBytes,
+                          std::max({mappingBytes, stagingBytes, mergedBytes})))
+      return PREWARM_SKIPPED;
     std::unique_ptr<CpIdx[]> mappings(new (std::nothrow) CpIdx[cpCount]);
     if (!mappings) {
       LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate mappings for style %u", si);
@@ -1496,6 +1605,8 @@ int SdCardFont::buildAdvanceTableRange(Iter begin, Iter end, bool includeSpace, 
   static constexpr uint32_t MAX_UNIQUE_CODEPOINTS = ADVANCE_CACHE_LIMIT;
   // ~3 KB at the current limit: too large for the task stack, short-lived, and
   // released automatically on every return path.
+  constexpr size_t collectionBytes = (MAX_UNIQUE_CODEPOINTS + 3) * sizeof(uint32_t);
+  if (!hasCacheHeadroom(collectionBytes, collectionBytes)) return PREWARM_SKIPPED;
   auto codepoints = makeUniqueNoThrow<uint32_t[]>(MAX_UNIQUE_CODEPOINTS + 3);
   if (!codepoints) {
     LOG_ERR("SDCF", "buildAdvanceTable: failed to allocate codepoint buffer (%u bytes)",

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -29,6 +29,8 @@ class SdCardFont {
  public:
   static constexpr uint16_t MAX_PAGE_GLYPHS = 512;
   static constexpr uint8_t MAX_STYLES = 4;
+  // Negative prewarm results are unavailable optimizations, not missing glyphs.
+  static constexpr int PREWARM_SKIPPED = -2;
 
   SdCardFont() = default;
   ~SdCardFont();
@@ -306,6 +308,8 @@ class SdCardFont {
   AdvanceEntry* advanceTable_[MAX_STYLES] = {};
   uint32_t advanceTableSize_[MAX_STYLES] = {};
   bool advanceTableLookup(uint8_t styleIdx, uint32_t codepoint, uint16_t* outAdvance) const;
+  bool cacheBudgetSkipped_ = false;
+  bool hasCacheHeadroom(size_t bytes, size_t largest);
   // Merge sortedNew (sorted by codepoint, no overlap with existing) into the
   // advance table for styleIdx, preserving sort order; cap-truncates the tail.
   void mergeIntoAdvanceTable(uint8_t styleIdx, const AdvanceEntry* sortedNew, uint32_t newCount);

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -238,7 +238,7 @@ bool Page::serialize(HalFile& file) const {
   return true;
 }
 
-std::unique_ptr<Page> Page::deserialize(HalFile& file) {
+std::unique_ptr<Page> Page::deserialize(HalFile& file, const bool collectTouchLinks) {
   auto page = makeUniqueNoThrow<Page>();
   if (!page) {
     LOG_ERR("PGE", "OOM: Page (%u bytes)", static_cast<unsigned>(sizeof(Page)));
@@ -299,9 +299,8 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
       LOG_ERR("PGE", "Failed to skip footnotes after OOM");
       return nullptr;
     }
-    return page;
   }
-  for (uint16_t i = 0; i < fnCount; i++) {
+  for (uint16_t i = 0; i < page->footnotes.size(); i++) {
     auto& entry = page->footnotes[i];
     if (file.read(entry.number, sizeof(entry.number)) != sizeof(entry.number) ||
         file.read(entry.href, sizeof(entry.href)) != sizeof(entry.href)) {
@@ -318,14 +317,16 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
     LOG_ERR("PGE", "Invalid link count %u", linkCount);
     return nullptr;
   }
-  if (!page->links.resize(linkCount)) {
+  if (!collectTouchLinks || !page->links.resize(linkCount)) {
     constexpr size_t SERIALIZED_LINK_SIZE = FOOTNOTE_HREF_LEN + 4 * sizeof(int16_t);
     const size_t bytesToSkip = static_cast<size_t>(linkCount) * SERIALIZED_LINK_SIZE;
     const size_t position = file.position();
     const size_t fileSize = file.size();
-    LOG_ERR("PGE", "OOM: dropping %u page links (%u bytes)", linkCount, static_cast<unsigned>(bytesToSkip));
+    if (collectTouchLinks) {
+      LOG_ERR("PGE", "OOM: dropping %u page links (%u bytes)", linkCount, static_cast<unsigned>(bytesToSkip));
+    }
     if (position > fileSize || bytesToSkip > fileSize - position || !file.seek(position + bytesToSkip)) {
-      LOG_ERR("PGE", "Failed to skip page links after OOM");
+      LOG_ERR("PGE", "Failed to skip page links");
       return nullptr;
     }
     return page;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -99,7 +99,7 @@ class Page {
   void extractImagesNeedingDecode();
   void cacheImagesNeedingDecode(GfxRenderer& renderer, int xOffset, int yOffset);
   bool serialize(HalFile& file) const;
-  static std::unique_ptr<Page> deserialize(HalFile& file);
+  static std::unique_ptr<Page> deserialize(HalFile& file, bool collectTouchLinks = true);
 
   // Check if page contains any images (used to force full refresh)
   bool hasImages() const {

--- a/lib/Epub/Epub/PageLink.h
+++ b/lib/Epub/Epub/PageLink.h
@@ -35,11 +35,13 @@ class PageLinkList {
   bool allocationFailed_ = false;
 
   bool allocateStorage(const size_t capacity) {
-    entries_ = makeUniqueNoThrow<PageLink[]>(capacity);
-    if (!entries_) {
+    auto entries = makeUniqueNoThrow<PageLink[]>(capacity);
+    if (!entries) {
       allocationFailed_ = true;
       return false;
     }
+    for (size_t i = 0; i < size_; ++i) entries[i] = entries_[i];
+    entries_ = std::move(entries);
     capacity_ = static_cast<uint8_t>(capacity);
     return true;
   }
@@ -63,10 +65,15 @@ class PageLinkList {
 
   PageLink* append() {
     if (size_ >= MAX_SIZE || allocationFailed_) return nullptr;
-    if (!entries_) {
-      // 32 links occupy 8,448 bytes: too large for the task stack. Allocate
-      // once per linked page so growth cannot fragment the C3 heap.
-      if (!allocateStorage(MAX_SIZE)) return nullptr;
+    if (size_ == capacity_) {
+      // Optional hit regions must not reserve 8,448 bytes for a single link
+      // on internal-heap-only devices. Failed growth preserves existing links.
+#ifdef BOARD_HAS_PSRAM
+      constexpr size_t capacity = MAX_SIZE;
+#else
+      const size_t capacity = capacity_ ? std::min<size_t>(capacity_ * 2, MAX_SIZE) : 1;
+#endif
+      if (!allocateStorage(capacity)) return nullptr;
     }
     if (size_ >= capacity_) return nullptr;
     return &entries_[size_++];

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -981,7 +981,8 @@ bool ParsedText::computeLineBreaks(const GfxRenderer& renderer, const int fontId
   const size_t totalWordCount = words.size();
 
   // One fallible allocation holds both the DP cost and chosen break for every
-  // word. At the parser's 750-word soft limit this is 6 KB on ESP32.
+  // word. Each entry takes 8 bytes on ESP32; the count can grow when splitting
+  // overwide words or retaining an intact Ruby group.
   workspace = makeUniqueNoThrow<LineBreakState[]>(totalWordCount);
   if (!workspace) {
     LOG_ERR("PTX", "OOM: line-break workspace (%u words, %u bytes, free=%u, maxAlloc=%u)",

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -414,7 +414,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordContinues.push_back(continues);
     wordNoSpaceBefore.push_back(noSpaceBefore);
     wordFocusBoundary.push_back(focusBoundary);
-    wordLinkIds.push_back(linkId);
+    if (collectTouchLinks) wordLinkIds.push_back(linkId);
     pushVisibleOffset(tokenOffset);
     if (!rubyTexts.empty()) {
       rubyTexts.push_back("");
@@ -452,7 +452,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordContinues.reserve(newCapacity);
     wordNoSpaceBefore.reserve(newCapacity);
     wordFocusBoundary.reserve(newCapacity);
-    wordLinkIds.reserve(newCapacity);
+    if (collectTouchLinks) wordLinkIds.reserve(newCapacity);
     wordVisibleOffsetDeltas.reserve(newCapacity);
   };
 
@@ -524,7 +524,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
       wordContinues.push_back(attach);
       wordNoSpaceBefore.push_back(noSpaceBefore);
       wordFocusBoundary.push_back(0);
-      wordLinkIds.push_back(linkId);
+      if (collectTouchLinks) wordLinkIds.push_back(linkId);
       pushVisibleOffset(segmentOffset);
     } else {
       size_t charCount = 0;
@@ -548,7 +548,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordFocusBoundary.push_back(0);
-        wordLinkIds.push_back(linkId);
+        if (collectTouchLinks) wordLinkIds.push_back(linkId);
         pushVisibleOffset(segmentOffset);
       } else {
         countPtr = reinterpret_cast<const unsigned char*>(segment.data());
@@ -564,7 +564,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordFocusBoundary.push_back(static_cast<uint8_t>(std::min<size_t>(splitByteOffset, 255)));
-        wordLinkIds.push_back(linkId);
+        if (collectTouchLinks) wordLinkIds.push_back(linkId);
         pushVisibleOffset(segmentOffset);
       }
     }
@@ -617,7 +617,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
 }
 
 uint8_t ParsedText::addLinkTarget(const char* href) {
-  if (!href || href[0] == '\0' || strnlen(href, FOOTNOTE_HREF_LEN) >= FOOTNOTE_HREF_LEN ||
+  if (!collectTouchLinks || !href || href[0] == '\0' || strnlen(href, FOOTNOTE_HREF_LEN) >= FOOTNOTE_HREF_LEN ||
       linkTargets.size() >= UINT8_MAX) {
     return 0;
   }
@@ -685,7 +685,7 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
 }
 // Consumes data to minimize memory usage
 bool ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
+                                       const std::function<bool(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
     return true;
@@ -749,8 +749,9 @@ bool ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   };
 
   for (size_t i = 0; i < lineCount; ++i) {
-    extractLine(i, breakAt(i), i > 0 ? breakAt(i - 1) : 0, lineBreakCount, pageWidth, wordWidths, wordContinues,
-                wordNoSpaceBefore, processLine, renderer, fontId);
+    if (!extractLine(i, breakAt(i), i > 0 ? breakAt(i - 1) : 0, lineBreakCount, pageWidth, wordWidths, wordContinues,
+                     wordNoSpaceBefore, processLine, renderer, fontId))
+      return false;
   }
 
   if (lineCount > 0) {
@@ -765,7 +766,7 @@ bool ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
     wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + consumed);
     wordFocusBoundary.erase(wordFocusBoundary.begin(), wordFocusBoundary.begin() + consumed);
-    wordLinkIds.erase(wordLinkIds.begin(), wordLinkIds.begin() + consumed);
+    if (collectTouchLinks) wordLinkIds.erase(wordLinkIds.begin(), wordLinkIds.begin() + consumed);
     eraseVisibleOffsetPrefix(consumed);
     if (!rubyTexts.empty()) {
       const size_t rtConsumed = std::min(consumed, rubyTexts.size());
@@ -1233,7 +1234,7 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   // Emphasis follows the text across the split, so a break at or after the boundary leaves the
   // remainder fully regular.
   wordFocusBoundary.insert(wordFocusBoundary.begin() + wordIndex + 1, focusBoundaryAfter(focusBoundary, chosenOffset));
-  wordLinkIds.insert(wordLinkIds.begin() + wordIndex + 1, wordLinkIds[wordIndex]);
+  if (collectTouchLinks) wordLinkIds.insert(wordLinkIds.begin() + wordIndex + 1, wordLinkIds[wordIndex]);
   wordFocusBoundary[wordIndex] = focusBoundaryBefore(focusBoundary, chosenOffset);
   // Invariant: a boundary is always strictly inside its token, so an all-bold part carries BOLD in
   // its style with boundary 0 and nothing downstream special-cases boundary == size.
@@ -1276,10 +1277,10 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   return true;
 }
 
-void ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, const size_t lastBreakAt,
+bool ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, const size_t lastBreakAt,
                              const size_t lineCount, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
-                             const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
+                             const std::function<bool(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
   const size_t lineWordCount = lineBreak - lastBreakAt;
   const uint32_t lineVisibleOffset = visibleOffsetAt(lastBreakAt);
@@ -1580,7 +1581,7 @@ void ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, con
 
   std::vector<TextBlock::LinkSpan> lineLinks;
   std::vector<uint8_t> lineLinkIdsSeen;
-  for (size_t i = 0; i < lineWordCount; i++) {
+  for (size_t i = 0; collectTouchLinks && i < lineWordCount; i++) {
     const uint8_t linkId = wordLinkIds[lastBreakAt + (willReorder ? visualOrderScratch[i] : i)];
     if (linkId == 0 || linkId > linkTargets.size()) continue;
 
@@ -1626,11 +1627,10 @@ void ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, con
                                               std::vector<uint16_t>{}, blockStyle, std::move(lineRubyTexts),
                                               std::move(lineLinks));
     if (!block || !block->valid()) {
-      LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
-      return;
+      LOG_ERR("PTX", "OOM: TextBlock arena allocation failed");
+      return false;
     }
-    processLine(std::move(block), lineVisibleOffset);
-    return;
+    return processLine(std::move(block), lineVisibleOffset);
   }
 
   // Each word is one TextBlock entry carrying its own boundary; all that remains is the suffix x
@@ -1649,8 +1649,8 @@ void ParsedText::extractLine(const size_t lineIndex, const size_t lineBreak, con
   auto block = makeUniqueNoThrow<TextBlock>(lineWords, lineXPos, lineWordStyles, outBoundaries, outSuffixX, blockStyle,
                                             std::move(lineRubyTexts), std::move(lineLinks));
   if (!block || !block->valid()) {
-    LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
-    return;
+    LOG_ERR("PTX", "OOM: TextBlock arena allocation failed");
+    return false;
   }
-  processLine(std::move(block), lineVisibleOffset);
+  return processLine(std::move(block), lineVisibleOffset);
 }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -54,6 +54,7 @@ class ParsedText {
   std::deque<std::string> rubyTexts;
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
+  bool collectTouchLinks;
   bool hyphenationEnabled;
   bool focusReadingEnabled;
   bool firstLinePending;
@@ -84,18 +85,20 @@ class ParsedText {
                                                   std::vector<bool>& noSpaceBeforeVec);
   bool hyphenateWordAtIndex(size_t wordIndex, int availableWidth, const GfxRenderer& renderer, int fontId,
                             std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks);
-  void extractLine(size_t lineIndex, size_t lineBreak, size_t lastBreakAt, size_t lineCount, int pageWidth,
+  bool extractLine(size_t lineIndex, size_t lineBreak, size_t lastBreakAt, size_t lineCount, int pageWidth,
                    const std::vector<uint16_t>& wordWidths, const std::vector<bool>& continuesVec,
                    const std::vector<bool>& noSpaceBeforeVec,
-                   const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
+                   const std::function<bool(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                    const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
  public:
   explicit ParsedText(const bool extraParagraphSpacing, const bool hyphenationEnabled = false,
-                      const bool focusReadingEnabled = false, const BlockStyle& blockStyle = BlockStyle())
+                      const bool focusReadingEnabled = false, const BlockStyle& blockStyle = BlockStyle(),
+                      const bool collectTouchLinks = false)
       : blockStyle(blockStyle),
         extraParagraphSpacing(extraParagraphSpacing),
+        collectTouchLinks(collectTouchLinks),
         hyphenationEnabled(hyphenationEnabled),
         focusReadingEnabled(focusReadingEnabled),
         firstLinePending(true),
@@ -119,6 +122,6 @@ class ParsedText {
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   bool layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
+                             const std::function<bool(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/ReaderRenderSpec.h
+++ b/lib/Epub/Epub/ReaderRenderSpec.h
@@ -6,8 +6,9 @@
 // with a different spec is discarded and rebuilt.
 //
 // Build one via CrossPointSettings::readerRenderSpec(width, height), which
-// fills every field: the settings-derived ones from the store, the viewport
-// from the caller. Taking the viewport as arguments is what keeps a spec from
+// fills settings and viewport fields. The reader supplies collectTouchLinks
+// from the input device and applies any session-only CSS fallback. Taking
+// the viewport as arguments is what keeps a spec from
 // existing in a half-filled state — the 0 defaults below are a last-resort
 // backstop (a 0x0 viewport lays out nothing), not an invitation to omit it.
 struct ReaderRenderSpec {
@@ -21,4 +22,5 @@ struct ReaderRenderSpec {
   bool embeddedStyle = true;
   uint8_t imageRendering = 0;
   bool focusReadingEnabled = false;
+  bool collectTouchLinks = false;
 };

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1,5 +1,7 @@
 #include "Section.h"
 
+#include <FontCacheManager.h>
+#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <Memory.h>
@@ -31,10 +33,12 @@ namespace {
 //   56 / 57 - focus-word break opportunities, image viewport clamping, and extra-wide line spacing
 //   58 / 59 - simple HTML table rows laid out as positioned columns
 //   60 / 61 - touch-link rectangles, inline direction inheritance, block spacing, and linked sup/sub
+//   62 / 63 - touch-link capability in the render spec
+//   64 / 65 - bounded no-PSRAM soft-flush windows
 #ifdef ENABLE_CHINESE_VERSION
-constexpr uint8_t SECTION_FILE_VERSION = 61;
+constexpr uint8_t SECTION_FILE_VERSION = 65;
 #else
-constexpr uint8_t SECTION_FILE_VERSION = 60;
+constexpr uint8_t SECTION_FILE_VERSION = 64;
 #endif
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
@@ -55,8 +59,23 @@ constexpr uint8_t SECTION_FILE_INCOMPLETE_VERSION = 0;
 constexpr uint8_t SECTION_FILE_PARTIAL_VERSION = 0xFE - (SECTION_FILE_VERSION - 28);
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
-                                 sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +
+                                 sizeof(uint8_t) + sizeof(bool) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +
                                  sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
+// Called only between layout/render operations; no borrowed glyph pointer is live.
+void reclaimLayoutCaches(GfxRenderer& renderer, const char* stage) {
+#ifndef BOARD_HAS_PSRAM
+  if (ESP.getFreeHeap() >= 48 * 1024 && ESP.getMaxAllocHeap() >= 16 * 1024) return;
+  auto* cache = renderer.getFontCacheManager();
+  if (!cache) return;
+  const auto before = ESP.getFreeHeap();
+  cache->releaseSdFontCaches();
+  if (ESP.getFreeHeap() > before) {
+    LOG_DBG("SCT", "Reclaimed fonts at %s (free=%u->%u, min=%u, maxAlloc=%u)", stage, static_cast<unsigned>(before),
+            static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+            static_cast<unsigned>(ESP.getMaxAllocHeap()));
+  }
+#endif
+}
 }  // namespace
 
 // Out-of-line so the unique_ptr<ChapterHtmlSlimParser> in BuildContext can be
@@ -103,8 +122,9 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
                                    sizeof(spec.extraParagraphSpacing) + sizeof(spec.paragraphAlignment) +
                                    sizeof(spec.viewportWidth) + sizeof(spec.viewportHeight) + sizeof(pageCount) +
                                    sizeof(spec.hyphenationEnabled) + sizeof(spec.embeddedStyle) +
-                                   sizeof(spec.imageRendering) + sizeof(spec.focusReadingEnabled) + sizeof(uint32_t) +
-                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
+                                   sizeof(spec.imageRendering) + sizeof(spec.focusReadingEnabled) +
+                                   sizeof(spec.collectTouchLinks) + sizeof(uint32_t) + sizeof(uint32_t) +
+                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
                 "Header size mismatch");
   // Written as the incomplete sentinel; finalizeBuild() patches it to
   // SECTION_FILE_VERSION as the last step, committing the file.
@@ -119,6 +139,7 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
   serialization::writePod(file, spec.embeddedStyle);
   serialization::writePod(file, spec.imageRendering);
   serialization::writePod(file, spec.focusReadingEnabled);
+  serialization::writePod(file, spec.collectTouchLinks);
   serialization::writePod(file, pageCount);  // Placeholder for page count (will be initially 0, patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for LUT offset (patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for anchor map offset (patched later)
@@ -128,6 +149,7 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
 }
 
 bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
+  collectTouchLinks_ = spec.collectTouchLinks;
   if (!Storage.openFileForRead("SCT", filePath, file)) {
     return false;
   }
@@ -156,19 +178,21 @@ bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
     bool fileEmbeddedStyle = false;
     uint8_t fileImageRendering = 0;
     bool fileFocusReadingEnabled = false;
+    bool fileCollectTouchLinks = false;
     const bool headerValid =
         serialization::readPod(file, fileFontId) && serialization::readPod(file, fileLineCompression) &&
         serialization::readPod(file, fileExtraParagraphSpacing) &&
         serialization::readPod(file, fileParagraphAlignment) && serialization::readPod(file, fileViewportWidth) &&
         serialization::readPod(file, fileViewportHeight) && serialization::readPod(file, fileHyphenationEnabled) &&
         serialization::readPod(file, fileEmbeddedStyle) && serialization::readPod(file, fileImageRendering) &&
-        serialization::readPod(file, fileFocusReadingEnabled);
+        serialization::readPod(file, fileFocusReadingEnabled) && serialization::readPod(file, fileCollectTouchLinks);
 
     if (!headerValid || spec.fontId != fileFontId || spec.lineCompression != fileLineCompression ||
         spec.extraParagraphSpacing != fileExtraParagraphSpacing || spec.paragraphAlignment != fileParagraphAlignment ||
         spec.viewportWidth != fileViewportWidth || spec.viewportHeight != fileViewportHeight ||
         spec.hyphenationEnabled != fileHyphenationEnabled || spec.embeddedStyle != fileEmbeddedStyle ||
-        spec.imageRendering != fileImageRendering || spec.focusReadingEnabled != fileFocusReadingEnabled) {
+        spec.imageRendering != fileImageRendering || spec.focusReadingEnabled != fileFocusReadingEnabled ||
+        spec.collectTouchLinks != fileCollectTouchLinks) {
       file.close();
       LOG_ERR("SCT", "Deserialization failed: Parameters do not match");
       clearCache();
@@ -254,10 +278,13 @@ bool Section::createSectionFile(const ReaderRenderSpec& spec, const std::functio
 }
 
 bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void()>& popupFn) {
+  buildError_ = BuildError::Io;
+  collectTouchLinks_ = spec.collectTouchLinks;
   if (build_) {
     LOG_ERR("SCT", "startBuild called while a build is already active");
     return false;
   }
+  reclaimLayoutCaches(renderer, "start");
   buildComplete_ = false;
   builtPageCount_ = 0;
   // Pages from a loaded partial stay readable (from filePath) while this build writes
@@ -356,6 +383,7 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   auto ctx = makeUniqueNoThrow<BuildContext>();
   if (!ctx) {
     LOG_ERR("SCT", "OOM: BuildContext");
+    buildError_ = BuildError::OutOfMemory;
     file.close();
     Storage.remove(binTmpPath().c_str());
     if (!reusedHtml) Storage.remove(tmpHtmlPath.c_str());
@@ -378,7 +406,8 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
     if (ctx->cssParser) {
       const CssParser::CacheLoadResult cacheResult = ctx->cssParser->loadFromCache();
       if (cacheResult == CssParser::CacheLoadResult::LowMemory) {
-        LOG_ERR("SCT", "Insufficient heap to hydrate CSS; section build deferred");
+        LOG_ERR("SCT", "Insufficient heap to hydrate CSS");
+        buildError_ = BuildError::OutOfMemory;
         ctx->cssParser->clear();
         file.close();
         Storage.remove(binTmpPath().c_str());
@@ -415,13 +444,19 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
       spec.focusReadingEnabled,
       [this, ctxPtr](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
                      const uint32_t visibleTextOffset) {
-        ctxPtr->lut.push_back(
-            {this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex, visibleTextOffset});
+        const uint32_t position = this->onPageComplete(std::move(page));
+        if (position == 0) {
+          buildError_ = BuildError::Io;
+          ctxPtr->parser->failIo();
+          return;
+        }
+        ctxPtr->lut.push_back({position, paragraphIndex, listItemIndex, visibleTextOffset});
       },
       spec.embeddedStyle, ctxPtr->contentBase, ctxPtr->imageBasePath, spec.imageRendering, std::move(tocAnchors),
-      popupFn, ctxPtr->cssParser);
+      popupFn, ctxPtr->cssParser, spec.collectTouchLinks);
   if (!ctx->parser) {
     LOG_ERR("SCT", "OOM: ChapterHtmlSlimParser");
+    buildError_ = BuildError::OutOfMemory;
     if (ctx->cssParser) ctx->cssParser->clear();
     file.close();
     Storage.remove(binTmpPath().c_str());
@@ -434,10 +469,12 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
 
   if (!build_->parser->beginParse()) {
     LOG_ERR("SCT", "Failed to begin parse");
+    if (build_->parser->allocationFailed()) buildError_ = BuildError::OutOfMemory;
     abandonBuild();
     return false;
   }
   build_->totalBytes = build_->parser->parseTotalBytes();
+  buildError_ = BuildError::None;
   return true;
 }
 
@@ -451,20 +488,28 @@ bool Section::buildSomeMore(const int maxPages) {
   // would otherwise turn one "small" chunk into a blocking rebuild of the whole watermark.
   const int startCount = builtPageCount_;
   for (;;) {
+    reclaimLayoutCaches(renderer, "parse batch");
     const auto status = build_->parser->parseStep();
-    if (status == ChapterHtmlSlimParser::ParseStatus::Error) {
-      LOG_ERR("SCT", "Parse error during incremental build");
-      abandonBuild();
-      return false;
+    switch (status) {
+      case ChapterHtmlSlimParser::ParseStatus::OutOfMemory:
+        buildError_ = BuildError::OutOfMemory;
+        break;
+      case ChapterHtmlSlimParser::ParseStatus::Error:
+        buildError_ = build_->parser->ioFailed() ? BuildError::Io : BuildError::InvalidData;
+        break;
+      case ChapterHtmlSlimParser::ParseStatus::Done:
+        return finalizeBuild();
+      case ChapterHtmlSlimParser::ParseStatus::More:
+        // Yield once we've laid out the requested number of pages.
+        if (maxPages > 0 && (builtPageCount_ - startCount) >= maxPages) {
+          build_->bytesConsumed = build_->parser->parseBytesConsumed();
+          return true;
+        }
+        continue;
     }
-    if (status == ChapterHtmlSlimParser::ParseStatus::Done) {
-      return finalizeBuild();
-    }
-    // ParseStatus::More: yield once we've laid out the requested number of pages.
-    if (maxPages > 0 && (builtPageCount_ - startCount) >= maxPages) {
-      build_->bytesConsumed = build_->parser->parseBytesConsumed();
-      return true;
-    }
+    LOG_ERR("SCT", "Parse error during incremental build");
+    abandonBuild();
+    return false;
   }
 }
 
@@ -626,6 +671,7 @@ bool Section::finalizeBuild() {
   // Flush the trailing page (emits the last page via the completePageFn into the LUT).
   if (!build_->parser->finishParse()) {
     LOG_ERR("SCT", "Failed to finish section parse");
+    buildError_ = build_->parser->allocationFailed() ? BuildError::OutOfMemory : BuildError::Io;
     abandonBuild();
     return false;
   }
@@ -643,6 +689,7 @@ bool Section::finalizeBuild() {
   if (build_->cssParser) build_->cssParser->clear();
   build_.reset();
   if (!committed) {
+    buildError_ = BuildError::Io;
     // commitBuildFile removed filePath before the failed swap, so nothing valid remains.
     partial_ = false;
     partialPageCount_ = 0;
@@ -733,7 +780,7 @@ std::unique_ptr<Page> Section::loadPageDuringBuild(const int page) {
   // the write cursor so the next onPageComplete keeps appending where it left off.
   const uint32_t writePos = file.position();
   file.seek(pos);
-  auto p = Page::deserialize(file);
+  auto p = Page::deserialize(file, collectTouchLinks_);
   file.seek(writePos);
   if (p) {
     p->visibleTextOffset = build_->lut[page].visibleTextOffset;
@@ -770,7 +817,7 @@ std::unique_ptr<Page> Section::loadPageAt(const int page) const {
   }
 
   if (!f.seek(pagePos)) return nullptr;
-  auto p = Page::deserialize(f);
+  auto p = Page::deserialize(f, collectTouchLinks_);
   if (p) {
     p->visibleTextOffset = visibleTextOffset;
   }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -380,15 +380,15 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   // Header is written with the incomplete-version sentinel; finalizeBuild() commits it.
   writeSectionFileHeader(spec);
 
-  auto ctx = makeUniqueNoThrow<BuildContext>();
-  if (!ctx) {
+  build_ = makeUniqueNoThrow<BuildContext>();
+  if (!build_) {
     LOG_ERR("SCT", "OOM: BuildContext");
     buildError_ = BuildError::OutOfMemory;
-    file.close();
-    Storage.remove(binTmpPath().c_str());
+    releaseBuildResources();
     if (!reusedHtml) Storage.remove(tmpHtmlPath.c_str());
     return false;
   }
+  auto& ctx = build_;
   // htmlCached == "htmlPath is the live cache" (reused, or just promoted). finalizeBuild/abandonBuild
   // then leave the cached HTML alone; only an un-promoted temp (rename failed) is theirs to clean up.
   ctx->reusedHtml = htmlCached;
@@ -408,10 +408,7 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
       if (cacheResult == CssParser::CacheLoadResult::LowMemory) {
         LOG_ERR("SCT", "Insufficient heap to hydrate CSS");
         buildError_ = BuildError::OutOfMemory;
-        ctx->cssParser->clear();
-        file.close();
-        Storage.remove(binTmpPath().c_str());
-        if (!ctx->reusedHtml) Storage.remove(ctx->tmpHtmlPath.c_str());
+        releaseBuildResources();
         return false;
       }
       if (cacheResult == CssParser::CacheLoadResult::Invalid) {
@@ -457,20 +454,16 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   if (!ctx->parser) {
     LOG_ERR("SCT", "OOM: ChapterHtmlSlimParser");
     buildError_ = BuildError::OutOfMemory;
-    if (ctx->cssParser) ctx->cssParser->clear();
-    file.close();
-    Storage.remove(binTmpPath().c_str());
-    if (!reusedHtml) Storage.remove(tmpHtmlPath.c_str());
+    releaseBuildResources();
     return false;
   }
 
   Hyphenator::setPreferredLanguage(epub->getLanguage());
-  build_ = std::move(ctx);
 
   if (!build_->parser->beginParse()) {
     LOG_ERR("SCT", "Failed to begin parse");
     if (build_->parser->allocationFailed()) buildError_ = BuildError::OutOfMemory;
-    abandonBuild();
+    releaseBuildResources();
     return false;
   }
   build_->totalBytes = build_->parser->parseTotalBytes();
@@ -686,8 +679,7 @@ bool Section::finalizeBuild() {
   }
 
   const bool committed = commitBuildFile(SECTION_FILE_VERSION, 0, 0);
-  if (build_->cssParser) build_->cssParser->clear();
-  build_.reset();
+  releaseBuildResources();
   if (!committed) {
     buildError_ = BuildError::Io;
     // commitBuildFile removed filePath before the failed swap, so nothing valid remains.
@@ -727,40 +719,34 @@ void Section::suspendBuild() {
     }
   }
 
-  if (build_->parser) build_->parser->abortParse();
-  if (build_->cssParser) build_->cssParser->clear();
-  if (!committed && file) {
-    // Explicit close() required before remove (member variable, O_RDWR handle).
-    file.close();
-    Storage.remove(binTmpPath().c_str());
-  }
-  if (!build_->reusedHtml && Storage.exists(build_->tmpHtmlPath.c_str())) {
-    Storage.remove(build_->tmpHtmlPath.c_str());
-  }
-  build_.reset();
+  releaseBuildResources();
   buildComplete_ = false;
   pageCount = partial_ ? partialPageCount_ : 0;
   builtPageCount_ = 0;
 }
 
+void Section::releaseBuildResources() {
+  if (build_) {
+    if (build_->parser) build_->parser->abortParse();
+    if (build_->cssParser) build_->cssParser->clear();
+    if (!build_->reusedHtml && Storage.exists(build_->tmpHtmlPath.c_str())) {
+      Storage.remove(build_->tmpHtmlPath.c_str());
+    }
+  }
+  // The member file must be closed before removing an uncommitted build.
+  if (file) file.close();
+  if (Storage.exists(binTmpPath().c_str())) Storage.remove(binTmpPath().c_str());
+  build_.reset();
+}
+
 void Section::abandonBuild() {
   if (!build_) return;
-  if (build_->parser) build_->parser->abortParse();
-  if (build_->cssParser) build_->cssParser->clear();
-  if (file) {
-    // Explicit close() required before remove (member variable, O_RDWR handle).
-    file.close();
-    Storage.remove(binTmpPath().c_str());
-  }
+  releaseBuildResources();
   // A parse error would recur against the same HTML, so drop any partial too -- resuming
   // from it would just re-enter the failing build every open.
   if (Storage.exists(filePath.c_str())) {
     Storage.remove(filePath.c_str());
   }
-  if (!build_->reusedHtml && Storage.exists(build_->tmpHtmlPath.c_str())) {
-    Storage.remove(build_->tmpHtmlPath.c_str());
-  }
-  build_.reset();
   buildComplete_ = false;
   partial_ = false;
   partialPageCount_ = 0;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -73,6 +73,7 @@ class Section {
   uint32_t partialBytesConsumed_ = 0;
   uint32_t partialTotalBytes_ = 0;
   bool finalizeBuild();
+  void releaseBuildResources();
   // Write the LUTs/anchor map (and, for a partial, the watermark trailer), patch the
   // header, stamp the version byte, and swap the tmp .bin over filePath.
   bool commitBuildFile(uint8_t version, uint32_t bytesConsumed, uint32_t totalBytes);

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -14,6 +14,13 @@ class ChapterHtmlSlimParser;
 class CssParser;
 
 class Section {
+ public:
+  enum class BuildError { None, OutOfMemory, InvalidData, Io };
+  BuildError buildError() const { return buildError_; }
+
+ private:
+  BuildError buildError_ = BuildError::None;
+  bool collectTouchLinks_ = false;
   std::shared_ptr<Epub> epub;
   const int spineIndex;
   GfxRenderer& renderer;

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -45,10 +45,6 @@ constexpr size_t MAX_RULES = 1500;
 constexpr size_t SELECTOR_POOL_CAP = 32 * 1024;
 constexpr size_t MAX_UNIQUE_STYLES = 256;
 
-// Minimum free heap required to apply CSS during rendering
-// If below this threshold, we skip CSS to avoid display artifacts.
-constexpr size_t MIN_FREE_HEAP_FOR_CSS = 48 * 1024;
-
 // Maximum length for a single selector string
 // Prevents parsing of extremely long or malformed selectors
 constexpr size_t MAX_SELECTOR_LENGTH = 256;
@@ -860,16 +856,6 @@ CssParser::ParseResult CssParser::loadFromStream(HalFile& source) {
 // Style resolution
 
 CssStyle CssParser::resolveStyle(std::string_view tagName, std::string_view classAttr) const {
-  static bool lowHeapWarningLogged = false;
-  if (ESP.getFreeHeap() < MIN_FREE_HEAP_FOR_CSS) {
-    if (!lowHeapWarningLogged) {
-      lowHeapWarningLogged = true;
-      LOG_DBG("CSS", "Warning: low heap (%u bytes) below MIN_FREE_HEAP_FOR_CSS (%u), returning empty style",
-              ESP.getFreeHeap(), static_cast<unsigned>(MIN_FREE_HEAP_FOR_CSS));
-    }
-    return CssStyle{};
-  }
-
   CssStyle result;
 
   // 1. Apply element-level style (lowest priority).

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -28,16 +28,10 @@
 constexpr size_t MIN_SIZE_FOR_POPUP = 10 * 1024;  // 10KB
 constexpr size_t PARSE_BUFFER_SIZE = 1024;
 
-// This number comes from PR #73
-// If we have > 750 words buffered up, perform the layout and consume out all but the last line
-// There should be enough here to build out 1-2 full pages and doing this will free up a lot of
-// memory.
-// Spotted when reading Intermezzo, there are some really long text blocks in there.
+// Keep the larger basic-layout window on PSRAM targets. Constrained or styled
+// parsing uses the smaller window, retaining the last line at each soft flush.
 constexpr size_t TEXT_BLOCK_SOFT_FLUSH_WORDS = 750;
-
-// No-PSRAM devices also use this smaller window for basic layout. Disabling
-// CSS must not increase the paragraph peak. It fits a CJK page at font size 14.
-constexpr size_t TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS = 320;
+constexpr size_t TEXT_BLOCK_SOFT_FLUSH_WORDS_CONSTRAINED = 320;
 
 // Hard cap on the number of anchor IDs recorded per chapter. Legitimate navigation
 // anchors (TOC entries, footnotes, cross-references) rarely exceed a few hundred per
@@ -1785,9 +1779,9 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
 void ChapterHtmlSlimParser::softFlushTextBlock() {
   if (hasFailed() || !currentTextBlock || inRuby || (insideTableCell && !tableRowStacked)) return;
 #ifdef BOARD_HAS_PSRAM
-  const size_t threshold = embeddedStyle ? TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS : TEXT_BLOCK_SOFT_FLUSH_WORDS;
+  const size_t threshold = embeddedStyle ? TEXT_BLOCK_SOFT_FLUSH_WORDS_CONSTRAINED : TEXT_BLOCK_SOFT_FLUSH_WORDS;
 #else
-  const size_t threshold = TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS;
+  const size_t threshold = TEXT_BLOCK_SOFT_FLUSH_WORDS_CONSTRAINED;
 #endif
   const size_t wordCount = currentTextBlock->size();
   if (wordCount <= threshold) return;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1,5 +1,6 @@
 #include "ChapterHtmlSlimParser.h"
 
+#include <Arduino.h>
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
@@ -34,8 +35,8 @@ constexpr size_t PARSE_BUFFER_SIZE = 1024;
 // Spotted when reading Intermezzo, there are some really long text blocks in there.
 constexpr size_t TEXT_BLOCK_SOFT_FLUSH_WORDS = 750;
 
-// When CSS is enabled, flush earlier to save RAM. 320 is still more than enough to build a CJK
-// page at font size 14
+// No-PSRAM devices also use this smaller window for basic layout. Disabling
+// CSS must not increase the paragraph peak. It fits a CJK page at font size 14.
 constexpr size_t TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS = 320;
 
 // Hard cap on the number of anchor IDs recorded per chapter. Legitimate navigation
@@ -294,6 +295,7 @@ void ChapterHtmlSlimParser::updateEffectiveInlineStyle() {
 }
 
 void ChapterHtmlSlimParser::flushPendingAnchor() {
+  if (hasFailed()) return;
   if (pendingAnchorId.empty()) return;
 
   // If the pending anchor is a TOC chapter boundary, force a page break after the previous
@@ -301,6 +303,7 @@ void ChapterHtmlSlimParser::flushPendingAnchor() {
   if (std::find(tocAnchors.begin(), tocAnchors.end(), pendingAnchorId) != tocAnchors.end()) {
     if (currentPage && !currentPage->elements.empty()) {
       completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
+      if (hasFailed()) return;
       completedPageCount++;
       if (!allocatePage()) return;
     }
@@ -312,10 +315,11 @@ void ChapterHtmlSlimParser::flushPendingAnchor() {
 }
 
 bool ChapterHtmlSlimParser::allocatePage() {
+  if (hasFailed()) return false;
   auto page = makeUniqueNoThrow<Page>();
   if (!page) {
     LOG_ERR("EHP", "OOM: Page (%u bytes)", static_cast<unsigned>(sizeof(Page)));
-    allocationFailed_ = true;
+    failAllocation("page layout");
     return false;
   }
   currentPage = std::move(page);
@@ -334,6 +338,7 @@ void ChapterHtmlSlimParser::setCurrentPageVisibleOffset(const uint32_t offset) {
 
 // flush the contents of partWordBuffer to currentTextBlock
 void ChapterHtmlSlimParser::flushPartWordBuffer() {
+  if (hasFailed()) return;
   if (!currentTextBlock) {
     partWordBufferIndex = 0;
     nextWordContinues = false;
@@ -364,10 +369,11 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
   const size_t wordBytes = static_cast<size_t>(partWordBufferIndex);
   if (insideTableCell && !tableRowStacked && tableCellTextBytes + wordBytes > MAX_GRID_TABLE_CELL_BYTES) {
     fallbackTableRowToStacked();
+    if (hasFailed()) return;
   }
 
   uint8_t linkId = 0;
-  if (insideFootnoteLink) {
+  if (collectTouchLinks && insideFootnoteLink) {
     if (!currentTextBlock->linkTargetMatches(currentFootnoteLinkId, currentFootnote.href)) {
       currentFootnoteLinkId = currentTextBlock->addLinkTarget(currentFootnote.href);
     }
@@ -378,6 +384,7 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
     tableCellTextBytes += wordBytes;
     if (currentTextBlock->size() > MAX_GRID_TABLE_CELL_WORDS) {
       fallbackTableRowToStacked();
+      if (hasFailed()) return;
     }
   }
   partWordBufferIndex = 0;
@@ -387,6 +394,7 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 
 // start a new text block if needed
 void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
+  if (hasFailed()) return;
   nextWordContinues = false;  // New block = new paragraph, no continuation
   if (currentTextBlock) {
     // already have a text block running and it is empty - just reuse it
@@ -424,17 +432,17 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
     }
 
     makePages();
-    if (allocationFailed_) return;
+    if (hasFailed()) return;
   }
   // If the pending anchor is a TOC chapter boundary, force a page break after the previous
   // block is flushed so the chapter starts on a fresh page.
   flushPendingAnchor();
-  if (allocationFailed_) return;
-  currentTextBlock =
-      makeUniqueNoThrow<ParsedText>(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle);
+  if (hasFailed()) return;
+  currentTextBlock = makeUniqueNoThrow<ParsedText>(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled,
+                                                   blockStyle, collectTouchLinks);
   if (!currentTextBlock) {
     LOG_ERR("EHP", "OOM: ParsedText (%u bytes)", static_cast<unsigned>(sizeof(ParsedText)));
-    allocationFailed_ = true;
+    failAllocation("page layout");
     return;
   }
   wordsExtractedInBlock = 0;
@@ -442,13 +450,16 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
 }
 
 void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
+  if (hasFailed()) return;
   if (partWordBufferIndex > 0) {
     flushPartWordBuffer();
+    if (hasFailed()) return;
   }
 
   if (currentTextBlock) {
     const BlockStyle parentBlockStyle = currentTextBlock->getBlockStyle();
     startNewTextBlock(parentBlockStyle);
+    if (hasFailed()) return;
   }
 
   if (!currentPage) {
@@ -473,6 +484,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   if (!currentPage->elements.empty() && currentPageNextY + totalHeight > viewportHeight) {
     setCurrentPageVisibleOffset(visibleTextOffset);
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
+    if (hasFailed()) return;
     completedPageCount++;
     if (!allocatePage()) return;
   }
@@ -482,6 +494,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   auto pageRule = makeUniqueNoThrow<PageHorizontalRule>(width, ruleThickness, xPos, currentPageNextY);
   if (!pageRule) {
     LOG_ERR("EHP", "Failed to create PageHorizontalRule");
+    failAllocation("PageHorizontalRule");
     return;
   }
   currentPage->elements.push_back(std::move(pageRule));
@@ -495,6 +508,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 }
 
 void ChapterHtmlSlimParser::fallbackTableRowToStacked() {
+  if (hasFailed()) return;
   if (tableRowStacked) {
     return;
   }
@@ -507,6 +521,7 @@ void ChapterHtmlSlimParser::fallbackTableRowToStacked() {
     wordsExtractedInBlock = 0;
     if (currentTextBlock && !currentTextBlock->isEmpty()) {
       makePages();
+      if (hasFailed()) return;
     }
   }
   tableRowCells.clear();
@@ -515,6 +530,7 @@ void ChapterHtmlSlimParser::fallbackTableRowToStacked() {
 }
 
 void ChapterHtmlSlimParser::closeTableCell() {
+  if (hasFailed()) return;
   if (!insideTableCell) {
     return;
   }
@@ -527,12 +543,14 @@ void ChapterHtmlSlimParser::closeTableCell() {
   if (!tableRowStacked &&
       (tableRowCells.size() >= MAX_GRID_TABLE_COLUMNS || currentTextBlock->size() > MAX_GRID_TABLE_CELL_WORDS)) {
     fallbackTableRowToStacked();
+    if (hasFailed()) return;
   }
 
   if (tableRowStacked) {
     wordsExtractedInBlock = 0;
     if (!currentTextBlock->isEmpty()) {
       makePages();
+      if (hasFailed()) return;
     }
     currentTextBlock.reset();
     return;
@@ -542,6 +560,7 @@ void ChapterHtmlSlimParser::closeTableCell() {
 }
 
 void ChapterHtmlSlimParser::addTableRowSeparator() {
+  if (hasFailed()) return;
   if (!currentPage || currentPage->elements.empty() || viewportWidth == 0 ||
       currentPageNextY + TABLE_ROW_SEPARATOR_GAP > viewportHeight) {
     return;
@@ -551,6 +570,7 @@ void ChapterHtmlSlimParser::addTableRowSeparator() {
       makeUniqueNoThrow<PageHorizontalRule>(viewportWidth, TABLE_ROW_SEPARATOR_THICKNESS, 0, currentPageNextY + 1);
   if (!separator) {
     LOG_ERR("EHP", "OOM: table row separator");
+    failAllocation("table row separator");
     return;
   }
   if (currentPage->elements.capacity() == currentPage->elements.size()) {
@@ -561,11 +581,14 @@ void ChapterHtmlSlimParser::addTableRowSeparator() {
 }
 
 void ChapterHtmlSlimParser::finishTableRow() {
+  if (hasFailed()) return;
   closeTableCell();
+  if (hasFailed()) return;
 
   if (tableRowCells.empty()) {
     if (tableRowStacked) {
       addTableRowSeparator();
+      if (hasFailed()) return;
     }
     tableRowStacked = false;
     return;
@@ -581,7 +604,9 @@ void ChapterHtmlSlimParser::finishTableRow() {
   if (columnCount < 2 || cellWidth <= TABLE_CELL_HORIZONTAL_PADDING * 2 ||
       cellWidth < lineHeight * TABLE_MIN_CELL_WIDTH_LINE_HEIGHTS) {
     fallbackTableRowToStacked();
+    if (hasFailed()) return;
     addTableRowSeparator();
+    if (hasFailed()) return;
     tableRowStacked = false;
     return;
   }
@@ -603,15 +628,19 @@ void ChapterHtmlSlimParser::finishTableRow() {
     if (lines.capacity() < MAX_GRID_TABLE_CELL_WORDS * 2) {
       lines.reserve(MAX_GRID_TABLE_CELL_WORDS * 2);
     }
-    tableRowCells[column]->layoutAndExtractLines(
-        renderer, fontId, textWidth, [this, &lines](std::unique_ptr<TextBlock> line, const uint32_t offset) {
-          const size_t lineIndex = lines.size();
-          lines.push_back(std::move(line));
-          if (tableLineVisibleOffsets.size() <= lineIndex) {
-            tableLineVisibleOffsets.resize(lineIndex + 1, UINT32_MAX);
-          }
-          tableLineVisibleOffsets[lineIndex] = std::min(tableLineVisibleOffsets[lineIndex], offset);
-        });
+    if (!tableRowCells[column]->layoutAndExtractLines(
+            renderer, fontId, textWidth, [this, &lines](std::unique_ptr<TextBlock> line, const uint32_t offset) {
+              const size_t lineIndex = lines.size();
+              lines.push_back(std::move(line));
+              if (tableLineVisibleOffsets.size() <= lineIndex) {
+                tableLineVisibleOffsets.resize(lineIndex + 1, UINT32_MAX);
+              }
+              tableLineVisibleOffsets[lineIndex] = std::min(tableLineVisibleOffsets[lineIndex], offset);
+              return true;
+            })) {
+      failAllocation("table layout");
+      return;
+    }
     maxLineCount = std::max(maxLineCount, lines.size());
   }
   tableRowCells.clear();
@@ -640,10 +669,10 @@ void ChapterHtmlSlimParser::finishTableRow() {
       if (pageFull) {
         setCurrentPageVisibleOffset(lineVisibleOffset);
         completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
+        if (hasFailed()) return;
         completedPageCount++;
       }
-      currentPage = makeUniqueNoThrow<Page>();
-      if (!currentPage) {
+      if (!allocatePage()) {
         LOG_ERR("EHP", "OOM: page for table row");
         clearLayoutLines();
         return;
@@ -674,18 +703,20 @@ void ChapterHtmlSlimParser::finishTableRow() {
 
       // Reset Y so every cell in this slice shares one baseline.
       currentPageNextY = rowY;
-      addLineToPage(std::move(line), lineVisibleOffset);
+      if (!addLineToPage(std::move(line), lineVisibleOffset)) return;
     }
     currentPageNextY = static_cast<int16_t>(rowY + rowLineHeight);
   }
 
   addTableRowSeparator();
+  if (hasFailed()) return;
   tableRowStacked = false;
   clearLayoutLines();
 }
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (!self->checkMemory()) return;
   if (strcasecmp(name, "body") == 0) {
     // Case-insensitive to match ParagraphStreamer's tag matching (ProgressMapper). A case
     // mismatch here would leave visibleTextOffset at 0 for the whole section, so every page
@@ -715,9 +746,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   std::string dirAttr;
   if (atts != nullptr) {
     for (int i = 0; atts[i]; i += 2) {
-      if (strcmp(atts[i], "class") == 0) {
+      if (self->cssParser && strcmp(atts[i], "class") == 0) {
         classAttr = atts[i + 1];
-      } else if (strcmp(atts[i], "style") == 0) {
+      } else if (self->cssParser && strcmp(atts[i], "style") == 0) {
         styleAttr = atts[i + 1];
       } else if (strcmp(atts[i], "id") == 0) {
         // Defer both anchor recording and TOC page breaks until startNewTextBlock,
@@ -738,6 +769,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
           // lands at page 0 (section start) instead of the footnote.
           if (!self->pendingAnchorId.empty()) {
             self->flushPendingAnchor();
+            if (self->hasFailed()) return;
           }
           self->pendingAnchorId = idValue;
         }
@@ -793,6 +825,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (self->tableDepth > 0) {
       if (self->tableDepth == 1 && self->insideTableCell && self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
       }
       self->nextWordContinues = false;
       self->tableDepth += 1;
@@ -802,12 +835,15 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
       self->makePages();
+      if (self->hasFailed()) return;
       self->currentTextBlock.reset();
     }
     self->flushPendingAnchor();
+    if (self->hasFailed()) return;
     self->pushTableTextStyleEntry(cssStyle);
     self->tableDepth = 1;
     self->insideTableCell = false;
@@ -823,9 +859,11 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
   if (self->tableDepth == 1 && strcmp(name, "tr") == 0) {
     self->finishTableRow();
+    if (self->hasFailed()) return;
     if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
       // Text before the first row is typically a <caption>.
       self->makePages();
+      if (self->hasFailed()) return;
     }
     self->currentTextBlock.reset();
     self->tableRowStacked = self->tableRowsSpannedRemaining > 0;
@@ -841,10 +879,13 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   if (self->tableDepth == 1 && (strcmp(name, "td") == 0 || strcmp(name, "th") == 0)) {
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     self->closeTableCell();
+    if (self->hasFailed()) return;
     if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
       self->makePages();
+      if (self->hasFailed()) return;
     }
     self->currentTextBlock.reset();
 
@@ -852,6 +893,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     const uint16_t rowSpan = parseTableSpan(getAttribute(atts, "rowspan"));
     if (columnSpan > 1 || rowSpan > 1) {
       self->fallbackTableRowToStacked();
+      if (self->hasFailed()) return;
     }
     if (rowSpan > 1) {
       const uint16_t remaining = rowSpan == UINT16_MAX ? UINT16_MAX : static_cast<uint16_t>(rowSpan - 1);
@@ -872,18 +914,19 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       tableCellBlockStyle.isRtl = cssStyle.direction == CssTextDirection::Rtl;
     }
 
-    self->currentTextBlock = makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled,
-                                                           self->focusReadingEnabled, tableCellBlockStyle);
+    self->currentTextBlock =
+        makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled, self->focusReadingEnabled,
+                                      tableCellBlockStyle, self->collectTouchLinks);
     if (!self->currentTextBlock) {
       LOG_ERR("EHP", "OOM: table cell");
-      self->skipUntilDepth = self->depth;
-      self->depth += 1;
+      self->failAllocation("table cell");
       return;
     }
     self->insideTableCell = true;
     self->tableCellTextBytes = 0;
     self->wordsExtractedInBlock = 0;
     self->flushPendingAnchor();
+    if (self->hasFailed()) return;
     self->pushTableTextStyleEntry(cssStyle);
 
     if (strcmp(name, "th") == 0 && (!cssStyle.hasFontWeight() || cssStyle.fontWeight == CssFontWeight::Bold)) {
@@ -903,6 +946,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // Collapse block markup inside a cell to a word boundary.
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     self->nextWordContinues = false;
     self->depth += 1;
@@ -915,6 +959,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (alt && alt[0] != '\0') {
       self->syntheticCharacterData = true;
       self->characterData(userData, alt, strlen(alt));
+      if (self->hasFailed()) return;
       self->syntheticCharacterData = false;
     }
     self->skipUntilDepth = self->depth;
@@ -1099,10 +1144,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 // Flush any pending text block so it appears before the image
                 if (self->partWordBufferIndex > 0) {
                   self->flushPartWordBuffer();
+                  if (self->hasFailed()) return;
                 }
                 if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
                   const BlockStyle parentBlockStyle = self->currentTextBlock->getBlockStyle();
                   self->startNewTextBlock(parentBlockStyle);
+                  if (self->hasFailed()) return;
                 }
 
                 // Apply vertical margins from the container to the image.
@@ -1125,6 +1172,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                      self->viewportHeight)) {
                   self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex,
                                        self->xpathListItemIndex, self->currentPageVisibleOffset);
+                  if (self->hasFailed()) return;
                   self->completedPageCount++;
                   if (!self->allocatePage()) return;
                 } else if (!self->currentPage) {
@@ -1150,12 +1198,14 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                     makeUniqueNoThrow<ImageBlock>(cachedImagePath, resolvedPath, displayWidth, displayHeight);
                 if (!imageBlock) {
                   LOG_ERR("EHP", "Failed to create ImageBlock");
+                  self->failAllocation("image block");
                   return;
                 }
                 int xPos = (self->viewportWidth - displayWidth) / 2;
                 auto pageImage = makeUniqueNoThrow<PageImage>(std::move(imageBlock), xPos, self->currentPageNextY);
                 if (!pageImage) {
                   LOG_ERR("EHP", "Failed to create PageImage");
+                  self->failAllocation("PageImage");
                   return;
                 }
                 self->currentPage->elements.push_back(std::move(pageImage));
@@ -1190,10 +1240,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->startNewTextBlock(self->blockStyleStack.back()
                                     .getCombinedBlockStyle(centeredBlockStyle, BlockStyle::CombineAxis::Horizontal)
                                     .withoutBottom());
+        if (self->hasFailed()) return;
         self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
         self->depth += 1;
         self->syntheticCharacterData = true;
         self->characterData(userData, alt.c_str(), alt.length());
+        if (self->hasFailed()) return;
         self->syntheticCharacterData = false;
         // Skip any child content (skip until parent as we pre-advanced depth above)
         self->skipUntilDepth = self->depth - 1;
@@ -1213,6 +1265,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // continues the same visual word, exactly like <b>/<i> handling in endElement().
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     self->inRuby = true;
@@ -1224,6 +1277,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   if (strcmp(name, "rt") == 0) {
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     self->collectingRubyText = true;
     self->depth += 1;
@@ -1269,18 +1323,22 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       // Footnote indices are block-relative, so linked rows use ordinary flow.
       if (self->tableDepth >= 1 && self->insideTableCell && !self->tableRowStacked) {
         self->fallbackTableRowToStacked();
+        if (self->hasFailed()) return;
       }
 
       // Flush buffer before style change
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
         self->nextWordContinues = true;
       }
       self->insideFootnoteLink = true;
       self->footnoteLinkDepth = self->depth;
       self->currentFootnoteLinkId = self->currentTextBlock ? self->currentTextBlock->addLinkTarget(href) : 0;
       self->currentFootnote.href[0] = '\0';
-      if (self->currentFootnoteLinkId != 0) strcpy(self->currentFootnote.href, href);
+      if (strnlen(href, sizeof(self->currentFootnote.href)) < sizeof(self->currentFootnote.href)) {
+        strcpy(self->currentFootnote.href, href);
+      }
       self->currentFootnote.number[0] = '\0';
       self->currentFootnoteLinkTextLen = 0;
 
@@ -1319,6 +1377,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       hrBlockStyle.textIndent = 0;
     }
     self->emitHorizontalRule(hrBlockStyle);
+    if (self->hasFailed()) return;
     self->depth += 1;
     return;
   }
@@ -1334,6 +1393,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->blockStyleStack.back().getCombinedBlockStyle(headerBlockStyle, BlockStyle::CombineAxis::Horizontal);
     self->blockStyleStack.push_back(accumulated);
     self->startNewTextBlock(accumulated.withoutBottom());
+    if (self->hasFailed()) return;
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
     self->updateEffectiveInlineStyle();
   } else if (matches(name, BLOCK_TAGS, std::size(BLOCK_TAGS))) {
@@ -1341,6 +1401,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       if (self->partWordBufferIndex > 0) {
         // flush word preceding <br/> to currentTextBlock before calling startNewTextBlock
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
       }
       // A <br> after text is a line break: start the next block with the container's
       // vertical margins stripped, matching browsers, which never apply paragraph
@@ -1360,12 +1421,14 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       }
       brStyle.fromBrElement = true;
       self->startNewTextBlock(brStyle);
+      if (self->hasFailed()) return;
     } else {
       self->currentCssStyle = cssStyle;
       const auto accumulated = self->blockStyleStack.back().getCombinedBlockStyle(userAlignmentBlockStyle,
                                                                                   BlockStyle::CombineAxis::Horizontal);
       self->blockStyleStack.push_back(accumulated);
       self->startNewTextBlock(accumulated.withoutBottom());
+      if (self->hasFailed()) return;
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
@@ -1377,6 +1440,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // Flush buffer before style change so preceding text gets current style
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     self->pushDecorationStyleEntry(CssTextDecoration::Underline, cssStyle);
@@ -1384,6 +1448,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // Flush buffer before style change so preceding text gets current style
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     self->pushDecorationStyleEntry(CssTextDecoration::LineThrough, cssStyle);
@@ -1391,6 +1456,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // Flush buffer before style change so preceding text gets current style
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
@@ -1411,6 +1477,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     // Flush buffer before style change so preceding text gets current style
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
@@ -1430,6 +1497,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   } else if (strcmp(name, "sup") == 0 || strcmp(name, "sub") == 0) {
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       self->nextWordContinues = true;
     }
     StyleStackEntry entry;
@@ -1451,6 +1519,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       // Flush buffer before style change so preceding text gets current style
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
         self->nextWordContinues = true;
       }
       StyleStackEntry entry;
@@ -1482,6 +1551,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
 void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char* s, const int len) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (!self->checkMemory()) return;
   const bool countVisibleOffsets = self->insideBody && self->nonVisibleTextDepth == 0 && !self->syntheticCharacterData;
   const uint32_t callbackVisibleOffset = self->visibleTextOffset;
   if (countVisibleOffsets) {
@@ -1526,10 +1596,12 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   if (!self->currentTextBlock) {
     const BlockStyle flowStyle =
         self->blockStyleStack.empty() ? BlockStyle() : self->blockStyleStack.back().withoutBottom();
-    self->currentTextBlock = makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled,
-                                                           self->focusReadingEnabled, flowStyle);
+    self->currentTextBlock =
+        makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled, self->focusReadingEnabled,
+                                      flowStyle, self->collectTouchLinks);
     if (!self->currentTextBlock) {
       LOG_ERR("EHP", "OOM: text block for character data");
+      self->failAllocation("text block for character data");
       return;
     }
     self->wordsExtractedInBlock = 0;
@@ -1565,6 +1637,13 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
 
   uint32_t nextCodepointOffset = callbackVisibleOffset;
   for (int i = 0; i < len; i++) {
+    // Only completed tokens are extracted; the pending UTF-8 word and last line
+    // stay intact. Check inside the callback so a large text node cannot grow
+    // the whole paragraph before yielding memory.
+    if ((static_cast<uint8_t>(s[i]) & 0xC0) != 0x80) {
+      self->softFlushTextBlock();
+      if (self->hasFailed()) return;
+    }
     const uint32_t codepointOffset = nextCodepointOffset;
     if (countVisibleOffsets && (static_cast<uint8_t>(s[i]) & 0xC0) != 0x80) {
       nextCodepointOffset++;
@@ -1574,6 +1653,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       // Currently looking at whitespace, if there's anything in the partWordBuffer, flush it
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
       }
       // Whitespace is a real word boundary — reset continuation state
       self->nextWordContinues = false;
@@ -1602,6 +1682,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     if (static_cast<uint8_t>(s[i]) == 0xC2 && i + 1 < len && static_cast<uint8_t>(s[i + 1]) == 0xA0) {
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
       }
 
       self->partWordBuffer[0] = ' ';
@@ -1610,6 +1691,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordVisibleOffset = codepointOffset;
       self->nextWordContinues = true;  // Attach space to previous word (no break).
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
 
       self->nextWordContinues = true;  // Next real word attaches to this space (no break).
 
@@ -1622,6 +1704,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
         static_cast<uint8_t>(s[i + 2]) == 0xAF) {
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
       }
 
       self->partWordBuffer[0] = ' ';
@@ -1630,6 +1713,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordVisibleOffset = codepointOffset;
       self->nextWordContinues = true;
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
 
       self->nextWordContinues = true;
 
@@ -1675,6 +1759,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
         }
         self->partWordBufferIndex = safeLen;
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
         self->nextWordContinues = true;
         for (int j = 0; j < overflow; j++) {
           self->partWordBuffer[j] = saved[j];
@@ -1683,6 +1768,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
         self->partWordVisibleOffset = overflowVisibleOffset;
       } else {
         self->flushPartWordBuffer();
+        if (self->hasFailed()) return;
         self->nextWordContinues = true;
       }
     }
@@ -1693,30 +1779,33 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
 
-  // Keep token growth bounded: CSS-heavy spans can fragment text into many tiny
-  // words, so flush earlier when embedded CSS is active. We still keep the
-  // "exclude last line" behavior to preserve paragraph flow across chunks.
-  const size_t blockWordCount = self->currentTextBlock->size();
-  const size_t softFlushThreshold =
-      self->embeddedStyle ? TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS : TEXT_BLOCK_SOFT_FLUSH_WORDS;
-  if (blockWordCount > softFlushThreshold && !self->inRuby) {
-    LOG_DBG("EHP", "Text block soft flush (%u words)", static_cast<unsigned>(blockWordCount));
-    const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
-    const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
-                                        ? static_cast<uint16_t>(self->viewportWidth - horizontalInset)
-                                        : self->viewportWidth;
-    if (!self->currentTextBlock->layoutAndExtractLines(
-            self->renderer, self->fontId, effectiveWidth,
-            [self](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
-              self->addLineToPage(std::move(textBlock), offset);
-            },
-            false)) {
-      self->allocationFailed_ = true;
-    }
+  self->softFlushTextBlock();
+}
+
+void ChapterHtmlSlimParser::softFlushTextBlock() {
+  if (hasFailed() || !currentTextBlock || inRuby || (insideTableCell && !tableRowStacked)) return;
+#ifdef BOARD_HAS_PSRAM
+  const size_t threshold = embeddedStyle ? TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS : TEXT_BLOCK_SOFT_FLUSH_WORDS;
+#else
+  const size_t threshold = TEXT_BLOCK_SOFT_FLUSH_WORDS_WITH_CSS;
+#endif
+  const size_t wordCount = currentTextBlock->size();
+  if (wordCount <= threshold) return;
+  LOG_DBG("EHP", "Text block soft flush (%u words)", static_cast<unsigned>(wordCount));
+  const int inset = currentTextBlock->getBlockStyle().totalHorizontalInset();
+  const uint16_t width = inset < viewportWidth ? static_cast<uint16_t>(viewportWidth - inset) : viewportWidth;
+  if (!currentTextBlock->layoutAndExtractLines(
+          renderer, fontId, width,
+          [this](std::unique_ptr<TextBlock> line, const uint32_t offset) {
+            return addLineToPage(std::move(line), offset);
+          },
+          false)) {
+    failAllocation("page layout");
   }
 }
 
 void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const XML_Char* s, const int len) {
+  if (!static_cast<ChapterHtmlSlimParser*>(userData)->checkMemory()) return;
   // Check if this looks like an entity reference (&...;)
   if (len >= 3 && s[0] == '&' && s[len - 1] == ';') {
     const char* utf8Value = lookupHtmlEntity(s, static_cast<size_t>(len));
@@ -1734,6 +1823,7 @@ void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const X
 
 void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* name) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (!self->checkMemory()) return;
   if (self->nonVisibleTextDepth > 0) {
     self->nonVisibleTextDepth--;
   }
@@ -1798,6 +1888,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   if (!insideSkippedSubtree && self->tableDepth > 1 && strcmp(name, "table") == 0) {
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     self->nextWordContinues = false;
     self->tableDepth -= 1;
@@ -1809,6 +1900,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   if (!insideSkippedSubtree && self->tableDepth >= 1 && self->insideTableCell && headerOrBlockTag) {
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
     }
     self->nextWordContinues = false;
     self->depth -= 1;
@@ -1828,6 +1920,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
     if (shouldFlush) {
       self->flushPartWordBuffer();
+      if (self->hasFailed()) return;
       // If closing an inline element, the next word fragment continues the same visual word
       if (isInlineTag) {
         self->nextWordContinues = true;
@@ -1860,18 +1953,22 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
   if (!insideSkippedSubtree && self->tableDepth == 1 && (strcmp(name, "td") == 0 || strcmp(name, "th") == 0)) {
     self->closeTableCell();
+    if (self->hasFailed()) return;
     self->nextWordContinues = false;
   }
 
   if (!insideSkippedSubtree && self->tableDepth == 1 && (strcmp(name, "tr") == 0)) {
     self->finishTableRow();
+    if (self->hasFailed()) return;
     self->nextWordContinues = false;
   }
 
   if (!insideSkippedSubtree && self->tableDepth == 1 && strcmp(name, "table") == 0) {
     self->finishTableRow();
+    if (self->hasFailed()) return;
     if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
       self->makePages();
+      if (self->hasFailed()) return;
     }
     self->currentTextBlock.reset();
     self->tableDepth = 0;
@@ -1884,10 +1981,13 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
     const BlockStyle flowStyle =
         self->blockStyleStack.empty() ? BlockStyle() : self->blockStyleStack.back().withoutBottom();
-    self->currentTextBlock = makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled,
-                                                           self->focusReadingEnabled, flowStyle);
+    self->currentTextBlock =
+        makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled, self->focusReadingEnabled,
+                                      flowStyle, self->collectTouchLinks);
     if (!self->currentTextBlock) {
       LOG_ERR("EHP", "OOM: text block after table");
+      self->failAllocation("text block after table");
+      return;
     }
     self->wordsExtractedInBlock = 0;
   }
@@ -1928,6 +2028,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       // from inheriting the closed block style (e.g. alignment or margins).
       // Vertical margins and paddings are stripped
       self->startNewTextBlock(self->blockStyleStack.back().withoutTop().withoutBottom());
+      if (self->hasFailed()) return;
       self->updateEffectiveInlineStyle();
     }
 
@@ -1946,10 +2047,38 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 }
 
+void ChapterHtmlSlimParser::stopParsing() {
+  // Expat must not be freed inside a callback. It can still emit an empty
+  // element's end callback after StopParser, so every callback checks failure.
+  if (parseActive_ && xmlParser_) XML_StopParser(xmlParser_, XML_FALSE);
+}
+
+void ChapterHtmlSlimParser::failAllocation(const char* stage) {
+  if (!hasFailed()) {
+    LOG_ERR("EHP", "OOM: %s (words=%u, free=%u, min=%u, maxAlloc=%u)", stage,
+            static_cast<unsigned>(currentTextBlock ? currentTextBlock->size() : 0),
+            static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+            static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    allocationFailed_ = true;
+    stopParsing();
+  }
+}
+
+bool ChapterHtmlSlimParser::checkMemory() {
+#ifndef BOARD_HAS_PSRAM
+  if (!hasFailed() && embeddedStyle && (ESP.getFreeHeap() < 48 * 1024 || ESP.getMaxAllocHeap() < 16 * 1024)) {
+    failAllocation("styled parsing headroom");
+  }
+#endif
+  return !hasFailed();
+}
+
 ChapterHtmlSlimParser::~ChapterHtmlSlimParser() { abortParse(); }
 
 bool ChapterHtmlSlimParser::beginParse() {
   allocationFailed_ = false;
+  ioFailed_ = false;
+  if (!checkMemory()) return false;
   htmlEnded_ = false;
   // Initialize block style stack with a root entry representing "no ancestor block elements".
   // The user's paragraph alignment is set as the default so child elements without explicit
@@ -1978,11 +2107,11 @@ bool ChapterHtmlSlimParser::beginParse() {
   const auto align = rootBlockStyle.alignment;
   paragraphAlignmentBlockStyle.alignment = align;
   startNewTextBlock(paragraphAlignmentBlockStyle);
-  if (allocationFailed_) return false;
+  if (hasFailed()) return false;
 
   xmlParser_ = XML_ParserCreate(nullptr);
   if (!xmlParser_) {
-    LOG_ERR("EHP", "Couldn't allocate memory for parser");
+    failAllocation("XML parser");
     return false;
   }
 
@@ -1991,6 +2120,7 @@ bool ChapterHtmlSlimParser::beginParse() {
   XML_SetDefaultHandlerExpand(xmlParser_, defaultHandlerExpand);
 
   if (!Storage.openFileForRead("EHP", filepath, parseFile_)) {
+    ioFailed_ = true;
     destroyXmlParser(xmlParser_);
     xmlParser_ = nullptr;
     return false;
@@ -2010,23 +2140,32 @@ bool ChapterHtmlSlimParser::beginParse() {
 }
 
 ChapterHtmlSlimParser::ParseStatus ChapterHtmlSlimParser::parseStep() {
-  if (allocationFailed_) return ParseStatus::Error;
+  if (!checkMemory()) return allocationFailed_ ? ParseStatus::OutOfMemory : ParseStatus::Error;
   void* const buf = XML_GetBuffer(xmlParser_, PARSE_BUFFER_SIZE);
   if (!buf) {
-    LOG_ERR("EHP", "Couldn't allocate memory for buffer");
-    return ParseStatus::Error;
+    failAllocation("XML buffer");
+    return ParseStatus::OutOfMemory;
   }
 
   const size_t len = parseFile_.read(buf, PARSE_BUFFER_SIZE);
 
   if (len == 0 && parseFile_.available() > 0) {
     LOG_ERR("EHP", "File read error");
+    failIo();
     return ParseStatus::Error;
   }
 
   const int done = parseFile_.available() == 0;
 
-  if (XML_ParseBuffer(xmlParser_, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+  parseActive_ = true;
+  const auto result = XML_ParseBuffer(xmlParser_, static_cast<int>(len), done);
+  parseActive_ = false;
+  if (hasFailed()) return allocationFailed_ ? ParseStatus::OutOfMemory : ParseStatus::Error;
+  if (result == XML_STATUS_ERROR) {
+    if (XML_GetErrorCode(xmlParser_) == XML_ERROR_NO_MEMORY) {
+      failAllocation("XML parsing");
+      return ParseStatus::OutOfMemory;
+    }
     if (htmlEnded_) {
       LOG_DBG("EHP", "Ignoring trailing data after </html>: %s", XML_ErrorString(XML_GetErrorCode(xmlParser_)));
       return ParseStatus::Done;
@@ -2036,7 +2175,7 @@ ChapterHtmlSlimParser::ParseStatus ChapterHtmlSlimParser::parseStep() {
     return ParseStatus::Error;
   }
 
-  if (allocationFailed_) return ParseStatus::Error;
+  if (!checkMemory()) return allocationFailed_ ? ParseStatus::OutOfMemory : ParseStatus::Error;
 
   return done ? ParseStatus::Done : ParseStatus::More;
 }
@@ -2053,12 +2192,15 @@ void ChapterHtmlSlimParser::abortParse() {
 }
 
 bool ChapterHtmlSlimParser::finishParse() {
-  if (allocationFailed_) {
+  if (!checkMemory()) {
     abortParse();
     return false;
   }
   if (xmlParser_) {
-    LOG_DBG("EHP", "Time to parse and build pages: %lu ms", millis() - parseStartTime_);
+    LOG_DBG("EHP", "Parsed in %lu ms (tail words=%u, free=%u, min=%u, maxAlloc=%u)", millis() - parseStartTime_,
+            static_cast<unsigned>(currentTextBlock ? currentTextBlock->size() : 0),
+            static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+            static_cast<unsigned>(ESP.getMaxAllocHeap()));
     destroyXmlParser(xmlParser_);
     xmlParser_ = nullptr;
   }
@@ -2067,13 +2209,14 @@ bool ChapterHtmlSlimParser::finishParse() {
   // Process last page if there is still text
   if (currentTextBlock) {
     makePages();
-    if (allocationFailed_) return false;
+    if (hasFailed()) return false;
     if (!pendingAnchorId.empty()) {
       anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
       pendingAnchorId.clear();
     }
     setCurrentPageVisibleOffset(visibleTextOffset);
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
+    if (hasFailed()) return false;
     completedPageCount++;
     currentPage.reset();
     currentTextBlock.reset();
@@ -2088,7 +2231,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   }
   for (;;) {
     const ParseStatus status = parseStep();
-    if (status == ParseStatus::Error) {
+    if (status == ParseStatus::Error || status == ParseStatus::OutOfMemory) {
       abortParse();
       return false;
     }
@@ -2099,19 +2242,21 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   return finishParse();
 }
 
-void ChapterHtmlSlimParser::addLineToPage(std::unique_ptr<TextBlock> line, const uint32_t visibleOffset) {
+bool ChapterHtmlSlimParser::addLineToPage(std::unique_ptr<TextBlock> line, const uint32_t visibleOffset) {
+  if (hasFailed()) return false;
   const int lineHeight =
       renderer.getLineHeight(fontId, lineCompression) + line->getRubyShift(renderer.getFontAscenderSize(fontId));
 
   if (!currentPage) {
-    if (!allocatePage()) return;
+    if (!allocatePage()) return false;
   }
 
   if (currentPageNextY + lineHeight > viewportHeight) {
     setCurrentPageVisibleOffset(visibleOffset);
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
+    if (hasFailed()) return false;
     completedPageCount++;
-    if (!allocatePage()) return;
+    if (!allocatePage()) return false;
   }
   setCurrentPageVisibleOffset(visibleOffset);
 
@@ -2138,14 +2283,16 @@ void ChapterHtmlSlimParser::addLineToPage(std::unique_ptr<TextBlock> line, const
   auto pageLine = makeUniqueNoThrow<PageLine>(std::move(line), xOffset, currentPageNextY);
   if (!pageLine) {
     LOG_ERR("EHP", "OOM: PageLine (%u bytes)", static_cast<unsigned>(sizeof(PageLine)));
-    allocationFailed_ = true;
-    return;
+    failAllocation("page layout");
+    return false;
   }
   currentPage->elements.push_back(std::move(pageLine));
   currentPageNextY += lineHeight;
+  return true;
 }
 
 void ChapterHtmlSlimParser::makePages() {
+  if (hasFailed()) return;
   if (!currentTextBlock) {
     LOG_ERR("EHP", "!! No text block to make pages for !!");
     return;
@@ -2173,12 +2320,12 @@ void ChapterHtmlSlimParser::makePages() {
 
   if (!currentTextBlock->layoutAndExtractLines(renderer, fontId, effectiveWidth,
                                                [this](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
-                                                 addLineToPage(std::move(textBlock), offset);
+                                                 return addLineToPage(std::move(textBlock), offset);
                                                })) {
-    allocationFailed_ = true;
+    failAllocation("page layout");
     return;
   }
-  if (allocationFailed_) return;
+  if (hasFailed()) return;
 
   // Fallback: transfer any remaining pending footnotes to current page.
   // Normally addLineToPage handles this via word-index tracking, but this catches

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -57,6 +57,7 @@ class ChapterHtmlSlimParser {
   bool focusReadingEnabled;
   const CssParser* cssParser;
   bool embeddedStyle;
+  bool collectTouchLinks;
   uint8_t imageRendering;
   std::string contentBase;
   std::string imageBasePath;
@@ -118,6 +119,11 @@ class ChapterHtmlSlimParser {
   uint32_t currentPageVisibleOffset = 0;
   bool currentPageVisibleOffsetSet = false;
   bool allocationFailed_ = false;
+  bool ioFailed_ = false;
+  bool parseActive_ = false;
+  void stopParsing();
+  void failAllocation(const char* stage);
+  bool checkMemory();
   bool insideBody = false;
   bool htmlEnded_ = false;
   bool syntheticCharacterData = false;
@@ -146,6 +152,7 @@ class ChapterHtmlSlimParser {
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPendingAnchor();
   void flushPartWordBuffer();
+  void softFlushTextBlock();
   void fallbackTableRowToStacked();
   void closeTableCell();
   void finishTableRow();
@@ -175,7 +182,8 @@ class ChapterHtmlSlimParser {
       const std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>& completePageFn,
       const bool embeddedStyle, const std::string& contentBase, const std::string& imageBasePath,
       const uint8_t imageRendering = 0, std::vector<std::string> tocAnchors = {},
-      const std::function<void()>& popupFn = nullptr, const CssParser* cssParser = nullptr)
+      const std::function<void()>& popupFn = nullptr, const CssParser* cssParser = nullptr,
+      const bool collectTouchLinks = false)
 
       : epub(epub),
         filepath(filepath),
@@ -190,8 +198,9 @@ class ChapterHtmlSlimParser {
         focusReadingEnabled(focusReadingEnabled),
         completePageFn(completePageFn),
         popupFn(popupFn),
-        cssParser(cssParser),
+        cssParser(embeddedStyle ? cssParser : nullptr),
         embeddedStyle(embeddedStyle),
+        collectTouchLinks(collectTouchLinks),
         imageRendering(imageRendering),
         contentBase(contentBase),
         imageBasePath(imageBasePath),
@@ -204,16 +213,23 @@ class ChapterHtmlSlimParser {
 
   // Resumable parse, for the incremental section builder. Drive as:
   //   if (!beginParse()) fail;
-  //   loop: switch (parseStep()) { More: keep going / yield; Done: finishParse(); Error: abortParse(); }
+  //   More: keep going / yield; Done: finishParse(); Error / OutOfMemory: abortParse().
   // Pages are emitted via completePageFn as they complete during parseStep(), so
   // the caller can stop once enough pages are built and resume on a later tick.
-  enum class ParseStatus { More, Done, Error };
+  enum class ParseStatus { More, Done, Error, OutOfMemory };
+  bool allocationFailed() const { return allocationFailed_; }
+  bool ioFailed() const { return ioFailed_; }
+  bool hasFailed() const { return allocationFailed_ || ioFailed_; }
+  void failIo() {
+    ioFailed_ = true;
+    stopParsing();
+  }
   bool beginParse();
   ParseStatus parseStep();
   bool finishParse();  // flush the trailing page and tear down; returns true
   void abortParse();   // tear down without flushing (error / abandon)
 
-  void addLineToPage(std::unique_ptr<TextBlock> line, uint32_t visibleOffset);
+  bool addLineToPage(std::unique_ptr<TextBlock> line, uint32_t visibleOffset);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 
   // Byte progress of the in-flight parse, used to estimate a still-building section's total page

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <Epub/Page.h>
 #include <Epub/blocks/TextBlock.h>
+#include <Epub/css/CssParser.h>
 #include <FontCacheManager.h>
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
@@ -380,10 +381,64 @@ void EpubReaderActivity::openReaderMenu() {
       !currentPageFootnotes.empty(), !cachedBookmarks.empty());
 }
 
+ReaderRenderSpec EpubReaderActivity::effectiveRenderSpec(const uint16_t width, const uint16_t height) const {
+  auto spec = SETTINGS.readerRenderSpec(width, height);
+  spec.collectTouchLinks = mappedInput.hasTouch();
+  if (stylesDisabledForSession_) spec.embeddedStyle = false;
+  return spec;
+}
+
+bool EpubReaderActivity::retryWithoutStyles() {
+#ifdef BOARD_HAS_PSRAM
+  return false;
+#else
+  if (!section || section->buildError() != Section::BuildError::OutOfMemory || stylesDisabledForSession_ ||
+      SETTINGS.embeddedStyle == 0)
+    return false;
+
+  // A page number is not a content position after CSS changes. Explicit
+  // anchor/percentage/offset requests retain precedence over the displayed page.
+  if (pendingPageJump == std::numeric_limits<uint16_t>::max()) {
+    pendingPercentJump = true;
+    pendingSpineProgress = 1.0f;
+  }
+  if (pendingAnchor.empty() && !pendingPercentJump && !pendingOffsetJump) {
+    if (renderedSpineIndex_ == currentSpineIndex && currentPageVisibleOffset) {
+      pendingOffsetJump = currentPageVisibleOffset;
+    } else if (cachedSpineIndex == currentSpineIndex && cachedVisibleTextOffset) {
+      pendingOffsetJump = cachedVisibleTextOffset;
+    }
+  }
+  pendingPageJump.reset();
+  clearDeferredReposition();
+  nextPageNumber = 0;
+  stylesDisabledForSession_ = true;
+  section->abandonBuild();
+  section.reset();
+  if (auto* css = epub->getCssParser()) css->clear();
+  discardOverlayPage();
+  currentPageLinks.clear();
+  currentPageFootnotes.resize(0);
+  if (auto* cache = renderer.getFontCacheManager()) cache->releaseSdFontCaches();
+  buildHeapPaused = false;
+  partialRebuildStartFailed = false;
+  buildPopupPending = false;
+  failedBuildSpine_ = -1;
+  LOG_INF("ERS", "Retrying spine %d without CSS (free=%u, min=%u, maxAlloc=%u)", currentSpineIndex,
+          static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+          static_cast<unsigned>(ESP.getMaxAllocHeap()));
+  requestUpdate();
+  return true;
+#endif
+}
+
 bool EpubReaderActivity::buildTickHeapGate() {
   const size_t freeHeap = ESP.getFreeHeap();
   const size_t maxBlock = ESP.getMaxAllocHeap();
   buildHeapPaused = freeHeap < BACKGROUND_BUILD_MIN_FREE_HEAP || maxBlock < BACKGROUND_BUILD_MIN_MAX_ALLOC;
+#ifndef BOARD_HAS_PSRAM
+  if (buildHeapPaused && !stylesDisabledForSession_ && SETTINGS.embeddedStyle != 0) return true;
+#endif
   return !buildHeapPaused;
 }
 
@@ -494,9 +549,12 @@ void EpubReaderActivity::loop() {
       !partialRebuildStartFailed &&
       section->currentPage + PARTIAL_REBUILD_START_MARGIN >= static_cast<int>(section->pageCount)) {
     RenderLock lock;
-    const ReaderRenderSpec buildSpec = SETTINGS.readerRenderSpec(buildViewportWidth, buildViewportHeight);
+    const ReaderRenderSpec buildSpec = effectiveRenderSpec(buildViewportWidth, buildViewportHeight);
     if (!section->startBuild(buildSpec)) {
+      if (retryWithoutStyles()) return;
       partialRebuildStartFailed = true;
+      failedBuildSpine_ = currentSpineIndex;
+      requestUpdate();
       LOG_ERR("ERS", "Failed to start deferred partial extension build");
     } else {
       LOG_DBG("ERS", "Reader near partial watermark (%d/%d), resuming extension build", section->currentPage,
@@ -511,6 +569,8 @@ void EpubReaderActivity::loop() {
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
         LOG_ERR("ERS", "Background section build failed");
+        if (retryWithoutStyles()) return;
+        failedBuildSpine_ = currentSpineIndex;
         section.reset();
         requestUpdate();
       } else if (section->isBuildComplete() && applyDeferredReposition()) {
@@ -1332,10 +1392,25 @@ void EpubReaderActivity::renderBook() {
   };
 
   const auto showBuildError = [this]() {
+    discardOverlayPage();
+    currentPageFootnotes.resize(0);
+    if (auto* cache = renderer.getFontCacheManager()) cache->releaseSdFontCaches();
+    if (failedBuildSpine_ != currentSpineIndex) {
+      LOG_ERR("ERS", "Index failed (basic=%d, free=%u, min=%u, maxAlloc=%u)", stylesDisabledForSession_,
+              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+              static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    }
+    failedBuildSpine_ = currentSpineIndex;
     renderer.clearScreen();
     GUI.drawPopup(renderer, tr(STR_INDEX_FAILED));
     automaticPageTurnActive = false;
   };
+
+  if (failedBuildSpine_ == currentSpineIndex) {
+    showBuildError();
+    return;
+  }
+  failedBuildSpine_ = -1;
 
   if (currentSpineIndex < 0) currentSpineIndex = 0;
   if (currentSpineIndex > epub->getSpineItemsCount()) currentSpineIndex = epub->getSpineItemsCount();
@@ -1372,7 +1447,7 @@ void EpubReaderActivity::renderBook() {
   buildViewportWidth = viewportWidth;
   buildViewportHeight = viewportHeight;
 
-  const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+  const ReaderRenderSpec renderSpec = effectiveRenderSpec(viewportWidth, viewportHeight);
 
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
@@ -1413,8 +1488,9 @@ void EpubReaderActivity::renderBook() {
         GfxRenderer::FrameBufferLoan loan(renderer);
         if (!section->createSectionFile(renderSpec, popupFn)) {
           LOG_ERR("ERS", "Failed to persist page data to SD");
-          section.reset();
           loan.end();
+          if (retryWithoutStyles()) return;
+          section.reset();
           showBuildError();
           return;
         }
@@ -1453,6 +1529,7 @@ void EpubReaderActivity::renderBook() {
           }
           if (!started) {
             LOG_ERR("ERS", "Failed to start section build");
+            if (retryWithoutStyles()) return;
             section.reset();
             buildPopupPending = false;
             showBuildError();
@@ -1467,6 +1544,7 @@ void EpubReaderActivity::renderBook() {
             }
             if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
               LOG_ERR("ERS", "Failed during incremental section build");
+              if (retryWithoutStyles()) return;
               section.reset();
               buildPopupPending = false;
               showBuildError();
@@ -1514,6 +1592,11 @@ void EpubReaderActivity::renderBook() {
       section->currentPage = newPage;
       pendingPercentJump = false;
     }
+    if (stylesDisabledForSession_) {
+      LOG_INF("ERS", "Basic layout ready: spine=%d page=%d (free=%u, min=%u, maxAlloc=%u)", currentSpineIndex,
+              section->currentPage, static_cast<unsigned>(ESP.getFreeHeap()),
+              static_cast<unsigned>(ESP.getMinFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
+    }
   }
 
   if (section->isPartial() && section->currentPage >= static_cast<int>(section->pageCount)) {
@@ -1523,6 +1606,7 @@ void EpubReaderActivity::renderBook() {
   while (section->isPartial() && section->currentPage >= static_cast<int>(section->pageCount)) {
     if (!section->isBuilding() && !section->startBuild(renderSpec)) {
       LOG_ERR("ERS", "Failed to start partial extension build");
+      if (retryWithoutStyles()) return;
       section.reset();
       showBuildError();
       return;
@@ -1530,6 +1614,7 @@ void EpubReaderActivity::renderBook() {
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
         LOG_ERR("ERS", "Failed during incremental section build");
+        if (retryWithoutStyles()) return;
         section.reset();
         showBuildError();
         return;
@@ -1540,6 +1625,7 @@ void EpubReaderActivity::renderBook() {
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
         LOG_ERR("ERS", "Failed during incremental section build");
+        if (retryWithoutStyles()) return;
         section.reset();
         showBuildError();
         return;
@@ -1609,6 +1695,7 @@ void EpubReaderActivity::renderBook() {
     pageLoadRetryCount = 0;
 
     currentPageVisibleOffset = p->visibleTextOffset;
+    renderedSpineIndex_ = currentSpineIndex;
     currentPageFootnotes = std::move(p->footnotes);
     currentPageLinks = std::move(p->links);
     currentPageLinkMarginLeft = orientedMarginLeft;
@@ -1737,7 +1824,9 @@ bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
                                getStatsChapterProgressPercent(currentPage, pageCount));
 
   std::optional<uint32_t> offset;
-  if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
+  if (footnoteDepth > 0 && savedPositions[0].spineIndex == spineIndex && savedPositions[0].pageNumber == currentPage) {
+    offset = savedPositions[0].visibleTextOffset;
+  } else if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
     offset = (currentPage == section->currentPage && currentPageVisibleOffset.has_value())
                  ? currentPageVisibleOffset
                  : section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage));
@@ -2835,7 +2924,7 @@ void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool s
   if (!epub) return;
 
   if (savePosition && section && footnoteDepth < MAX_FOOTNOTE_DEPTH) {
-    savedPositions[footnoteDepth] = {currentSpineIndex, section->currentPage};
+    savedPositions[footnoteDepth] = {currentSpineIndex, section->currentPage, currentPageVisibleOffset};
     footnoteDepth++;
     LOG_DBG("ERS", "Saved position [%d]: spine %d, page %d", footnoteDepth, currentSpineIndex, section->currentPage);
   }
@@ -2878,6 +2967,10 @@ void EpubReaderActivity::restoreSavedPosition() {
     clearDeferredReposition();
     currentSpineIndex = pos.spineIndex;
     nextPageNumber = pos.pageNumber;
+    pendingAnchor.clear();
+    pendingPercentJump = false;
+    pendingPageJump.reset();
+    pendingOffsetJump = pos.visibleTextOffset;
     section.reset();
   }
   requestUpdate();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -388,12 +388,11 @@ ReaderRenderSpec EpubReaderActivity::effectiveRenderSpec(const uint16_t width, c
   return spec;
 }
 
-bool EpubReaderActivity::handleBuildFailure(const char* stage) {
+bool EpubReaderActivity::handleBuildFailure(const char* stage, const Section::BuildError error) {
   if (failedBuildSpine_ == currentSpineIndex) return false;
   bool retry = false;
 #ifndef BOARD_HAS_PSRAM
-  retry = section && section->buildError() == Section::BuildError::OutOfMemory && !stylesDisabledForSession_ &&
-          SETTINGS.embeddedStyle != 0;
+  retry = error == Section::BuildError::OutOfMemory && !stylesDisabledForSession_ && SETTINGS.embeddedStyle != 0;
 #endif
   if (retry) {
     // A page number is not a content position after CSS changes. Explicit
@@ -424,9 +423,9 @@ bool EpubReaderActivity::handleBuildFailure(const char* stage) {
   buildHeapPaused = false;
   buildPopupPending = false;
   failedBuildSpine_ = retry ? -1 : currentSpineIndex;
-  LOG_ERR("ERS", "Build failed: spine=%d stage=%s retryWithoutCss=%d (free=%u, min=%u, maxAlloc=%u)", currentSpineIndex,
-          stage, retry, static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
-          static_cast<unsigned>(ESP.getMaxAllocHeap()));
+  LOG_ERR("ERS", "Build failed: spine=%d stage=%s error=%u retryWithoutCss=%d (free=%u, min=%u, maxAlloc=%u)",
+          currentSpineIndex, stage, static_cast<unsigned>(error), retry, static_cast<unsigned>(ESP.getFreeHeap()),
+          static_cast<unsigned>(ESP.getMinFreeHeap()), static_cast<unsigned>(ESP.getMaxAllocHeap()));
   if (retry) {
     requestUpdate();
   } else {
@@ -554,7 +553,7 @@ void EpubReaderActivity::loop() {
     RenderLock lock;
     const ReaderRenderSpec buildSpec = effectiveRenderSpec(buildViewportWidth, buildViewportHeight);
     if (!section->startBuild(buildSpec)) {
-      if (!handleBuildFailure("deferred partial start")) requestUpdate();
+      if (!handleBuildFailure("deferred partial start", section->buildError())) requestUpdate();
       return;
     } else {
       LOG_DBG("ERS", "Reader near partial watermark (%d/%d), resuming extension build", section->currentPage,
@@ -568,7 +567,7 @@ void EpubReaderActivity::loop() {
     RenderLock lock;
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
-        if (!handleBuildFailure("background build")) requestUpdate();
+        if (!handleBuildFailure("background build", section->buildError())) requestUpdate();
         return;
       } else if (section->isBuildComplete() && applyDeferredReposition()) {
         requestUpdate();
@@ -1442,7 +1441,7 @@ void EpubReaderActivity::renderBook() {
     section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
     if (!section) {
       LOG_ERR("ERS", "OOM: Section (%u bytes)", static_cast<unsigned>(sizeof(Section)));
-      handleBuildFailure("section allocation");
+      if (handleBuildFailure("section allocation", Section::BuildError::OutOfMemory)) return;
       showBuildError();
       return;
     }
@@ -1475,7 +1474,7 @@ void EpubReaderActivity::renderBook() {
         GfxRenderer::FrameBufferLoan loan(renderer);
         if (!section->createSectionFile(renderSpec, popupFn)) {
           loan.end();
-          if (handleBuildFailure("full build")) return;
+          if (handleBuildFailure("full build", section->buildError())) return;
           showBuildError();
           return;
         }
@@ -1513,7 +1512,7 @@ void EpubReaderActivity::renderBook() {
             started = section->startBuild(renderSpec, [this] { showBuildPopup(renderer, pagesUntilFullRefresh); });
           }
           if (!started) {
-            if (handleBuildFailure("start")) return;
+            if (handleBuildFailure("start", section->buildError())) return;
             showBuildError();
             return;
           }
@@ -1525,7 +1524,7 @@ void EpubReaderActivity::renderBook() {
               showBuildPopup(renderer, pagesUntilFullRefresh);
             }
             if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-              if (handleBuildFailure("foreground build")) return;
+              if (handleBuildFailure("foreground build", section->buildError())) return;
               showBuildError();
               return;
             }
@@ -1584,13 +1583,13 @@ void EpubReaderActivity::renderBook() {
   }
   while (section->isPartial() && section->currentPage >= static_cast<int>(section->pageCount)) {
     if (!section->isBuilding() && !section->startBuild(renderSpec)) {
-      if (handleBuildFailure("partial start")) return;
+      if (handleBuildFailure("partial start", section->buildError())) return;
       showBuildError();
       return;
     }
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-        if (handleBuildFailure("extension build")) return;
+        if (handleBuildFailure("extension build", section->buildError())) return;
         showBuildError();
         return;
       }
@@ -1599,7 +1598,7 @@ void EpubReaderActivity::renderBook() {
   if (section->isBuilding()) {
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-        if (handleBuildFailure("extension build")) return;
+        if (handleBuildFailure("extension build", section->buildError())) return;
         showBuildError();
         return;
       }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -388,32 +388,33 @@ ReaderRenderSpec EpubReaderActivity::effectiveRenderSpec(const uint16_t width, c
   return spec;
 }
 
-bool EpubReaderActivity::retryWithoutStyles() {
-#ifdef BOARD_HAS_PSRAM
-  return false;
-#else
-  if (!section || section->buildError() != Section::BuildError::OutOfMemory || stylesDisabledForSession_ ||
-      SETTINGS.embeddedStyle == 0)
-    return false;
-
-  // A page number is not a content position after CSS changes. Explicit
-  // anchor/percentage/offset requests retain precedence over the displayed page.
-  if (pendingPageJump == std::numeric_limits<uint16_t>::max()) {
-    pendingPercentJump = true;
-    pendingSpineProgress = 1.0f;
-  }
-  if (pendingAnchor.empty() && !pendingPercentJump && !pendingOffsetJump) {
-    if (renderedSpineIndex_ == currentSpineIndex && currentPageVisibleOffset) {
-      pendingOffsetJump = currentPageVisibleOffset;
-    } else if (cachedSpineIndex == currentSpineIndex && cachedVisibleTextOffset) {
-      pendingOffsetJump = cachedVisibleTextOffset;
+bool EpubReaderActivity::handleBuildFailure(const char* stage) {
+  if (failedBuildSpine_ == currentSpineIndex) return false;
+  bool retry = false;
+#ifndef BOARD_HAS_PSRAM
+  retry = section && section->buildError() == Section::BuildError::OutOfMemory && !stylesDisabledForSession_ &&
+          SETTINGS.embeddedStyle != 0;
+#endif
+  if (retry) {
+    // A page number is not a content position after CSS changes. Explicit
+    // anchor/percentage/offset requests retain precedence over the displayed page.
+    if (pendingPageJump == std::numeric_limits<uint16_t>::max()) {
+      pendingPercentJump = true;
+      pendingSpineProgress = 1.0f;
     }
+    if (pendingAnchor.empty() && !pendingPercentJump && !pendingOffsetJump) {
+      if (renderedSpineIndex_ == currentSpineIndex && currentPageVisibleOffset) {
+        pendingOffsetJump = currentPageVisibleOffset;
+      } else if (cachedSpineIndex == currentSpineIndex && cachedVisibleTextOffset) {
+        pendingOffsetJump = cachedVisibleTextOffset;
+      }
+    }
+    pendingPageJump.reset();
+    clearDeferredReposition();
+    nextPageNumber = 0;
+    stylesDisabledForSession_ = true;
   }
-  pendingPageJump.reset();
-  clearDeferredReposition();
-  nextPageNumber = 0;
-  stylesDisabledForSession_ = true;
-  section->abandonBuild();
+  if (section) section->abandonBuild();
   section.reset();
   if (auto* css = epub->getCssParser()) css->clear();
   discardOverlayPage();
@@ -421,15 +422,17 @@ bool EpubReaderActivity::retryWithoutStyles() {
   currentPageFootnotes.resize(0);
   if (auto* cache = renderer.getFontCacheManager()) cache->releaseSdFontCaches();
   buildHeapPaused = false;
-  partialRebuildStartFailed = false;
   buildPopupPending = false;
-  failedBuildSpine_ = -1;
-  LOG_INF("ERS", "Retrying spine %d without CSS (free=%u, min=%u, maxAlloc=%u)", currentSpineIndex,
-          static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
+  failedBuildSpine_ = retry ? -1 : currentSpineIndex;
+  LOG_ERR("ERS", "Build failed: spine=%d stage=%s retryWithoutCss=%d (free=%u, min=%u, maxAlloc=%u)", currentSpineIndex,
+          stage, retry, static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
           static_cast<unsigned>(ESP.getMaxAllocHeap()));
-  requestUpdate();
-  return true;
-#endif
+  if (retry) {
+    requestUpdate();
+  } else {
+    automaticPageTurnActive = false;
+  }
+  return retry;
 }
 
 bool EpubReaderActivity::buildTickHeapGate() {
@@ -546,16 +549,13 @@ void EpubReaderActivity::loop() {
   }
 
   if (section && !section->isBuilding() && section->isPartial() && !RenderLock::peek() && buildViewportWidth > 0 &&
-      !partialRebuildStartFailed &&
+      failedBuildSpine_ != currentSpineIndex &&
       section->currentPage + PARTIAL_REBUILD_START_MARGIN >= static_cast<int>(section->pageCount)) {
     RenderLock lock;
     const ReaderRenderSpec buildSpec = effectiveRenderSpec(buildViewportWidth, buildViewportHeight);
     if (!section->startBuild(buildSpec)) {
-      if (retryWithoutStyles()) return;
-      partialRebuildStartFailed = true;
-      failedBuildSpine_ = currentSpineIndex;
-      requestUpdate();
-      LOG_ERR("ERS", "Failed to start deferred partial extension build");
+      if (!handleBuildFailure("deferred partial start")) requestUpdate();
+      return;
     } else {
       LOG_DBG("ERS", "Reader near partial watermark (%d/%d), resuming extension build", section->currentPage,
               section->pageCount);
@@ -568,11 +568,8 @@ void EpubReaderActivity::loop() {
     RenderLock lock;
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
-        LOG_ERR("ERS", "Background section build failed");
-        if (retryWithoutStyles()) return;
-        failedBuildSpine_ = currentSpineIndex;
-        section.reset();
-        requestUpdate();
+        if (!handleBuildFailure("background build")) requestUpdate();
+        return;
       } else if (section->isBuildComplete() && applyDeferredReposition()) {
         requestUpdate();
       }
@@ -1392,18 +1389,8 @@ void EpubReaderActivity::renderBook() {
   };
 
   const auto showBuildError = [this]() {
-    discardOverlayPage();
-    currentPageFootnotes.resize(0);
-    if (auto* cache = renderer.getFontCacheManager()) cache->releaseSdFontCaches();
-    if (failedBuildSpine_ != currentSpineIndex) {
-      LOG_ERR("ERS", "Index failed (basic=%d, free=%u, min=%u, maxAlloc=%u)", stylesDisabledForSession_,
-              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(ESP.getMinFreeHeap()),
-              static_cast<unsigned>(ESP.getMaxAllocHeap()));
-    }
-    failedBuildSpine_ = currentSpineIndex;
     renderer.clearScreen();
     GUI.drawPopup(renderer, tr(STR_INDEX_FAILED));
-    automaticPageTurnActive = false;
   };
 
   if (failedBuildSpine_ == currentSpineIndex) {
@@ -1455,10 +1442,10 @@ void EpubReaderActivity::renderBook() {
     section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
     if (!section) {
       LOG_ERR("ERS", "OOM: Section (%u bytes)", static_cast<unsigned>(sizeof(Section)));
+      handleBuildFailure("section allocation");
       showBuildError();
       return;
     }
-    partialRebuildStartFailed = false;
 
     const bool cacheLoaded = section->loadSectionFile(renderSpec);
     if (cacheLoaded) {
@@ -1487,10 +1474,8 @@ void EpubReaderActivity::renderBook() {
         };
         GfxRenderer::FrameBufferLoan loan(renderer);
         if (!section->createSectionFile(renderSpec, popupFn)) {
-          LOG_ERR("ERS", "Failed to persist page data to SD");
           loan.end();
-          if (retryWithoutStyles()) return;
-          section.reset();
+          if (handleBuildFailure("full build")) return;
           showBuildError();
           return;
         }
@@ -1528,10 +1513,7 @@ void EpubReaderActivity::renderBook() {
             started = section->startBuild(renderSpec, [this] { showBuildPopup(renderer, pagesUntilFullRefresh); });
           }
           if (!started) {
-            LOG_ERR("ERS", "Failed to start section build");
-            if (retryWithoutStyles()) return;
-            section.reset();
-            buildPopupPending = false;
+            if (handleBuildFailure("start")) return;
             showBuildError();
             return;
           }
@@ -1543,10 +1525,7 @@ void EpubReaderActivity::renderBook() {
               showBuildPopup(renderer, pagesUntilFullRefresh);
             }
             if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-              LOG_ERR("ERS", "Failed during incremental section build");
-              if (retryWithoutStyles()) return;
-              section.reset();
-              buildPopupPending = false;
+              if (handleBuildFailure("foreground build")) return;
               showBuildError();
               return;
             }
@@ -1605,17 +1584,13 @@ void EpubReaderActivity::renderBook() {
   }
   while (section->isPartial() && section->currentPage >= static_cast<int>(section->pageCount)) {
     if (!section->isBuilding() && !section->startBuild(renderSpec)) {
-      LOG_ERR("ERS", "Failed to start partial extension build");
-      if (retryWithoutStyles()) return;
-      section.reset();
+      if (handleBuildFailure("partial start")) return;
       showBuildError();
       return;
     }
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-        LOG_ERR("ERS", "Failed during incremental section build");
-        if (retryWithoutStyles()) return;
-        section.reset();
+        if (handleBuildFailure("extension build")) return;
         showBuildError();
         return;
       }
@@ -1624,9 +1599,7 @@ void EpubReaderActivity::renderBook() {
   if (section->isBuilding()) {
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
-        LOG_ERR("ERS", "Failed during incremental section build");
-        if (retryWithoutStyles()) return;
-        section.reset();
+        if (handleBuildFailure("extension build")) return;
         showBuildError();
         return;
       }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -101,6 +101,8 @@ class EpubReaderActivity final : public ReaderActivity {
   struct SavedPosition {
     int spineIndex;
     int pageNumber;
+    // Fixed-size return stack; offsets survive session CSS fallback without heap storage.
+    std::optional<uint32_t> visibleTextOffset;
   };
   static constexpr int MAX_FOOTNOTE_DEPTH = 3;
   SavedPosition savedPositions[MAX_FOOTNOTE_DEPTH] = {};
@@ -119,6 +121,11 @@ class EpubReaderActivity final : public ReaderActivity {
   static constexpr size_t BACKGROUND_BUILD_MIN_FREE_HEAP = 32 * 1024;
   static constexpr size_t BACKGROUND_BUILD_MIN_MAX_ALLOC = 16 * 1024;
   bool buildTickHeapGate();
+  bool stylesDisabledForSession_ = false;
+  int renderedSpineIndex_ = -1;
+  int failedBuildSpine_ = -1;
+  ReaderRenderSpec effectiveRenderSpec(uint16_t width, uint16_t height) const;
+  bool retryWithoutStyles();
   bool buildHeapPaused = false;
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr size_t RENDER_MIN_MAX_ALLOC = 24 * 1024;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -110,7 +110,6 @@ class EpubReaderActivity final : public ReaderActivity {
 
   uint16_t buildViewportWidth = 0;
   uint16_t buildViewportHeight = 0;
-  bool partialRebuildStartFailed = false;
 
   int lastSavedSpineIndex = -1;
   int lastSavedPage = -1;
@@ -125,7 +124,7 @@ class EpubReaderActivity final : public ReaderActivity {
   int renderedSpineIndex_ = -1;
   int failedBuildSpine_ = -1;
   ReaderRenderSpec effectiveRenderSpec(uint16_t width, uint16_t height) const;
-  bool retryWithoutStyles();
+  bool handleBuildFailure(const char* stage);
   bool buildHeapPaused = false;
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr size_t RENDER_MIN_MAX_ALLOC = 24 * 1024;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -124,7 +124,7 @@ class EpubReaderActivity final : public ReaderActivity {
   int renderedSpineIndex_ = -1;
   int failedBuildSpine_ = -1;
   ReaderRenderSpec effectiveRenderSpec(uint16_t width, uint16_t height) const;
-  bool handleBuildFailure(const char* stage);
+  bool handleBuildFailure(const char* stage, Section::BuildError error);
   bool buildHeapPaused = false;
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr size_t RENDER_MIN_MAX_ALLOC = 24 * 1024;

--- a/src/activities/settings/TextSettingsPreview.cpp
+++ b/src/activities/settings/TextSettingsPreview.cpp
@@ -64,6 +64,7 @@ void relayout(PreviewLayout& layout, const GfxRenderer& renderer, int fontId, in
   if (!parsed.layoutAndExtractLines(renderer, fontId, static_cast<uint16_t>(textWidth),
                                     [&layout, maxLines](std::unique_ptr<TextBlock> line, uint32_t) {
                                       if (layout.lines.size() < maxLines) layout.lines.push_back(std::move(line));
+                                      return true;
                                     })) {
     layout.lines.clear();
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,3 +92,5 @@ add_subdirectory(css_parser)
 add_subdirectory(chapter_html_slim_parser)
 add_subdirectory(ligature_guard)
 add_subdirectory(page_link)
+
+add_subdirectory(reader_build_failure)

--- a/test/chapter_html_slim_parser/CMakeLists.txt
+++ b/test/chapter_html_slim_parser/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(ChapterHtmlSlimParserTest
   ${REPO_ROOT}/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
   ${REPO_ROOT}/lib/Epub/Epub/css/CssParser.cpp
   ${REPO_ROOT}/lib/Epub/Epub/ParsedText.cpp
+  ${REPO_ROOT}/lib/Epub/Epub/Section.cpp
   ${REPO_ROOT}/lib/Epub/Epub/converters/ImageDimsProbe.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
 )
@@ -21,6 +22,7 @@ target_include_directories(ChapterHtmlSlimParserTest PRIVATE
   ${REPO_ROOT}/lib/MiniBidi
   ${REPO_ROOT}/lib/FsHelpers
   ${REPO_ROOT}/lib/XmlParserUtils
+  ${REPO_ROOT}/lib/Serialization
 )
 
 target_link_libraries(ChapterHtmlSlimParserTest PRIVATE

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -455,6 +455,67 @@ TEST_F(SectionMemoryTest, LayoutOomAndWriteErrorNeverCommitCache) {
   expectNoCache();
 }
 
+TEST_F(SectionMemoryTest, InitializationFailureReleasesResourcesAndPreservesPriorCache) {
+  std::string html = "<html><body>";
+  for (int i = 0; i < 400; ++i) html += "<p>word</p>";
+  html += "</body></html>";
+  writeHtml(html);
+  for (const bool partial : {false, true}) {
+    {
+      Section original(epub, 0, renderer);
+      ASSERT_TRUE(original.startBuild(spec));
+      ASSERT_TRUE(original.buildSomeMore(partial ? 1 : 0));
+    }
+    for (const size_t size : {sizeof(Section::BuildContext), sizeof(ChapterHtmlSlimParser), sizeof(ParsedText)}) {
+      SCOPED_TRACE(size);
+      const auto cachePath = epub->cachePath + "/sections/0.bin";
+      std::ifstream beforeFile(cachePath, std::ios::binary);
+      const std::string before{std::istreambuf_iterator<char>(beforeFile), {}};
+      {
+        Section section(epub, 0, renderer);
+        ASSERT_TRUE(section.loadSectionFile(spec));
+        failObjectSize = size;
+        EXPECT_FALSE(section.startBuild(spec));
+        EXPECT_EQ(failObjectSize, 0U);
+        EXPECT_EQ(section.buildError(), Section::BuildError::OutOfMemory);
+        EXPECT_FALSE(section.isBuilding());
+        EXPECT_FALSE(section.file.isOpen());
+        EXPECT_FALSE(std::filesystem::exists(section.binTmpPath()));
+      }
+      std::ifstream afterFile(cachePath, std::ios::binary);
+      EXPECT_EQ((std::string{std::istreambuf_iterator<char>(afterFile), {}}), before);
+      Section restored(epub, 0, renderer);
+      ASSERT_TRUE(restored.loadSectionFile(spec));
+      EXPECT_EQ(restored.isPartial(), partial);
+    }
+  }
+}
+
+TEST_F(SectionMemoryTest, MixedChapterCacheMatchesVerifiedLayout) {
+  std::string html = "<html><body><p id='start'>";
+  for (int i = 0; i < 900; ++i) html += "中文正文";
+  html += "<ruby>汉字<rt>han zi</rt></ruby><a href='#note'>[1]</a></p>";
+  for (int i = 0; i < 80; ++i) html += "<p>English paragraph words.</p>";
+  html += "<p id='note'>Footnote text.</p></body></html>";
+  writeHtml(html);
+  laidOutWords.clear();
+  collectedFootnotes.clear();
+  spec.embeddedStyle = false;
+  Section section(epub, 0, renderer);
+  ASSERT_TRUE(section.createSectionFile(spec));
+  const auto path = epub->cachePath + "/sections/0.bin";
+  std::ifstream file(path, std::ios::binary);
+  const std::string bytes{std::istreambuf_iterator<char>(file), {}};
+  uint64_t digest = 14695981039346656037ULL;
+  const auto append = [&digest](const std::string& value) {
+    for (const unsigned char byte : value) digest = (digest ^ byte) * 1099511628211ULL;
+  };
+  append(bytes);
+  for (const auto& word : laidOutWords) append(word);
+  for (const auto& href : collectedFootnotes) append(href);
+  EXPECT_EQ(digest, 13330287791149729058ULL);  // Pre-refactor cache, text and footnotes.
+}
+
 TEST_F(SectionMemoryTest, CssCacheOomIsReportedAndBasicBuildDoesNotHydrateCss) {
   writeHtml("<html><body><p>text</p></body></html>");
   CssParser css(epub->cachePath);
@@ -475,6 +536,17 @@ TEST_F(SectionMemoryTest, CssCacheOomIsReportedAndBasicBuildDoesNotHydrateCss) {
   spec.embeddedStyle = false;
   ASSERT_TRUE(section.createSectionFile(spec));
   EXPECT_EQ(css.ruleCount(), 0U);
+  spec.embeddedStyle = true;
+  failNextArray = true;
+  EXPECT_FALSE(section.startBuild(spec));
+  EXPECT_EQ(section.buildError(), Section::BuildError::OutOfMemory);
+  EXPECT_FALSE(section.isBuilding());
+  EXPECT_FALSE(section.file.isOpen());
+  EXPECT_FALSE(std::filesystem::exists(section.binTmpPath()));
+  EXPECT_EQ(css.ruleCount(), 0U);
+  spec.embeddedStyle = false;
+  Section restored(epub, 0, renderer);
+  EXPECT_TRUE(restored.loadSectionFile(spec));
 }
 
 }  // namespace

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -1,15 +1,53 @@
+#include <Arduino.h>
 #include <Epub/Page.h>
 #include <GfxRenderer.h>
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <new>
 #include <string>
 
 #define class struct
 #define private public
+#include "Epub/Section.h"
 #include "Epub/parsers/ChapterHtmlSlimParser.h"
 #undef private
 #undef class
+
+extern bool failPageSerialization;
+extern std::vector<std::string> collectedFootnotes;
+extern std::vector<std::string> laidOutWords;
+extern bool invalidateNextTextBlock;
+
+namespace {
+size_t failObjectSize = 0;
+bool failNextArray = false;
+}  // namespace
+
+void* operator new[](const size_t size, const std::nothrow_t&) noexcept {
+  if (std::exchange(failNextArray, false)) return nullptr;
+  try {
+    return ::operator new[](size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void* operator new(const size_t size, const std::nothrow_t&) noexcept {
+  if (size == failObjectSize) {
+    failObjectSize = 0;
+    failNextArray = false;
+    invalidateNextTextBlock = false;
+    return nullptr;
+  }
+  try {
+    return ::operator new(size);
+  } catch (...) {
+    return nullptr;
+  }
+}
 
 namespace {
 
@@ -36,10 +74,229 @@ class ChapterHtmlSlimParserTest : public ::testing::TestWithParam<const char*> {
                                0,
                                {},
                                nullptr,
-                               &cssParser};
+                               &cssParser,
+                               true};
 
-  void SetUp() override { parser.currentTextBlock = std::make_unique<ParsedText>(false); }
+  void SetUp() override {
+    ESP = {};
+    collectedFootnotes.clear();
+    laidOutWords.clear();
+    parser.currentTextBlock = std::make_unique<ParsedText>(false, false, false, BlockStyle{}, true);
+  }
+  void TearDown() override {
+    ESP = {};
+    failObjectSize = 0;
+    failPageSerialization = false;
+    parser.abortParse();
+    if (filepath != "unused.xhtml") std::filesystem::remove(filepath);
+  }
+  void writeHtml(const std::string& html) {
+    filepath = (std::filesystem::temp_directory_path() / "crossmux-parser-oom.xhtml").string();
+    std::ofstream(filepath) << html;
+  }
 };
+
+TEST_F(ChapterHtmlSlimParserTest, NoTouchKeepsFootnotesWithoutLinkStorage) {
+  parser.collectTouchLinks = false;
+  parser.currentTextBlock = std::make_unique<ParsedText>(false, false, false, BlockStyle{}, false);
+  const XML_Char* attributes[] = {"href", "#note-target", nullptr};
+  ChapterHtmlSlimParser::startElement(&parser, "a", attributes);
+  ChapterHtmlSlimParser::characterData(&parser, "1", 1);
+  ChapterHtmlSlimParser::endElement(&parser, "a");
+  ASSERT_EQ(parser.pendingFootnotes.size(), 1U);
+  EXPECT_STREQ(parser.pendingFootnotes[0].second.href, "#note-target");
+  EXPECT_EQ(parser.currentTextBlock->wordLinkIds.capacity(), 0U);
+  EXPECT_EQ(parser.currentTextBlock->linkTargets.capacity(), 0U);
+  size_t lines = 0;
+  EXPECT_TRUE(
+      parser.currentTextBlock->layoutAndExtractLines(renderer, 0, 400, [&](std::unique_ptr<TextBlock> line, uint32_t) {
+        EXPECT_EQ(line->takeLinkSpans().capacity(), 0U);
+        ++lines;
+        return true;
+      }));
+  EXPECT_EQ(lines, 1U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, StyledHeadroomFailureStopsCallbacksAndFinish) {
+  writeHtml("<html><body><p>first</p><p>second</p></body></html>");
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  ASSERT_TRUE(parser.beginParse());
+  ESP.maxAlloc = 16 * 1024 - 1;
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::OutOfMemory);
+  ChapterHtmlSlimParser::characterData(&parser, "ignored", 7);
+  EXPECT_TRUE(parser.currentTextBlock->isEmpty());
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, BasicLayoutDoesNotUseStyledHeadroomGate) {
+  parser.embeddedStyle = false;
+  ESP.freeHeap = 48 * 1024 - 1;
+  ESP.maxAlloc = 16 * 1024 - 1;
+  EXPECT_TRUE(parser.checkMemory());
+  EXPECT_FALSE(parser.allocationFailed());
+}
+
+TEST_F(ChapterHtmlSlimParserTest, HeadroomCrossedInsideCallbackAbortsExpat) {
+  writeHtml("<html><body><p>ignored</p></body></html>");
+  parser.completePageFn = [](auto, auto, auto, auto) { FAIL() << "Page emitted after OOM"; };
+  ASSERT_TRUE(parser.beginParse());
+  ESP.callsUntilLow = 2;
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::OutOfMemory);
+  EXPECT_EQ(XML_GetErrorCode(parser.xmlParser_), XML_ERROR_ABORTED);
+  EXPECT_EQ(parser.visibleTextOffset, 0U);
+  EXPECT_FALSE(parser.finishParse());
+}
+
+TEST_F(ChapterHtmlSlimParserTest, InvalidTextArenaFailsLayoutInsteadOfDroppingLine) {
+  parser.currentTextBlock->addWord("first", EpdFontFamily::REGULAR);
+  size_t lines = 0;
+  invalidateNextTextBlock = true;
+  EXPECT_FALSE(parser.currentTextBlock->layoutAndExtractLines(renderer, 0, 400, [&](auto, auto) {
+    ++lines;
+    return true;
+  }));
+  EXPECT_FALSE(invalidateNextTextBlock);
+  EXPECT_EQ(lines, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, TextBlockFailureInsideExpatStopsBeforeNextParagraph) {
+  writeHtml("<html><body><p>first</p><p>second</p></body></html>");
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  ASSERT_TRUE(parser.beginParse());
+  failObjectSize = sizeof(TextBlock);
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::OutOfMemory);
+  EXPECT_EQ(XML_GetErrorCode(parser.xmlParser_), XML_ERROR_ABORTED);
+  EXPECT_LT(parser.visibleTextOffset, 11U);
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, PageFailureStopsTableAndTrailingText) {
+  writeHtml("<html><body><table><tr><td>first</td><td>second</td></tr></table><p>tail</p></body></html>");
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  ASSERT_TRUE(parser.beginParse());
+  failObjectSize = sizeof(Page);
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::OutOfMemory);
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, LineWorkspaceFailureEmitsNothing) {
+  parser.currentTextBlock->addWord("first", EpdFontFamily::REGULAR);
+  parser.currentTextBlock->addWord("second", EpdFontFamily::REGULAR);
+  size_t lines = 0;
+  failNextArray = true;
+  EXPECT_FALSE(parser.currentTextBlock->layoutAndExtractLines(renderer, 0, 400, [&](auto, auto) {
+    ++lines;
+    return true;
+  }));
+  EXPECT_FALSE(failNextArray);
+  EXPECT_EQ(lines, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, TableLayoutFailureStopsBeforeTrailingText) {
+  writeHtml("<html><body><table><tr><td>first</td><td>second</td></tr></table><p>tail</p></body></html>");
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  ASSERT_TRUE(parser.beginParse());
+  failObjectSize = sizeof(TextBlock);
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::OutOfMemory);
+  EXPECT_EQ(XML_GetErrorCode(parser.xmlParser_), XML_ERROR_ABORTED);
+  EXPECT_LT(parser.visibleTextOffset, 15U);
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, SoftFlushFailureStopsLaterCallbacks) {
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  std::string text;
+  for (int i = 0; i < 330; ++i) text += "word ";
+  failObjectSize = sizeof(PageLine);
+  ChapterHtmlSlimParser::characterData(&parser, text.data(), text.size());
+  EXPECT_TRUE(parser.allocationFailed());
+  const auto offset = parser.visibleTextOffset;
+  ChapterHtmlSlimParser::characterData(&parser, "tail", 4);
+  EXPECT_EQ(parser.visibleTextOffset, offset);
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, BasicLongCallbackFlushesEarlyWithoutLosingTextOrRuby) {
+  parser.embeddedStyle = false;
+  parser.insideBody = true;
+  parser.completePageFn = [](auto, auto, auto, auto) {};
+  parser.inRuby = true;
+  std::string text;
+  for (int i = 0; i < 1200; ++i) text += "阅读";
+  ChapterHtmlSlimParser::characterData(&parser, text.data(), text.size());
+  EXPECT_TRUE(laidOutWords.empty());  // A ruby group cannot be split by soft flushing.
+  parser.inRuby = false;
+  ChapterHtmlSlimParser::characterData(&parser, " ", 1);
+  ASSERT_FALSE(parser.hasFailed());
+  EXPECT_LE(parser.currentTextBlock->size(), 320U);
+  EXPECT_FALSE(parser.currentTextBlock->firstLinePending);
+  ASSERT_TRUE(parser.finishParse());
+  std::string actual;
+  for (const auto& word : laidOutWords) actual += word;
+  EXPECT_EQ(actual, text);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, BasicLongCallbackKeepsWindowAndFootnoteOffsets) {
+  parser.embeddedStyle = false;
+  parser.insideBody = true;
+  size_t pages = 0;
+  uint32_t lastOffset = 0;
+  parser.completePageFn = [&](auto, auto, auto, uint32_t offset) {
+    EXPECT_GE(offset, lastOffset);
+    lastOffset = offset;
+    ++pages;
+  };
+  std::string text;
+  for (int i = 0; i < 1800; ++i) text += "word ";
+  ChapterHtmlSlimParser::characterData(&parser, text.data(), text.size());
+  ASSERT_FALSE(parser.hasFailed());
+  EXPECT_LE(parser.currentTextBlock->size(), 320U);
+  EXPECT_GT(pages, 0U);  // output happens inside this single callback
+  const XML_Char* attrs[] = {"href", "#note", nullptr};
+  ChapterHtmlSlimParser::startElement(&parser, "a", attrs);
+  ChapterHtmlSlimParser::characterData(&parser, "1", 1);
+  ChapterHtmlSlimParser::endElement(&parser, "a");
+  ASSERT_TRUE(parser.finishParse());
+  ASSERT_EQ(laidOutWords.size(), 1801U);
+  EXPECT_EQ(laidOutWords.back(), "1");
+  for (size_t i = 0; i < 1800; ++i) EXPECT_EQ(laidOutWords[i], "word");
+  ASSERT_EQ(collectedFootnotes.size(), 1U);
+  EXPECT_EQ(collectedFootnotes[0], "#note");
+}
+
+TEST_F(ChapterHtmlSlimParserTest, FinishFailureDoesNotEmitTrailingPage) {
+  writeHtml("<html><body>tail</body></html>");
+  size_t pages = 0;
+  parser.completePageFn = [&](auto, auto, auto, auto) { ++pages; };
+  ASSERT_TRUE(parser.beginParse());
+  ASSERT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::Done);
+  failObjectSize = sizeof(TextBlock);
+  EXPECT_FALSE(parser.finishParse());
+  EXPECT_TRUE(parser.allocationFailed());
+  EXPECT_EQ(pages, 0U);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, MalformedXmlAndMissingFileAreNotOutOfMemory) {
+  EXPECT_FALSE(parser.beginParse());
+  EXPECT_TRUE(parser.ioFailed());
+  EXPECT_FALSE(parser.allocationFailed());
+  writeHtml("<html><body><p>first</body></html>");
+  parser.completePageFn = [](auto, auto, auto, auto) {};
+  ASSERT_TRUE(parser.beginParse());
+  EXPECT_EQ(parser.parseStep(), ChapterHtmlSlimParser::ParseStatus::Error);
+  EXPECT_FALSE(parser.ioFailed());
+  EXPECT_FALSE(parser.allocationFailed());
+}
 
 TEST_P(ChapterHtmlSlimParserTest, KeepsCssVerticalAlignAndInternalLinkMetadata) {
   const char* verticalAlign = GetParam();
@@ -68,5 +325,156 @@ TEST_P(ChapterHtmlSlimParserTest, KeepsCssVerticalAlignAndInternalLinkMetadata) 
 
 INSTANTIATE_TEST_SUITE_P(CssVerticalAlign, ChapterHtmlSlimParserTest,
                          ::testing::Values("vertical-align: super", "vertical-align: sub"));
+
+class SectionMemoryTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<Epub> epub = std::make_shared<Epub>();
+  GfxRenderer renderer;
+  ReaderRenderSpec spec{};
+
+  void SetUp() override {
+    ESP = {};
+    epub->cachePath = (std::filesystem::temp_directory_path() / "crossmux-section-memory-test").string();
+    std::filesystem::remove_all(epub->cachePath);
+    std::filesystem::create_directories(epub->cachePath + "/html");
+    spec.viewportWidth = 160;
+    spec.viewportHeight = 64;
+    spec.lineCompression = 1;
+    spec.embeddedStyle = true;
+    spec.collectTouchLinks = false;
+  }
+  void TearDown() override {
+    failObjectSize = 0;
+    failNextArray = false;
+    failPageSerialization = false;
+    ESP = {};
+    std::filesystem::remove_all(epub->cachePath);
+  }
+  void writeHtml(const std::string& html) { std::ofstream(epub->cachePath + "/html/0.html") << html; }
+  void expectNoCache() {
+    EXPECT_FALSE(std::filesystem::exists(epub->cachePath + "/sections/0.bin"));
+    EXPECT_FALSE(std::filesystem::exists(epub->cachePath + "/sections/0.bin.part"));
+  }
+};
+
+TEST_F(SectionMemoryTest, OomAbandonsBuildAndBasicRetryPreservesBodyAndOffsets) {
+  std::string html = "<html><body><p id='start'>";
+  for (int i = 0; i < 400; ++i) html += "word" + std::to_string(i) + " ";
+  html += "</p></body></html>";
+  writeHtml(html);
+  uint32_t offset = 0;
+  {
+    Section section(epub, 0, renderer);
+    ASSERT_TRUE(section.startBuild(spec));
+    ASSERT_TRUE(section.buildSomeMore(1));
+    ASSERT_TRUE(section.isBuilding());
+    ASSERT_GT(section.pageCount, 1U);
+    offset = *section.getVisibleTextOffsetForPage(1);
+    ESP.freeHeap = 48 * 1024 - 1;
+    EXPECT_FALSE(section.buildSomeMore(1));
+    EXPECT_EQ(section.buildError(), Section::BuildError::OutOfMemory);
+    EXPECT_FALSE(section.isBuilding());
+  }
+  expectNoCache();  // Destructor must not commit a partial after failure.
+  laidOutWords.clear();
+  spec.embeddedStyle = false;
+  Section retry(epub, 0, renderer);
+  ASSERT_TRUE(retry.createSectionFile(spec));
+  ASSERT_EQ(laidOutWords.size(), 400U);
+  for (int i = 0; i < 400; ++i) EXPECT_EQ(laidOutWords[i], "word" + std::to_string(i));
+  const auto page = retry.getPageForVisibleTextOffset(offset);
+  ASSERT_TRUE(page.has_value());
+  EXPECT_LE(*retry.getVisibleTextOffsetForPage(*page), offset);
+  EXPECT_EQ(retry.findAnchor("start"), 0);
+  Section restored(epub, 0, renderer);
+  ASSERT_TRUE(restored.loadSectionFile(spec));
+  EXPECT_EQ(restored.getPageForVisibleTextOffset(offset), page);
+  spec.embeddedStyle = true;
+  EXPECT_FALSE(restored.loadSectionFile(spec));
+}
+
+TEST_F(SectionMemoryTest, ReclaimsCachesBeforeStartAndContinuation) {
+  std::string html = "<html><body>";
+  for (int i = 0; i < 500; ++i) html += "<p>word</p>";
+  html += "</body></html>";
+  writeHtml(html);
+  ESP.freeHeap = 40 * 1024;
+  renderer.fontCache.reclaimedBytes = 16 * 1024;
+  Section section(epub, 0, renderer);
+  ASSERT_TRUE(section.startBuild(spec));
+  EXPECT_EQ(renderer.fontCache.releases, 1);
+  ESP.freeHeap = 32 * 1024;
+  renderer.fontCache.reclaimedBytes = 24 * 1024;
+  ASSERT_TRUE(section.buildSomeMore(0));
+  EXPECT_EQ(renderer.fontCache.releases, 2);
+  EXPECT_TRUE(section.isBuildComplete());
+  EXPECT_EQ(section.buildError(), Section::BuildError::None);
+}
+
+TEST_F(SectionMemoryTest, TouchCapabilityInvalidatesCompleteAndPartialCaches) {
+  std::string html = "<html><body>";
+  for (int i = 0; i < 400; ++i) html += "<p>word</p>";
+  html += "</body></html>";
+  writeHtml(html);
+  for (bool partial : {false, true}) {
+    spec.collectTouchLinks = true;
+    {
+      Section section(epub, 0, renderer);
+      ASSERT_TRUE(section.startBuild(spec));
+      ASSERT_TRUE(section.buildSomeMore(partial ? 1 : 0));
+    }
+    Section restored(epub, 0, renderer);
+    ASSERT_TRUE(restored.loadSectionFile(spec));
+    EXPECT_EQ(restored.isPartial(), partial);
+    spec.collectTouchLinks = false;
+    EXPECT_FALSE(restored.loadSectionFile(spec));
+  }
+}
+
+TEST_F(SectionMemoryTest, LayoutOomAndWriteErrorNeverCommitCache) {
+  writeHtml("<html><body><p>first</p><p>second</p></body></html>");
+  for (bool oom : {false, true}) {
+    {
+      Section section(epub, 0, renderer);
+      ASSERT_TRUE(section.startBuild(spec));
+      if (oom)
+        failObjectSize = sizeof(TextBlock);
+      else
+        failPageSerialization = true;
+      EXPECT_FALSE(section.buildSomeMore(0));
+      EXPECT_EQ(section.buildError(), oom ? Section::BuildError::OutOfMemory : Section::BuildError::Io);
+      EXPECT_FALSE(section.isBuilding());
+      failPageSerialization = false;
+    }
+    expectNoCache();
+  }
+  writeHtml("<html><body><p>broken</body></html>");
+  Section section(epub, 0, renderer);
+  EXPECT_FALSE(section.createSectionFile(spec));
+  EXPECT_EQ(section.buildError(), Section::BuildError::InvalidData);
+  expectNoCache();
+}
+
+TEST_F(SectionMemoryTest, CssCacheOomIsReportedAndBasicBuildDoesNotHydrateCss) {
+  writeHtml("<html><body><p>text</p></body></html>");
+  CssParser css(epub->cachePath);
+  const auto cssPath = epub->cachePath + "/style.css";
+  std::ofstream(cssPath) << "p { margin-top: 20px; }";
+  HalFile source;
+  ASSERT_TRUE(Storage.openFileForRead("TEST", cssPath, source));
+  ASSERT_EQ(css.loadFromStream(source), CssParser::ParseResult::Complete);
+  ASSERT_TRUE(css.saveToCache(true));
+  css.clear();
+  epub->css = &css;
+  Section section(epub, 0, renderer);
+  failNextArray = true;
+  EXPECT_FALSE(section.startBuild(spec));
+  EXPECT_EQ(section.buildError(), Section::BuildError::OutOfMemory);
+  EXPECT_FALSE(failNextArray);
+  expectNoCache();
+  spec.embeddedStyle = false;
+  ASSERT_TRUE(section.createSectionFile(spec));
+  EXPECT_EQ(css.ruleCount(), 0U);
+}
 
 }  // namespace

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -2,6 +2,7 @@
 #include <Epub/Page.h>
 #include <GfxRenderer.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <filesystem>
 #include <fstream>
@@ -91,7 +92,8 @@ class ChapterHtmlSlimParserTest : public ::testing::TestWithParam<const char*> {
     if (filepath != "unused.xhtml") std::filesystem::remove(filepath);
   }
   void writeHtml(const std::string& html) {
-    filepath = (std::filesystem::temp_directory_path() / "crossmux-parser-oom.xhtml").string();
+    filepath = (std::filesystem::temp_directory_path() / ("crossmux-parser-oom-" + std::to_string(getpid()) + ".xhtml"))
+                   .string();
     std::ofstream(filepath) << html;
   }
 };
@@ -334,7 +336,10 @@ class SectionMemoryTest : public ::testing::Test {
 
   void SetUp() override {
     ESP = {};
-    epub->cachePath = (std::filesystem::temp_directory_path() / "crossmux-section-memory-test").string();
+    // CTest launches each case in a separate process when running in parallel.
+    epub->cachePath =
+        (std::filesystem::temp_directory_path() / ("crossmux-section-memory-test-" + std::to_string(getpid())))
+            .string();
     std::filesystem::remove_all(epub->cachePath);
     std::filesystem::create_directories(epub->cachePath + "/html");
     spec.viewportWidth = 160;

--- a/test/chapter_html_slim_parser/ParserLinkStubs.cpp
+++ b/test/chapter_html_slim_parser/ParserLinkStubs.cpp
@@ -15,6 +15,7 @@ bool isExplicitHyphen(uint32_t) { return false; }
 bool isSoftHyphen(uint32_t) { return false; }
 
 std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string&, bool) { return {}; }
+void Hyphenator::setPreferredLanguage(const std::string&) {}
 
 namespace BidiUtils {
 bool startsWithRtl(const char*, int) { return false; }
@@ -25,11 +26,18 @@ bool computeVisualWordOrder(const std::vector<std::string>& words, bool, std::ve
 }
 }  // namespace BidiUtils
 
-TextBlock::TextBlock(const std::vector<std::string>&, const std::vector<int16_t>&,
+std::vector<std::string> laidOutWords;
+bool invalidateNextTextBlock = false;
+
+TextBlock::TextBlock(const std::vector<std::string>& words, const std::vector<int16_t>&,
                      const std::vector<EpdFontFamily::Style>&, const std::vector<uint8_t>&,
                      const std::vector<uint16_t>&, const BlockStyle& blockStyle, std::vector<std::string> rubyTexts,
                      std::vector<LinkSpan> linkSpans)
-    : blockStyle(blockStyle), rubyTexts(std::move(rubyTexts)), linkSpans(std::move(linkSpans)) {}
+    : blockStyle(blockStyle), rubyTexts(std::move(rubyTexts)), linkSpans(std::move(linkSpans)) {
+  numWords = words.size();
+  isValid = !std::exchange(invalidateNextTextBlock, false);
+  laidOutWords.insert(laidOutWords.end(), words.begin(), words.end());
+}
 
 bool TextBlock::hasRuby() const { return false; }
 
@@ -42,8 +50,19 @@ bool ImageToFramebufferDecoder::validateAndStoreDimensions(int64_t, int64_t, Ima
   return false;
 }
 
-void Page::addFootnote(const char*, const char*) {}
+std::vector<std::string> collectedFootnotes;
+void Page::addFootnote(const char*, const char* href) { collectedFootnotes.emplace_back(href); }
 bool Page::addLink(const char*, int16_t, int16_t, int16_t, int16_t) { return true; }
+
+// Section tests exercise the real transaction/LUT paths; Page cache geometry
+// has its own tests using the real serializer in footnote_list_test.
+bool failPageSerialization = false;
+bool Page::serialize(HalFile& file) const { return !failPageSerialization && file.write(uint8_t{0}) == 1; }
+std::unique_ptr<Page> Page::deserialize(HalFile& file, bool) {
+  uint8_t value = 0;
+  if (file.read(&value, 1) != 1) return nullptr;
+  return std::make_unique<Page>();
+}
 
 void PageLine::render(GfxRenderer&, int, int, int) {}
 bool PageLine::serialize(HalFile&) { return false; }

--- a/test/chapter_html_slim_parser/stubs/Arduino.h
+++ b/test/chapter_html_slim_parser/stubs/Arduino.h
@@ -3,7 +3,16 @@
 #include <cstdint>
 
 struct EspHostStub {
-  uint32_t getFreeHeap() const { return UINT32_MAX; }
+  uint32_t freeHeap = UINT32_MAX;
+  uint32_t maxAlloc = UINT32_MAX;
+  mutable int callsUntilLow = -1;
+  uint32_t getFreeHeap() const {
+    if (callsUntilLow == 0) return 0;
+    if (callsUntilLow > 0) --callsUntilLow;
+    return freeHeap;
+  }
+  uint32_t getMinFreeHeap() const { return freeHeap; }
+  uint32_t getMaxAllocHeap() const { return maxAlloc; }
 };
 
 inline EspHostStub ESP;

--- a/test/chapter_html_slim_parser/stubs/Epub.h
+++ b/test/chapter_html_slim_parser/stubs/Epub.h
@@ -1,10 +1,28 @@
 #pragma once
 
+#include <HalStorage.h>
+
 #include <cstddef>
 #include <string>
 
+class CssParser;
+
 class Epub {
  public:
+  std::string cachePath;
+  CssParser* css = nullptr;
+  struct Item {
+    std::string href = "chapter.xhtml";
+    std::string anchor;
+    int spineIndex = 0;
+  };
+  const std::string& getCachePath() const { return cachePath; }
+  Item getSpineItem(int) const { return {}; }
+  Item getTocItem(int) const { return {}; }
+  int getTocIndexForSpineIndex(int) const { return -1; }
+  int getTocItemsCount() const { return 0; }
+  std::string getLanguage() const { return "en"; }
+  CssParser* getCssParser() const { return css; }
   template <typename Output>
   bool readItemContentsToStream(const std::string&, Output&, size_t, bool = false) const {
     return false;

--- a/test/chapter_html_slim_parser/stubs/FontCacheManager.h
+++ b/test/chapter_html_slim_parser/stubs/FontCacheManager.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <Arduino.h>
+class FontCacheManager {
+ public:
+  int releases = 0;
+  uint32_t reclaimedBytes = 0;
+  void releaseSdFontCaches() {
+    ++releases;
+    ESP.freeHeap += reclaimedBytes;
+    reclaimedBytes = 0;
+  }
+};

--- a/test/chapter_html_slim_parser/stubs/GfxRenderer.h
+++ b/test/chapter_html_slim_parser/stubs/GfxRenderer.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <EpdFontFamily.h>
+#include <FontCacheManager.h>
 
 #include <deque>
 #include <string>
 
 class GfxRenderer {
  public:
+  FontCacheManager fontCache;
+  FontCacheManager* getFontCacheManager() { return &fontCache; }
   int getScreenWidth() const { return 480; }
   int getScreenHeight() const { return 800; }
   int getLineHeight(int, float = 1.0f) const { return 16; }

--- a/test/chapter_html_slim_parser/stubs/HalStorage.h
+++ b/test/chapter_html_slim_parser/stubs/HalStorage.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <Arduino.h>
+
 #include <cstdint>
 #include <cstdio>
+#include <filesystem>
 #include <string>
 
 class HalFile {
@@ -22,6 +25,8 @@ class HalFile {
   size_t write(uint8_t byte) { return write(&byte, 1); }
   bool flush() { return file_ && std::fflush(file_) == 0; }
   bool seekCur(size_t offset) { return file_ && std::fseek(file_, static_cast<long>(offset), SEEK_CUR) == 0; }
+  bool seekSet(size_t offset) { return seek(offset); }
+  bool seek(size_t offset) { return file_ && std::fseek(file_, static_cast<long>(offset), SEEK_SET) == 0; }
   bool close() {
     if (!file_) return false;
     const bool ok = std::fclose(file_) == 0;
@@ -51,7 +56,11 @@ class HalStorage {
     return instance;
   }
   bool openFileForRead(const char*, const std::string& path, HalFile& file) { return file.open(path.c_str(), "rb"); }
-  bool openFileForWrite(const char*, const std::string& path, HalFile& file) { return file.open(path.c_str(), "wb"); }
+  bool openFileForWrite(const char*, const std::string& path, HalFile& file) { return file.open(path.c_str(), "w+b"); }
+  bool mkdir(const char* path) {
+    std::error_code error;
+    return std::filesystem::create_directories(path, error) || std::filesystem::exists(path);
+  }
   bool exists(const char* path) const {
     std::FILE* file = std::fopen(path, "rb");
     if (!file) return false;
@@ -64,5 +73,6 @@ class HalStorage {
 
 #define Storage HalStorage::getInstance()
 
+inline uint32_t micros() { return 0; }
 inline uint32_t millis() { return 0; }
 inline void delay(uint32_t) {}

--- a/test/chapter_html_slim_parser/stubs/Logging.h
+++ b/test/chapter_html_slim_parser/stubs/Logging.h
@@ -1,4 +1,5 @@
 #pragma once
+#define LOG_INF(...) ((void)0)
 
 #define LOG_DBG(...) ((void)0)
 #define LOG_ERR(...) ((void)0)

--- a/test/footnote_list/FootnoteListTest.cpp
+++ b/test/footnote_list/FootnoteListTest.cpp
@@ -145,6 +145,7 @@ TEST_F(PageFootnoteOomTest, KeepsBodyAndSkipsFootnotesWhenAllocationFails) {
     ASSERT_EQ(output.write(footnotes[i].number, sizeof(footnotes[i].number)), sizeof(footnotes[i].number));
     ASSERT_EQ(output.write(footnotes[i].href, sizeof(footnotes[i].href)), sizeof(footnotes[i].href));
   }
+  serialization::writePod(output, static_cast<uint16_t>(0));  // links
   const size_t markerPosition = output.position();
   const uint32_t marker = 0x1234ABCD;
   serialization::writePod(output, marker);
@@ -165,4 +166,46 @@ TEST_F(PageFootnoteOomTest, KeepsBodyAndSkipsFootnotesWhenAllocationFails) {
   uint32_t restoredMarker = 0;
   ASSERT_TRUE(serialization::readPod(input, restoredMarker));
   EXPECT_EQ(restoredMarker, marker);
+}
+
+TEST_F(PageFootnoteOomTest, NoTouchSkipsLinksWithoutAllocatingAndKeepsFootnotes) {
+  HalFile output;
+  ASSERT_TRUE(Storage.openFileForWrite("TEST", "/page.bin", output));
+  Page original;
+  original.addFootnote("1", "#note");
+  ASSERT_TRUE(original.addLink("#note", 1, 2, 30, 40));
+  ASSERT_TRUE(original.serialize(output));
+  const auto end = output.position();
+  serialization::writePod(output, static_cast<uint32_t>(0x1234ABCD));
+  output.close();
+  HalFile input;
+  ASSERT_TRUE(Storage.openFileForRead("TEST", "/page.bin", input));
+  lastArrayAllocationSize = 0;
+  auto page = Page::deserialize(input, false);
+  const size_t allocated = lastArrayAllocationSize;
+  ASSERT_NE(page, nullptr);
+  EXPECT_EQ(allocated, sizeof(FootnoteEntry));
+  EXPECT_EQ(page->links.size(), 0U);
+  ASSERT_EQ(page->footnotes.size(), 1U);
+  EXPECT_STREQ(page->footnotes[0].href, "#note");
+  EXPECT_EQ(input.position(), end);
+}
+
+TEST_F(PageFootnoteOomTest, RejectsTruncatedAndOversizedLinksEvenWithoutTouch) {
+  for (const uint16_t count : {uint16_t{1}, uint16_t{33}}) {
+    HalFile output;
+    ASSERT_TRUE(Storage.openFileForWrite("TEST", "/page.bin", output));
+    serialization::writePod(output, uint16_t{0});  // elements
+    serialization::writePod(output, uint16_t{0});  // footnotes
+    serialization::writePod(output, count);
+    serialization::writePod(output, uint8_t{0});  // truncated link
+    output.close();
+    HalFile input;
+    ASSERT_TRUE(Storage.openFileForRead("TEST", "/page.bin", input));
+    lastArrayAllocationSize = 0;
+    auto page = Page::deserialize(input, false);
+    const auto allocated = lastArrayAllocationSize;
+    EXPECT_EQ(page, nullptr);
+    EXPECT_EQ(allocated, 0U);
+  }
 }

--- a/test/footnote_list/FootnoteListTest.cpp
+++ b/test/footnote_list/FootnoteListTest.cpp
@@ -2,6 +2,7 @@
 #include <GfxRenderer.h>
 #include <Serialization.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <atomic>
 #include <cstdlib>
@@ -98,7 +99,8 @@ class PageFootnoteOomTest : public ::testing::Test {
  protected:
   void SetUp() override {
     static std::atomic<unsigned> serial{0};
-    root_ = std::filesystem::temp_directory_path() / ("crossmux-footnote-oom-" + std::to_string(serial++));
+    root_ = std::filesystem::temp_directory_path() /
+            ("crossmux-footnote-oom-" + std::to_string(getpid()) + "-" + std::to_string(serial++));
     std::error_code error;
     std::filesystem::remove_all(root_, error);
     ASSERT_TRUE(std::filesystem::create_directories(root_, error));

--- a/test/page_link/PageLinkTest.cpp
+++ b/test/page_link/PageLinkTest.cpp
@@ -1,6 +1,59 @@
 #include <Epub/Epub/PageLink.h>
 #include <gtest/gtest.h>
 
+#include <new>
+#include <utility>
+
+namespace {
+bool failNextAllocation = false;
+size_t allocatedBytes = 0;
+}  // namespace
+
+void* operator new[](const size_t size, const std::nothrow_t&) noexcept {
+  allocatedBytes = size;
+  if (std::exchange(failNextAllocation, false)) return nullptr;
+  try {
+    return ::operator new[](size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+TEST(PageLinkTest, GrowsFromOneToBoundWithoutLosingEntries) {
+  PageLinkList links;
+  for (size_t i = 0; i < PageLinkList::MAX_SIZE; ++i) {
+    allocatedBytes = 0;
+    auto* entry = links.append();
+    const auto bytes = allocatedBytes;
+    ASSERT_NE(entry, nullptr);
+    entry->x = i;
+    const bool grows = i == 0 || (i & (i - 1)) == 0;
+    EXPECT_EQ(bytes, grows ? sizeof(PageLink) * (i == 0 ? 1 : i * 2) : 0);
+    for (size_t j = 0; j <= i; ++j) EXPECT_EQ(links[j].x, j);
+  }
+  EXPECT_EQ(links.append(), nullptr);
+}
+
+TEST(PageLinkTest, FailedGrowthPreservesLinksAndStopsAllocatingUntilClear) {
+  PageLinkList links;
+  ASSERT_NE(links.append(), nullptr);
+  links[0].x = 42;
+  failNextAllocation = true;
+  auto* next = links.append();
+  ASSERT_EQ(next, nullptr);
+  ASSERT_TRUE(links.allocationFailed());
+  EXPECT_EQ(links.size(), 1U);
+  EXPECT_EQ(links[0].x, 42);
+  PageLinkList moved;
+  moved = std::move(links);
+  allocatedBytes = 0;
+  EXPECT_EQ(moved.append(), nullptr);
+  EXPECT_EQ(allocatedBytes, 0U);
+  EXPECT_EQ(moved[0].x, 42);
+  moved.clear();
+  EXPECT_NE(moved.append(), nullptr);
+}
+
 TEST(PageLinkTest, HitAreaIncludesFingerSlopAndMinimumWidth) {
   PageLink link;
   link.x = 100;

--- a/test/reader_build_failure/CMakeLists.txt
+++ b/test/reader_build_failure/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+add_test(NAME ReaderBuildFailureTest
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_reader_failure.py ${CMAKE_CXX_COMPILER}
+)

--- a/test/reader_build_failure/check_reader_failure.py
+++ b/test/reader_build_failure/check_reader_failure.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+# Compile the production method with lightweight collaborators, not a second
+# implementation of the retry policy. This does not model the full Activity lifecycle.
+repo = Path(__file__).resolve().parents[2]
+s = (repo / 'src/activities/reader/EpubReaderActivity.cpp').read_text()
+method = s[s.index('bool EpubReaderActivity::handleBuildFailure('):s.index('bool EpubReaderActivity::buildTickHeapGate(')]
+# Compile the actual production method, with only its collaborators stubbed.
+prelude = r'''
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+#include <cstdio>
+#define LOG_ERR(...) ((void)0)
+struct { int embeddedStyle = 1; } SETTINGS;
+struct { unsigned getFreeHeap(){return 65536;} unsigned getMinFreeHeap(){return 65536;} unsigned getMaxAllocHeap(){return 32768;} } ESP;
+struct Css { int clears=0; void clear(){++clears;} };
+struct Epub { Css css; Css* getCssParser(){return &css;} };
+struct Cache { int releases=0; void releaseSdFontCaches(){++releases;} };
+struct Renderer { Cache cache; Cache* getFontCacheManager(){return &cache;} };
+struct Section {
+  enum class BuildError { None, OutOfMemory, InvalidData, Io };
+  BuildError error = BuildError::OutOfMemory;
+  BuildError buildError(){return error;}
+  void abandonBuild(){}
+};
+struct EpubReaderActivity {
+  int failedBuildSpine_=-1, currentSpineIndex=5, renderedSpineIndex_=5, cachedSpineIndex=5, nextPageNumber=7;
+  bool stylesDisabledForSession_=false, pendingPercentJump=false, buildHeapPaused=true, buildPopupPending=true;
+  bool automaticPageTurnActive=true;
+  float pendingSpineProgress=0;
+  std::optional<uint16_t> pendingPageJump;
+  std::optional<uint32_t> pendingOffsetJump, currentPageVisibleOffset=123, cachedVisibleTextOffset=456;
+  std::string pendingAnchor;
+  std::unique_ptr<Section> section=std::make_unique<Section>();
+  std::unique_ptr<Epub> epub=std::make_unique<Epub>();
+  Renderer renderer;
+  std::vector<int> currentPageLinks{1}, currentPageFootnotes{1};
+  int updates=0, discards=0, deferredClears=0;
+  void clearDeferredReposition(){++deferredClears;}
+  void discardOverlayPage(){++discards;}
+  void requestUpdate(){++updates;}
+  bool handleBuildFailure(const char* stage, Section::BuildError error);
+};
+'''
+checks = r'''
+int main() {
+  for (auto error : {Section::BuildError::Io, Section::BuildError::InvalidData}) {
+    EpubReaderActivity r; r.section->error=error;
+    assert(!r.handleBuildFailure("error", error)); assert(!r.stylesDisabledForSession_);
+    assert(!r.section && r.failedBuildSpine_==5 && !r.automaticPageTurnActive);
+    assert(r.renderer.cache.releases==1 && r.currentPageLinks.empty() && r.currentPageFootnotes.empty());
+    assert(!r.handleBuildFailure("repeat", Section::BuildError::OutOfMemory)); assert(r.renderer.cache.releases==1 && r.discards==1);
+  }
+  EpubReaderActivity r;
+#ifdef BOARD_HAS_PSRAM
+  assert(!r.handleBuildFailure("oom", Section::BuildError::OutOfMemory)); assert(!r.stylesDisabledForSession_);
+#else
+  assert(r.handleBuildFailure("oom", Section::BuildError::OutOfMemory)); assert(r.stylesDisabledForSession_);
+  assert(r.pendingOffsetJump==123 && !r.pendingPageJump && r.nextPageNumber==0 && r.updates==1);
+  r.section=std::make_unique<Section>();
+  assert(!r.handleBuildFailure("basic oom", Section::BuildError::OutOfMemory)); assert(r.failedBuildSpine_==5 && r.updates==1);
+  assert(r.renderer.cache.releases==2);
+  assert(!r.handleBuildFailure("repeat", Section::BuildError::OutOfMemory)); assert(r.renderer.cache.releases==2);
+  for (int target=0; target<5; ++target) {
+    EpubReaderActivity p;
+    switch (target) {
+      case 0: p.pendingAnchor="note"; break;
+      case 1: p.pendingPercentJump=true; p.pendingSpineProgress=0.75f; break;
+      case 2: p.pendingOffsetJump=0; break;
+      case 3: p.pendingPageJump=UINT16_MAX; break;
+      case 4: p.renderedSpineIndex_=4; break;
+    }
+    assert(p.handleBuildFailure("target", Section::BuildError::OutOfMemory));
+    switch (target) {
+      case 0: assert(p.pendingAnchor=="note" && !p.pendingOffsetJump); break;
+      case 1: assert(p.pendingPercentJump && p.pendingSpineProgress==0.75f && !p.pendingOffsetJump); break;
+      case 2: assert(p.pendingOffsetJump==0); break;
+      case 3: assert(p.pendingPercentJump && p.pendingSpineProgress==1.f && !p.pendingPageJump); break;
+      case 4: assert(p.pendingOffsetJump==456); break;
+    }
+  }
+#endif
+  SETTINGS.embeddedStyle=0;
+  EpubReaderActivity basic; assert(!basic.handleBuildFailure("disabled", Section::BuildError::OutOfMemory)); assert(!basic.stylesDisabledForSession_);
+  SETTINGS.embeddedStyle=1;
+  EpubReaderActivity noSection; noSection.section.reset();
+#ifdef BOARD_HAS_PSRAM
+  assert(!noSection.handleBuildFailure("allocation", Section::BuildError::OutOfMemory));
+#else
+  assert(noSection.handleBuildFailure("allocation", Section::BuildError::OutOfMemory));
+  assert(noSection.pendingOffsetJump==123 && noSection.updates==1 && noSection.failedBuildSpine_==-1);
+  assert(!noSection.handleBuildFailure("basic allocation", Section::BuildError::OutOfMemory));
+  assert(noSection.failedBuildSpine_==5 && noSection.updates==1);
+  assert(!noSection.handleBuildFailure("repeat allocation", Section::BuildError::OutOfMemory));
+  assert(noSection.renderer.cache.releases==2 && noSection.discards==2);
+#endif
+  for (auto error : {Section::BuildError::Io, Section::BuildError::InvalidData}) {
+    EpubReaderActivity empty; empty.section.reset();
+    assert(!empty.handleBuildFailure("empty error", error));
+    assert(!empty.stylesDisabledForSession_ && empty.failedBuildSpine_==5);
+  }
+  puts("Reader failure transition checks passed");
+}
+'''
+with tempfile.TemporaryDirectory(prefix="reader-failure-") as directory:
+    root = Path(directory)
+    source = root / 'reader-failure-check.cpp'
+    source.write_text(prelude + method + checks)
+    for name, flags in [('c3', []), ('psram', ['-DBOARD_HAS_PSRAM'])]:
+        binary = root / name
+        subprocess.run([sys.argv[1], '-std=c++20', *flags, str(source), '-o', str(binary)], check=True)
+        subprocess.run([str(binary)], check=True)

--- a/test/sd_card_font_cache_format/CMakeLists.txt
+++ b/test/sd_card_font_cache_format/CMakeLists.txt
@@ -1,3 +1,17 @@
 add_executable(sd_card_font_cache_format_test SdCardFontCacheFormatTest.cpp SdCardFontAlgorithmsTest.cpp)
 target_link_libraries(sd_card_font_cache_format_test PRIVATE crosspoint_test_common GTest::gtest_main)
 gtest_discover_tests(sd_card_font_cache_format_test)
+
+add_executable(SdCardFontMemoryTest
+  SdCardFontMemoryTest.cpp
+  ${REPO_ROOT}/lib/EpdFont/SdCardFont.cpp
+  ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+)
+target_include_directories(SdCardFontMemoryTest PRIVATE
+  ${REPO_ROOT}/test/chapter_html_slim_parser/stubs
+  ${REPO_ROOT}/lib/EpdFont
+  ${REPO_ROOT}/lib/Memory
+  ${REPO_ROOT}/lib/Utf8
+)
+target_link_libraries(SdCardFontMemoryTest PRIVATE crosspoint_test_common GTest::gtest_main)
+gtest_discover_tests(SdCardFontMemoryTest)

--- a/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
+++ b/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
@@ -3,6 +3,7 @@
 #include <EpdFontData.h>
 #include <SdCardFontCache.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <cstring>
 #include <deque>
@@ -39,7 +40,9 @@ void* operator new[](size_t size, const std::nothrow_t&) noexcept {
 class SdCardFontMemoryTest : public ::testing::Test {
  protected:
   SdCardFont font;
-  std::string path = (std::filesystem::temp_directory_path() / "crossmux-font-memory.cpfont").string();
+  std::string path =
+      (std::filesystem::temp_directory_path() / ("crossmux-font-memory-" + std::to_string(getpid()) + ".cpfont"))
+          .string();
   void SetUp() override {
     ESP = {};
     font.loaded_ = true;

--- a/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
+++ b/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
@@ -1,0 +1,139 @@
+#include <Arduino.h>
+#include <EpdFont.h>
+#include <EpdFontData.h>
+#include <SdCardFontCache.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <new>
+#include <string>
+#include <vector>
+
+#define private public
+#include <SdCardFont.h>
+#undef private
+
+namespace SdCardFontCache {
+bool isValidFor(const char*, size_t*) { return false; }
+bool readAt(size_t, void*, size_t, size_t) { return false; }
+}  // namespace SdCardFontCache
+
+namespace {
+size_t arrayAllocations = 0;
+size_t failArraySize = 0;
+}  // namespace
+void* operator new[](size_t size, const std::nothrow_t&) noexcept {
+  ++arrayAllocations;
+  if (size == failArraySize) return nullptr;
+  try {
+    return ::operator new[](size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+class SdCardFontMemoryTest : public ::testing::Test {
+ protected:
+  SdCardFont font;
+  std::string path = (std::filesystem::temp_directory_path() / "crossmux-font-memory.cpfont").string();
+  void SetUp() override {
+    ESP = {};
+    font.loaded_ = true;
+    std::strncpy(font.filePath_, path.c_str(), sizeof(font.filePath_) - 1);
+    auto& style = font.styles_[0];
+    style.present = true;
+    style.header.intervalCount = 1;
+    style.header.glyphCount = 2;
+    style.fullIntervals = new EpdUnicodeInterval[1]{{'A', 'B', 0}};
+    style.bitmapFileOffset = 2 * sizeof(EpdGlyph);
+    font.applyGlyphMissCallback(0);
+    style.epdFont.data = &style.stubData;
+    EpdGlyph glyphs[2]{};
+    glyphs[0].advanceX = 9;
+    glyphs[1].advanceX = 13;
+    glyphs[0].dataLength = glyphs[1].dataLength = 16;
+    glyphs[1].dataOffset = 16;
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char*>(glyphs), sizeof(glyphs));
+    const char bitmaps[32] = {};
+    file.write(bitmaps, sizeof(bitmaps));
+    arrayAllocations = 0;
+  }
+  void TearDown() override {
+    failArraySize = 0;
+    ESP = {};
+    std::filesystem::remove(path);
+  }
+};
+
+TEST_F(SdCardFontMemoryTest, LowBudgetSkipsAllPrewarmAllocationsAndKeepsMetrics) {
+  ESP.freeHeap = 16 * 1024;
+  ESP.maxAlloc = 8 * 1024;
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(font.buildAdvanceTable("AB", 1), SdCardFont::PREWARM_SKIPPED);
+    EXPECT_EQ(font.prewarm("AB", 1, false, false), SdCardFont::PREWARM_SKIPPED);
+  }
+  EXPECT_EQ(arrayAllocations, 0U);
+  EXPECT_EQ(font.getAdvanceOrLoad('A', 0), 9);
+  EXPECT_EQ(font.getAdvanceOrLoad('B', 0), 13);
+  ESP = {};
+  EXPECT_EQ(font.buildAdvanceTable("AB", 1), 0);
+  EXPECT_EQ(font.getAdvance('A', 0), 9);
+  EXPECT_EQ(font.getAdvance('B', 0), 13);
+}
+
+TEST_F(SdCardFontMemoryTest, MiniGrowthFailurePreservesOldGlyphsAndBitmap) {
+  ASSERT_EQ(font.prewarm("A", 1, false, false), 1);  // fixture has no replacement glyph
+  const auto* data = font.styles_[0].epdFont.data;
+  const auto* bitmap = data->bitmap;
+  const auto* glyph = data->glyph;
+  ASSERT_EQ(data->intervalCount, 1U);
+  failArraySize = 2 * sizeof(EpdGlyph);
+  EXPECT_LT(font.prewarm("AB", 1, false, false), 0);
+  EXPECT_EQ(font.styles_[0].epdFont.data, data);
+  EXPECT_EQ(data->bitmap, bitmap);
+  EXPECT_EQ(data->glyph, glyph);
+  EXPECT_EQ(data->glyph[0].advanceX, 9);
+  EXPECT_EQ(data->intervalCount, 1U);
+}
+
+TEST_F(SdCardFontMemoryTest, AdvanceGrowthFailurePreservesOldTable) {
+  ASSERT_EQ(font.buildAdvanceTable("A", 1), 0);
+  auto* table = font.advanceTable_[0];
+  const SdCardFont::AdvanceEntry entry{'B', 13};
+  failArraySize = 2 * sizeof(SdCardFont::AdvanceEntry);
+  font.mergeIntoAdvanceTable(0, &entry, 1);
+  EXPECT_EQ(font.advanceTable_[0], table);
+  EXPECT_EQ(font.getAdvance('A', 0), 9);
+  EXPECT_EQ(font.getAdvanceOrLoad('B', 0), 13);
+}
+
+TEST_F(SdCardFontMemoryTest, PeakBudgetRejectsMiniGrowthBeforeAllocatingAndKeepsOldCache) {
+  ASSERT_EQ(font.prewarm("A", 1, false, false), 1);  // fixture has no replacement glyph
+  const uint32_t cps[] = {'A', 'B'};
+  auto* bitmap = font.styles_[0].miniBitmap;
+  ESP.freeHeap = 16 * 1024 + 16;
+  ESP.maxAlloc = 8 * 1024 + 16;
+  arrayAllocations = 0;
+  EXPECT_EQ(font.prewarmStyle(0, cps, 2, false, false), SdCardFont::PREWARM_SKIPPED);
+  EXPECT_EQ(font.styles_[0].miniBitmap, bitmap);
+  // The optional union can fit; the larger combined replacement peak cannot.
+  EXPECT_LE(arrayAllocations, 1U);
+}
+
+TEST_F(SdCardFontMemoryTest, ReleasingResidentCachesClearsPublishedLigaturePointers) {
+  auto& style = font.styles_[0];
+  style.ligaturePairs = new EpdLigaturePair[1]{};
+  style.stubData.ligaturePairs = style.miniData.ligaturePairs = style.ligaturePairs;
+  style.stubData.ligaturePairCount = style.miniData.ligaturePairCount = 1;
+  font.releaseResidentCaches();
+  EXPECT_EQ(style.stubData.ligaturePairs, nullptr);
+  EXPECT_EQ(style.miniData.ligaturePairs, nullptr);
+  EXPECT_EQ(style.stubData.ligaturePairCount, 0);
+  EXPECT_EQ(style.epdFont.data, &style.stubData);
+  EXPECT_NE(SdCardFont::onGlyphMiss(&font.overflowCtx_[0], 'B'), nullptr);
+  EXPECT_EQ(font.getAdvanceOrLoad('B', 0), 13);
+}

--- a/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
+++ b/test/sd_card_font_cache_format/SdCardFontMemoryTest.cpp
@@ -24,10 +24,11 @@ bool readAt(size_t, void*, size_t, size_t) { return false; }
 namespace {
 size_t arrayAllocations = 0;
 size_t failArraySize = 0;
+size_t failArrayAt = 0;
 }  // namespace
 void* operator new[](size_t size, const std::nothrow_t&) noexcept {
   ++arrayAllocations;
-  if (size == failArraySize) return nullptr;
+  if (size == failArraySize || arrayAllocations == failArrayAt) return nullptr;
   try {
     return ::operator new[](size);
   } catch (...) {
@@ -64,6 +65,7 @@ class SdCardFontMemoryTest : public ::testing::Test {
   }
   void TearDown() override {
     failArraySize = 0;
+    failArrayAt = 0;
     ESP = {};
     std::filesystem::remove(path);
   }
@@ -98,6 +100,37 @@ TEST_F(SdCardFontMemoryTest, MiniGrowthFailurePreservesOldGlyphsAndBitmap) {
   EXPECT_EQ(data->glyph, glyph);
   EXPECT_EQ(data->glyph[0].advanceX, 9);
   EXPECT_EQ(data->intervalCount, 1U);
+}
+
+TEST_F(SdCardFontMemoryTest, EveryReplacementAllocationFailureKeepsPublishedCache) {
+  ASSERT_EQ(font.prewarm("A", 1, false, false), 1);
+  auto& style = font.styles_[0];
+  const auto* data = style.epdFont.data;
+  const auto* intervals = data->intervals;
+  const auto* glyphs = data->glyph;
+  const auto* bitmap = data->bitmap;
+  const uint32_t cps[] = {'A', 'B'};
+  // Union first, then replacement intervals, glyphs, bitmap and mappings.
+  for (size_t allocation = 2; allocation <= 5; ++allocation) {
+    SCOPED_TRACE(allocation);
+    arrayAllocations = 0;
+    failArrayAt = allocation;
+    EXPECT_LT(font.prewarmStyle(0, cps, 2, false, false), 0);
+    EXPECT_EQ(arrayAllocations, allocation);  // No later allocations after failure.
+    EXPECT_EQ(style.epdFont.data, data);
+    EXPECT_EQ(data->intervals, intervals);
+    EXPECT_EQ(data->glyph, glyphs);
+    EXPECT_EQ(data->bitmap, bitmap);
+    EXPECT_EQ(data->intervalCount, 1U);
+    EXPECT_EQ(data->glyph[0].advanceX, 9);
+  }
+  failArrayAt = 0;
+  EXPECT_EQ(font.prewarmStyle(0, cps, 2, false, false), 0);
+  EXPECT_EQ(style.miniGlyphCount, 2U);
+  EXPECT_EQ(style.miniGlyphs[1].advanceX, 13);
+  arrayAllocations = 0;
+  for (int batch = 0; batch < 3; ++batch) EXPECT_EQ(font.prewarmStyle(0, cps, 2, false, false), 0);
+  EXPECT_EQ(arrayAllocations, 0U);
 }
 
 TEST_F(SdCardFontMemoryTest, AdvanceGrowthFailurePreservesOldTable) {


### PR DESCRIPTION
## Summary

On devices without PSRAM, EPUB indexing could spend scarce heap on touch-only links and optional font prewarm, then continue after required layout allocations failed. This change removes touch-link allocations on button-only devices, bounds optional cache growth, and stops failed builds before they can be published. A no-PSRAM reader may retry once per session with embedded CSS disabled, preserving the selected font and visible text position.

This is a **phase-closing Draft PR**, not a claim that the original hardware issue is fully resolved. Ordinary reopening of the reported book still failed in the preceding verified candidate; the session-dependent memory difference remains under investigation.

Changes:
- Propagate touch capability through the render spec and cache key; retain button footnotes and navigation. Grow touch link storage on demand without PSRAM.
- Keep the constrained 320-token soft-flush window for basic layout, preserve Ruby groups and text offsets, and propagate required allocation/write failures.
- Budget optional font prewarm while replacement buffers and old caches coexist; preserve old data when growth allocations fail and retain on-demand reads.
- Centralize reader failure cleanup and Section build resource ownership. Explicit error propagation also covers failure to allocate the Section object itself.
- Upgrade complete section cache versions to 64/65 and partial versions to 218/217. Old or capability-mismatched section caches rebuild; book/font formats are unchanged.

## Validation

- 496 host checks passed with `ctest -j8`, including parser/Section fault injection, cache/link behavior, font replacement failures and reader retry policy. The 32 filesystem/memory cases also passed 20 parallel repetitions each (640 executions). Commit `8d373d3b` isolates their temporary paths by process, fixing the CI race in which one case removed another case's cache. The latest GitHub `unit-tests` job passed.
- clang-format checks and `git diff --check` passed.
- `default`, `simulator_x3` and `murphy_m4` builds passed. Hardware builds report the existing WebSockets `NetworkClient::flush()` deprecation warning.
- Host cache digest tests use serialization stubs; the reader policy check compiles the actual method with collaborator stubs. Neither establishes pixel equivalence or full device-lifecycle behavior.
- New X4 candidate: 5,905,008 bytes, SHA256 `e64b85aa5c8b0f297526a75cdcf66c143211ad7a753ee9ba0bf0b0d9b9cd3da3`. Application-only flash and hash verification succeeded; X4 boot and WenKai 18 Flash font source were observed. New-candidate reading/visual acceptance is still in progress.

## Known limitation / acceptance

The preceding candidate was verified by application readback. With the reported Jobs biography and WenKai 18 from Flash, ordinary reopening at spine 41 failed in basic layout: 2,672 bytes required for 334 tokens, largest free block 2,036 bytes. After a commanded reset, the same firmware completed all 11 pages, restored visible offset 390/page 2 and continued into spine 42. Free heap after CSS-retry cleanup differed by 19,052 bytes between those sessions. Network/standby lifetime is a hypothesis, not a confirmed cause or a change in this PR.

X3, SD-direct font mode, cold-cache and full visual/position acceptance remain separate and incomplete. No font/size/global-setting replacement, automatic basic-layout retry loop, standby/network change or automatic reboot is introduced. Keep this PR draft pending review and the outstanding device work; it does not close the original issue.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback or PDF feature.
- Existing CrossMux indexing reproduces the reported constrained-memory failure; no claim is made about all other forks.
- SDK/HAL, bootloader, OTA and recovery sources are untouched.

## Additional Context

Commits separate the established memory fix, resource ownership cleanup, naming-only cleanup, Section allocation failure correction and checkpoint documentation. Optional prewarm trades speed for heap headroom; no quantified general memory-saving claim is made beyond the documented allocation mechanisms. Local firmware images, the original book and raw device logs are excluded.

### AI Usage

YES — implemented and reviewed with Codex; hardware visual acceptance requires the operator.
