### PR TITLE
feat: enable BLE in all hardware builds

### DIFF
--- a/docs/engineering/build-system.md
+++ b/docs/engineering/build-system.md
@@ -53,11 +53,15 @@ shared X3/X4 firmware with runtime device detection. The path-filtered Hardware
 CI workflow builds all four simulators and all seven S3 environments when
 hardware-sensitive files change, and can also be started manually.
 
-Bluetooth Page Turner Beta is compiled only into these seven S3 development and
-`*_nightly` environments. C3, release-candidate, stable, and `gh_release*`
-environments do not link the BLE host. Sticky and eego A4 use the custom-core
-controller-only NimBLE configuration; X4 Pro, X4 Classic, and PaperMono retain
-their prebuilt `dio_opi` core so the TinyUSB MSC component graph remains intact.
+Bluetooth Page Turner Beta is compiled into every hardware environment,
+including development, Nightly, release-candidate, stable, and slim builds.
+The runtime Bluetooth switch defaults to off; native simulators use SDK stubs.
+C3 environments inherit the internal-RAM and Flash-controller configuration
+from `c3_hardware`. S3 hardware profiles inherit the PSRAM and IPC configuration.
+Sticky and eego A4 use the custom-core controller-only NimBLE configuration;
+the other five S3 targets retain their prebuilt `dio_opi` core so the TinyUSB
+MSC component graph remains intact. See [C3 Bluetooth](c3-bluetooth.md) for
+memory gates, validation results, and remaining hardware acceptance work.
 
 The SDK's obsolete passkey callback is removed only from a generated source copy
 under `$BUILD_DIR/ble-compat`; the SDK and NimBLE dependency sources are never

--- a/docs/engineering/c3-bluetooth.md
+++ b/docs/engineering/c3-bluetooth.md
@@ -1,8 +1,10 @@
-# ESP32-C3 BLE page-turner candidate
+# ESP32-C3 BLE page-turner support
 
-The shared X3/X4 firmware has an **opt-in** C3 BLE profile. `default`, release,
-RC and slim builds remain BLE-off; the saved Bluetooth switch also defaults to
-off. X4 users have confirmed pairing, physical page/menu keys, chapter changes,
+All hardware firmware builds include BLE support, including the shared X3/X4
+`default`, release, RC and slim profiles. Compilation makes Bluetooth available
+in settings; the saved Bluetooth switch still defaults to **off**. Native
+simulators retain the SDK stub because they have no BLE radio backend.
+X4 users have confirmed pairing, physical page/menu keys, chapter changes,
 alternating EPUBs and subsequent reconnection. This is not X3 hardware acceptance
 or completion of the quantitative endurance matrix below.
 
@@ -39,22 +41,11 @@ reconnect loop, SDK public API, persistent setting or reader menu is introduced.
 
 ## Reproducible build
 
-Add this local-only environment to ignored `platformio.local.ini`:
-
-```ini
-[env:c3_ble_probe]
-extends = env:default
-lib_deps = ${c3_ble.lib_deps}
-extra_scripts = ${c3_ble.extra_scripts}
-custom_nimble_config = ${c3_ble.custom_nimble_config}
-custom_sdkconfig =
-  ${firmware_tuned.custom_sdkconfig}
-  ${c3_ble.custom_sdkconfig}
-build_flags =
-  ${env:default.build_flags}
-  ${c3_ble.build_flags}
-  -DCROSSPOINT_VERSION=\"${crosspoint.version}-dev-c3ble\"
-```
+No local override is needed. Build X3/X4 with `pio run -e default`,
+`-e gh_release`, `-e gh_release_rc`, or `-e slim`. Each inherits `c3_hardware`,
+which supplies the C3 host configuration, tuned controller-only core and Flash
+controller link script. The existing S3 hardware profiles supply their PSRAM
+host configuration to every firmware flavor, including release and RC.
 
 The common `ble_host` profile pins NimBLE-Arduino 2.3.8 and SDK compatibility
 middleware. C3 injects `NimbleC3Config.h` into both NimBLE and the SDK host:
@@ -81,7 +72,8 @@ cmake --build build/test --target ble_input_internal_tests ble_input_psram_tests
   ChapterHtmlSlimParserTest
 ctest --test-dir build/test --output-on-failure \
   -R 'Ble|Nimble|internal\.|psram\.|unavailable\.|SdCardFont|FontCacheManager|ChapterHtmlSlimParser|Section'
-pio run -e c3_ble_probe -e default -e gh_release -e murphy_m4
+pio run -e default -e gh_release -e gh_release_rc -e slim \
+  -e sticky-gh_release -e x4pro-gh_release -e x4c-gh_release -e papermono-gh_release
 ```
 
 Host checks exercise production lifecycle methods, startup failure/retry, input
@@ -89,17 +81,48 @@ isolation, CPU protection, profile/link isolation, paged/resident lookup agreeme
 non-BMP and page boundaries, corrupt files, allocation failures, short-read retry
 and Flash fallback. They do not model the actual controller or prove radio timing.
 
-The September 7 review passed 71 BLE/font checks and 23 chapter/parser checks,
-changed-file formatting, and all four builds above. Default/release ELFs exclude
-NimBLE and paged lookup; S3 retains its host/IPC wrapper and excludes the C3
-controller and paged lookup. C3 resolves controller initialization to Flash,
-includes paged lookup and omits the IPC wrapper. Upstream dependency warnings
-remain (WebSockets deprecation and Arduino/ESP-IDF dependencies).
-The exported compiler commands and preprocessing of actual NimBLE `ble_hs.c`
-and SDK host units confirm the C3 header, internal allocator, one connection,
-MTU 23, Central/Observer roles and 12 events; neither uses the PSRAM override.
+### All-hardware enablement (September 7)
 
-| Review build | Static DRAM | IRAM reservation | Program | Application image |
+All 26 committed hardware environments resolve to BLE-enabled PlatformIO
+configurations. The 14 existing S3 development/Nightly environments retain
+equivalent flags, dependencies, scripts and core options. The 94 related host
+checks and all 43 build/packaging script tests pass; these suites overlap.
+
+Eight firmware builds pass. Every ELF contains the NimBLE host. C3 controller
+initialization resolves to Flash and the actual exported core headers enable
+Flash/controller-only operation, without S3 IPC symbols. S3 retains PSRAM and
+IPC symbols without the C3 paged index or Flash controller; the three USB release
+ELFs also retain TinyUSB/MSC. Every application image passes checksum/hash
+validation. Download interruptions were resolved without source changes.
+
+| Build | Static DRAM | IRAM reservation | Program | Image | SHA256 prefix |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `default` | 65,116 B | 68,608 B | 6,269,913 B | 6,283,904 B | `951416473213` |
+| `gh_release` | 65,092 B | 68,608 B | 6,218,739 B | 6,232,736 B | `2606e030bf82` |
+| `gh_release_rc` | 65,092 B | 68,608 B | 6,218,779 B | 6,232,768 B | `b0f30f369b92` |
+| `slim` | 65,092 B | 68,608 B | 6,137,183 B | 6,151,168 B | `da8bd9c9294b` |
+| `sticky-gh_release` | 75,724 B | 85,248 B | 5,797,587 B | 5,798,096 B | `8b14e6db1cfa` |
+| `x4pro-gh_release` | 99,532 B | 85,760 B | 5,906,130 B | 5,906,640 B | `a9c86613588d` |
+| `x4c-gh_release` | 99,332 B | 85,248 B | 5,882,547 B | 5,883,056 B | `9adddf50f428` |
+| `papermono-gh_release` | 115,924 B | 85,760 B | 5,913,842 B | 5,914,352 B | `0ecddf432350` |
+
+Full hashes, ELF/map files, actual configuration headers and logs are local under
+`/private/tmp/crossmux-ble-all-builds/`. These images have not been flashed; the
+hardware evidence and remaining acceptance matrix below remain separate.
+
+### Earlier review and device evidence
+
+Before all-build enablement, the September 7 review passed 71 BLE/font checks,
+23 chapter/parser checks, changed-file formatting and the four historical
+builds below. At that point, default/release ELFs excluded NimBLE and paged
+lookup; the local C3 candidate included them and resolved controller startup
+to Flash. S3 retained its host/IPC wrapper without C3 code. The exported compiler
+commands and preprocessing of actual NimBLE `ble_hs.c` and SDK host units
+confirmed the C3 internal allocator, one connection, MTU 23, Central/Observer
+roles and 12 events. Upstream dependency warnings remained (WebSockets
+deprecation and Arduino/ESP-IDF dependencies).
+
+| Historical review build | Static DRAM | IRAM reservation | Program | Application image |
 | --- | ---: | ---: | ---: | ---: |
 | `default` | 57,412 B | 67,072 B | 5,896,729 B | 5,910,416 B |
 | `gh_release` | 57,388 B | 67,072 B | 5,845,085 B | 5,858,768 B |
@@ -164,6 +187,8 @@ Cover WenKai 16/18 and Noto, SD-direct and Flash-cached fonts, cold/hot chapter
 caches, and TXT/XTC lifecycle regression. Always verify physical buttons/menu
 response as well as HID delivery. Require at least 512 B task stack headroom,
 no font-selection loss, crashes or sustained decline in equivalent recovered
-heap states. A normal-reading gate failure blocks default enablement; do not
-lower thresholds to pass. X4 Flash JEDEC 85:2018 suspend support was not confirmed
-by the driver, so automatic Flash erase/write suspend remains disabled.
+heap states. Keep any normal-reading gate failure open as a stability issue;
+do not lower thresholds to pass. Enabling compilation in every build does not
+complete this hardware acceptance matrix. X4 Flash JEDEC 85:2018 suspend support
+was not confirmed by the driver, so automatic Flash erase/write suspend remains
+disabled.

--- a/docs/engineering/device-variants.md
+++ b/docs/engineering/device-variants.md
@@ -59,22 +59,22 @@ not yet been quantified, so no measured power reduction is claimed. All S3
 targets remain in the normal downclocked standby loop; a successful build alone
 is not a hardware acceptance test.
 
-Bluetooth Page Turner Beta is compiled into all seven S3 development and Nightly
-builds, including the build-only X4 Classic target. The runtime setting is
-disabled by default. C3 `default`, stable/release, RC and slim profiles do not
-enable BLE. The opt-in `c3_ble` candidate uses internal RAM, a Flash controller
-and paged coverage indexes for large SD fonts; it does not inherit S3 PSRAM or
-IPC flags. The HAL protects its entire BLE host lifetime from manual 10 MHz
-idle downclocking. X4 user tests confirm reading/page-turner operation, while
-quantitative endurance and X3 hardware acceptance remain separate.
-See [C3 Bluetooth](c3-bluetooth.md) for configuration, ownership and validation.
+Bluetooth Page Turner Beta is compiled into every hardware firmware flavor:
+development, Nightly, release, RC and slim where those profiles exist. The
+runtime setting remains disabled by default; existing saved choices are kept.
+Native simulator builds retain the BLE stub.
 
-Sticky, X4 Pro, X4 Classic, Paper Mono, EEGO A4, Murphy M4 and Waveshare 3.97 BLE
-development/Nightly builds use `s3_ble_psram`. Its middleware forces the external
-allocator configuration into NimBLE-Arduino sources only, after `sdkconfig.h`;
-the existing core, controller and task stacks are not migrated. Sticky retains
-its controller-only core and DRAM framebuffer. Release builds do not inherit
-this configuration.
+X3/X4 profiles share `c3_hardware`: internal RAM, a Flash controller and paged
+coverage indexes for large SD fonts. The HAL protects the entire C3 BLE host
+lifetime from manual 10 MHz idle downclocking. Sticky, X4 Pro, X4 Classic, Paper
+Mono, EEGO A4, Murphy M4 and Waveshare 3.97 inherit `s3_ble_psram` through their
+hardware profiles, including release/RC flavors. Sticky and EEGO keep their
+tuned controller-only cores; USB-capable boards keep the prebuilt TinyUSB graph.
+C3 never inherits the S3 allocator or IPC wrapper.
+
+X4 user tests confirm reading/page-turner operation; quantitative endurance and
+X3/other-board hardware acceptance remain separate. See
+[C3 Bluetooth](c3-bluetooth.md) for configuration, ownership and validation.
 
 The diagnostic PSRAM mode additionally requires 256 KiB free and a 32 KiB
 contiguous PSRAM block. Before starting the Host it allocates and immediately

--- a/docs/engineering/index.md
+++ b/docs/engineering/index.md
@@ -16,7 +16,7 @@ that matches your task — don't load everything at once.
 | [ui-and-input.md](ui-and-input.md) | Rendering UI, handling orientation, mapping buttons, or using the `GUI`/UITheme macro and `tr()`. |
 | [generated-files.md](generated-files.md) | Editing HTML pages, i18n translations, or fonts (anything produced by a build script). |
 | [testing-and-debugging.md](testing-and-debugging.md) | Building, monitoring, debugging crashes, verifying changes, or reading CI workflows. |
-| [c3-bluetooth.md](c3-bluetooth.md) | Reviewing the opt-in C3 BLE profile, reader lifecycle, paged font indexes, build isolation, or X4 validation limits. |
+| [c3-bluetooth.md](c3-bluetooth.md) | Reviewing the C3 BLE profile, reader lifecycle, paged font indexes, build isolation, or X4 validation limits. |
 | [git-workflow.md](git-workflow.md) | Any git operation: detecting repo context, branching, commit format, or deciding whether to commit. |
 | [cache-management.md](cache-management.md) | Changing a cache binary layout, invalidating caches, or bumping a format version. (Byte-level formats: [../file-formats.md](../file-formats.md).) |
 | [sd-card-font-cache.md](sd-card-font-cache.md) | Reviewing the SD-card reader-font cache, its inactive-OTA-slot backend, rollback boundary, commit protocol, SD fallback, progress UI, or performance logs. |

--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -191,10 +191,11 @@ local artifacts and are not committed to the repository.
 
 ### C3 Bluetooth page-turner development validation
 
-See [C3 Bluetooth](c3-bluetooth.md) for the opt-in build profile, lifecycle and
-font-memory ownership, reproducible checks, X4 evidence and remaining acceptance
-limits. Default/release BLE remains disabled. Distinguish host/build success,
-application hash verification and physical-device acceptance.
+See [C3 Bluetooth](c3-bluetooth.md) for the shared hardware build profiles,
+lifecycle and font-memory ownership, reproducible checks, X4 evidence and
+remaining acceptance limits. Hardware builds include BLE; the runtime switch
+defaults off. Distinguish host/build success, application hash verification
+and physical-device acceptance.
 
 ### Distinguishing TCP Stalls, Watchdogs, and Restarts
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -169,13 +169,26 @@ custom_component_remove =
   espressif/esp_secure_cert_mgr
   espressif/cbor
 
-[env:default]
+; X3/X4 share the C3 controller and internal-RAM host in every firmware flavor.
+[c3_hardware]
 extends = base, firmware_tuned
+lib_deps = ${c3_ble.lib_deps}
+extra_scripts = ${c3_ble.extra_scripts}
+custom_nimble_config = ${c3_ble.custom_nimble_config}
+custom_sdkconfig =
+  ${firmware_tuned.custom_sdkconfig}
+  ${c3_ble.custom_sdkconfig}
 build_flags =
   ${base.build_flags}
-  ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
+  ${c3_ble.build_flags}
   -DFREEINK_DEVICE_X4=1
   -DFREEINK_DEVICE_X3=1
+
+[env:default]
+extends = c3_hardware
+build_flags =
+  ${c3_hardware.build_flags}
+  ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
   -DENABLE_SERIAL_LOG
   -DCROSSPOINT_WAIT_FOR_USB_SERIAL
   -DLOG_LEVEL=2 ; Set log level to debug for development builds
@@ -243,7 +256,7 @@ extra_scripts =
   ${base.extra_scripts}
   pre:scripts/patch_ble_keyboard_host.py
 
-; Opt-in C3 candidate; default/release profiles deliberately do not inherit it.
+; C3 host/controller settings shared by development, release, RC and slim.
 [c3_ble]
 custom_nimble_config = src/platform/NimbleC3Config.h
 build_flags = ${ble_host.build_flags}
@@ -264,7 +277,7 @@ custom_sdkconfig =
   CONFIG_BT_CTRL_ADV_DUP_FILT_MAX=10
   CONFIG_BLE_MESH=n
 
-; BLE HID is deliberately opt-in per S3 development/Nightly environment.
+; S3 host settings shared by every hardware firmware flavor.
 [s3_ble]
 build_flags =
   ${ble_host.build_flags}
@@ -326,31 +339,25 @@ build_flags =
   -DSIMULATOR_DEVICE_MURPHY_M4
 
 [env:gh_release]
-extends = base, firmware_tuned
+extends = c3_hardware
 build_flags =
-  ${base.build_flags}
-  -DFREEINK_DEVICE_X4=1
-  -DFREEINK_DEVICE_X3=1
+  ${c3_hardware.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
 
 [env:gh_release_rc]
-extends = base, firmware_tuned
+extends = c3_hardware
 build_flags =
-  ${base.build_flags}
-  -DFREEINK_DEVICE_X4=1
-  -DFREEINK_DEVICE_X3=1
+  ${c3_hardware.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
 
 [env:slim]
-extends = base, firmware_tuned
+extends = c3_hardware
 build_flags =
-  ${base.build_flags}
-  -DFREEINK_DEVICE_X4=1
-  -DFREEINK_DEVICE_X3=1
+  ${c3_hardware.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
@@ -364,28 +371,27 @@ build_flags =
 ; --- Seeed Sticky — ESP32-S3R8, 3.97" 800x480 SSD1677 + GT911 touch -----------
 ; Different MCU family than the C3 envs (one binary per family). The SDK
 ; auto-enables CAP_TOUCH (GT911) and the BQ27220 gauge for this device. BLE
-; development/Nightly builds use the existing PSRAM heap for the Host only;
+; builds use the existing PSRAM heap for the Host only;
 ; the 48KB framebuffer remains in DRAM, same as X4.
 ;   pio run -e sticky -t upload
 [sticky_hardware]
 extends = base, firmware_tuned
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
-build_flags =
-  ${base.build_flags}
-  -DFREEINK_DEVICE_STICKY=1
-
-[env:sticky]
-extends = sticky_hardware
 lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts =
-  ${s3_ble_psram.extra_scripts}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 custom_sdkconfig =
   ${firmware_tuned.custom_sdkconfig}
   ${s3_ble_controller.custom_sdkconfig}
 build_flags =
-  ${sticky_hardware.build_flags}
+  ${base.build_flags}
   ${s3_ble_psram.build_flags}
+  -DFREEINK_DEVICE_STICKY=1
+
+[env:sticky]
+extends = sticky_hardware
+build_flags =
+  ${sticky_hardware.build_flags}
   -DENABLE_SERIAL_LOG
   -DCROSSPOINT_WAIT_FOR_USB_SERIAL
   -DLOG_LEVEL=2
@@ -408,15 +414,8 @@ build_flags =
 
 [env:sticky_nightly]
 extends = sticky_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts =
-  ${s3_ble_psram.extra_scripts}
-custom_sdkconfig =
-  ${firmware_tuned.custom_sdkconfig}
-  ${s3_ble_controller.custom_sdkconfig}
 build_flags =
   ${sticky_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-sticky-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -434,8 +433,11 @@ board_build.arduino.memory_type = dio_opi
 ; Use the prebuilt dio_opi Arduino variant: its TinyUSB component is enabled
 ; for CDC and MSC. This profile deliberately extends base rather than
 ; firmware_tuned, whose custom SDK rebuild omits that component.
+lib_deps = ${s3_ble_psram.lib_deps}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${base.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -446,11 +448,8 @@ build_flags =
 
 [env:x4pro]
 extends = x4pro_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${x4pro_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
   -DENABLE_SERIAL_LOG
   -DCROSSPOINT_WAIT_FOR_USB_SERIAL
@@ -474,11 +473,8 @@ build_flags =
 
 [env:x4pro_nightly]
 extends = x4pro_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${x4pro_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -494,8 +490,11 @@ extends = base
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
+lib_deps = ${s3_ble_psram.lib_deps}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${base.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_X4CLASSIC=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -505,11 +504,8 @@ build_flags =
 
 [env:x4c]
 extends = x4c_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${x4c_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4c\"
   -DENABLE_SERIAL_LOG
   -DCROSSPOINT_WAIT_FOR_USB_SERIAL
@@ -533,11 +529,8 @@ build_flags =
 
 [env:x4c_nightly]
 extends = x4c_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${x4c_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4c-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -547,8 +540,11 @@ build_flags =
 extends = base, firmware_tuned
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
+lib_deps = ${s3_ble_psram.lib_deps}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${base.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_EEGO_A4=1
   -DBOARD_HAS_PSRAM
 ; WeRead's network steps (TLS handshake + JSON decode) run on the Arduino
@@ -557,32 +553,19 @@ build_flags =
 custom_sdkconfig =
   ${firmware_tuned.custom_sdkconfig}
   CONFIG_ARDUINO_LOOP_STACK_SIZE=16384
+  ${s3_ble_controller.custom_sdkconfig}
 
 [env:eego_a4]
 extends = eego_a4_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts =
-  ${s3_ble_psram.extra_scripts}
-custom_sdkconfig =
-  ${eego_a4_hardware.custom_sdkconfig}
-  ${s3_ble_controller.custom_sdkconfig}
 build_flags =
   ${eego_a4_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2
 
 [env:eego_a4_nightly]
 extends = eego_a4_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts =
-  ${s3_ble_psram.extra_scripts}
-custom_sdkconfig =
-  ${eego_a4_hardware.custom_sdkconfig}
-  ${s3_ble_controller.custom_sdkconfig}
 build_flags =
   ${eego_a4_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-eego-a4-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -594,8 +577,11 @@ extends = base
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
+lib_deps = ${s3_ble_psram.lib_deps}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${base.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_MURPHY_M4=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -605,21 +591,15 @@ build_flags =
 
 [env:murphy_m4]
 extends = murphy_m4_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${murphy_m4_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2
 
 [env:murphy_m4_nightly]
 extends = murphy_m4_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${murphy_m4_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-murphy-m4-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -648,8 +628,13 @@ board_build.mcu = esp32s3
 ; Keep this profile on the prebuilt TinyUSB-enabled variant so USB Drive can
 ; switch the shared S3 PHY from Serial/JTAG to MSC and back.
 board_build.arduino.memory_type = dio_opi
+lib_deps =
+  ${s3_ble_psram.lib_deps}
+  AudioManager=symlink://freeink-sdk/libs/hardware/AudioManager
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${sound_feedback_hardware.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_WAVESHARE_EPAPER_397=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -659,25 +644,15 @@ build_flags =
 
 [env:waveshare_epaper_397]
 extends = waveshare_epaper_397_hardware
-lib_deps =
-  ${s3_ble_psram.lib_deps}
-  AudioManager=symlink://freeink-sdk/libs/hardware/AudioManager
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${waveshare_epaper_397_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2
 
 [env:waveshare_epaper_397_nightly]
 extends = waveshare_epaper_397_hardware
-lib_deps =
-  ${s3_ble_psram.lib_deps}
-  AudioManager=symlink://freeink-sdk/libs/hardware/AudioManager
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${waveshare_epaper_397_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-waveshare-epaper-397-rc+${sysenv.CROSSPOINT_RC_HASH}\"
 
@@ -693,8 +668,11 @@ extends = base
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
+lib_deps = ${s3_ble_psram.lib_deps}
+extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${base.build_flags}
+  ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_PAPERMONO=1
   -DFREEINK_CAP_USB_MSC=1
   ; The SSD1677 grayscale target planes are batched in PSRAM.
@@ -706,11 +684,8 @@ build_flags =
 
 [env:papermono]
 extends = papermono_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${papermono_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-papermono\"
   -DENABLE_SERIAL_LOG
   -DCROSSPOINT_WAIT_FOR_USB_SERIAL
@@ -734,10 +709,7 @@ build_flags =
 
 [env:papermono_nightly]
 extends = papermono_hardware
-lib_deps = ${s3_ble_psram.lib_deps}
-extra_scripts = ${s3_ble_psram.extra_scripts}
 build_flags =
   ${papermono_hardware.build_flags}
-  ${s3_ble_psram.build_flags}
   ${s3_nightly.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-papermono-rc+${sysenv.CROSSPOINT_RC_HASH}\"

--- a/scripts/tests/test_ble_c3_config.py
+++ b/scripts/tests/test_ble_c3_config.py
@@ -81,7 +81,7 @@ int main() {
                 ], check=True, capture_output=True)
                 subprocess.run([str(exe)], check=True)
 
-    def test_c3_candidate_is_not_enabled_in_default_or_releases(self):
+    def test_all_hardware_builds_enable_ble_with_target_specific_configuration(self):
         config = configparser.ConfigParser(interpolation=None)
         config.read(ROOT / "platformio.ini")
 
@@ -111,12 +111,43 @@ int main() {
         self.assertIn("CONFIG_BT_CONTROLLER_ONLY=y", resolve("c3_ble", "custom_sdkconfig"))
         self.assertIn("CONFIG_BT_CTRL_RUN_IN_FLASH_ONLY=y", resolve("c3_ble", "custom_sdkconfig"))
         self.assertIn("CONFIG_BT_NIMBLE_ENABLED=n", resolve("c3_ble", "custom_sdkconfig"))
-        for section in ("env:default", "env:gh_release", "env:gh_release_rc", "env:slim", "env:simulator"):
+        hardware_count = 0
+        for section in config.sections():
+            if not section.startswith("env:"):
+                continue
             with self.subTest(section=section):
-                self.assertNotIn("FREEINK_CAP_BLE_HID_HOST", resolve(section, "build_flags"))
-                self.assertNotIn("NimBLE-Arduino", resolve(section, "lib_deps"))
-                self.assertFalse(resolve(section, "custom_nimble_config"))
-                self.assertNotIn("configure_c3_ble_controller.py", resolve(section, "extra_scripts"))
+                flags = resolve(section, "build_flags")
+                libraries = resolve(section, "lib_deps")
+                scripts = resolve(section, "extra_scripts")
+                if resolve(section, "platform") == "native":
+                    self.assertNotIn("FREEINK_CAP_BLE_HID_HOST", flags)
+                    self.assertNotIn("NimBLE-Arduino", libraries)
+                    self.assertNotIn("configure_c3_ble_controller.py", scripts)
+                    continue
+                hardware_count += 1
+                self.assertIn("-DFREEINK_CAP_BLE_HID_HOST=1", flags)
+                self.assertIn("h2zero/NimBLE-Arduino @ 2.3.8", libraries)
+                self.assertIn("patch_ble_keyboard_host.py", scripts)
+                self.assertIn("configure_nimble_psram.py", scripts)
+                if resolve(section, "board_build.mcu") == "esp32s3":
+                    self.assertIn("-DCROSSPOINT_BLE_HOST_PSRAM=1", flags)
+                    self.assertIn("--wrap=xTaskCreatePinnedToCore", flags)
+                    self.assertNotIn("configure_c3_ble_controller.py", scripts)
+                    self.assertFalse(resolve(section, "custom_nimble_config"))
+                    if "FREEINK_CAP_USB_MSC=1" in flags:
+                        self.assertFalse(resolve(section, "custom_sdkconfig"))
+                        self.assertEqual(resolve(section, "board_build.arduino.memory_type"), "dio_opi")
+                    else:
+                        self.assertIn("CONFIG_BT_CONTROLLER_ONLY=y", resolve(section, "custom_sdkconfig"))
+                else:
+                    self.assertEqual(resolve(section, "board"), "esp32-c3-devkitm-1")
+                    self.assertNotIn("CROSSPOINT_BLE_HOST_PSRAM", flags)
+                    self.assertNotIn("xTaskCreatePinnedToCore", flags)
+                    self.assertIn("post:scripts/configure_c3_ble_controller.py", scripts)
+                    self.assertEqual(resolve(section, "custom_nimble_config"), "src/platform/NimbleC3Config.h")
+                    self.assertIn("CONFIG_BT_CTRL_RUN_IN_FLASH_ONLY=y", resolve(section, "custom_sdkconfig"))
+                    self.assertIn("CONFIG_BT_CONTROLLER_ONLY=y", resolve(section, "custom_sdkconfig"))
+        self.assertGreaterEqual(hardware_count, 26)
         self.assertIn("uint8_t bluetoothEnabled = 0;", (ROOT / "src/CrossPointSettings.h").read_text())
 
     def test_flash_controller_link_uses_matching_archive_without_changing_packages(self):

--- a/scripts/tests/test_configure_nimble_psram.py
+++ b/scripts/tests/test_configure_nimble_psram.py
@@ -11,34 +11,29 @@ class NimblePsramMiddlewareTest(unittest.TestCase):
         config.read(Path(__file__).resolve().parents[2] / "platformio.ini")
         devices = ("sticky", "x4pro", "x4c", "papermono", "eego_a4", "murphy_m4", "waveshare_epaper_397")
         for device in devices:
-            for suffix in ("", "_nightly"):
-                target = config[f"env:{device}{suffix}"]
-                with self.subTest(target=target.name):
-                    for option in ("lib_deps", "extra_scripts", "build_flags"):
-                        self.assertIn(f"${{s3_ble_psram.{option}}}", target[option])
-        for name in ("env:sticky", "env:sticky_nightly"):
-            self.assertEqual(config[name]["extends"], "sticky_hardware")
-            self.assertEqual(
-                config[name]["custom_sdkconfig"].split(),
-                ["${firmware_tuned.custom_sdkconfig}", "${s3_ble_controller.custom_sdkconfig}"],
-            )
-            self.assertNotIn("BOARD_HAS_PSRAM", config[name]["build_flags"])
+            hardware = f"{device}_hardware"
+            for option in ("lib_deps", "extra_scripts", "build_flags"):
+                self.assertIn(f"${{s3_ble_psram.{option}}}", config[hardware][option])
+            for name in config.sections():
+                if name.startswith("env:") and config[name].get("extends") == hardware:
+                    with self.subTest(target=name):
+                        self.assertIn(f"${{{hardware}.build_flags}}", config[name]["build_flags"])
+                        self.assertNotIn("lib_deps", config[name])
+                        self.assertNotIn("extra_scripts", config[name])
+        self.assertEqual(
+            config["sticky_hardware"]["custom_sdkconfig"].split(),
+            ["${firmware_tuned.custom_sdkconfig}", "${s3_ble_controller.custom_sdkconfig}"],
+        )
         self.assertNotIn("BOARD_HAS_PSRAM", config["sticky_hardware"]["build_flags"])
+        self.assertIn("CONFIG_ARDUINO_LOOP_STACK_SIZE=16384", config["eego_a4_hardware"]["custom_sdkconfig"])
         self.assertIn("CONFIG_BT_CONTROLLER_ONLY=y", config["s3_ble_controller"]["custom_sdkconfig"])
         self.assertIn("CONFIG_BT_NIMBLE_ENABLED=n", config["s3_ble_controller"]["custom_sdkconfig"])
 
-    def test_non_ble_profiles_do_not_inherit_ble_configuration(self):
+    def test_generic_base_and_simulators_do_not_inherit_radio_configuration(self):
         config = configparser.ConfigParser(interpolation=None)
         config.read(Path(__file__).resolve().parents[2] / "platformio.ini")
-        for name in config.sections():
-            if name.startswith("s3_ble") or name in ("c3_ble", "ble_host"):
-                continue
-            # BLE references belong only to the development/Nightly envs above,
-            # never shared hardware/base profiles or release/simulator envs.
-            if name.startswith("env:") and not (
-                "gh_release" in name or "simulator" in name or name in ("env:default", "env:slim")
-            ):
-                continue
+        for name in ("base", "firmware_tuned", "env:simulator", "env:simulator_x3",
+                     "env:simulator_eego_a4", "env:simulator_murphy_m4"):
             with self.subTest(profile=name):
                 for value in config[name].values():
                     self.assertNotIn("s3_ble", value)


### PR DESCRIPTION
## Change

BLE page-turner support was missing from the shared X3/X4 builds and S3 release/RC builds. Enable it through `c3_hardware` and the existing S3 hardware profiles so all 26 hardware environments inherit it, including development, Nightly, release, RC and slim where those flavors exist. The saved Bluetooth switch still defaults to off; native simulators keep the SDK stub.

Reuse the existing C3 internal-RAM/Flash-controller profile and S3 PSRAM/IPC profile. Remove repeated S3 environment-level options; preserve the TinyUSB prebuilt core on USB boards and the tuned controller-only core on Sticky/EEGO. Update the support/validation documentation and configuration checks. No application logic, SDK gitlink, public API or persistent field changes.

## Validation

- PlatformIO resolved configuration: BLE enabled in all 26 committed hardware environments; the 14 existing S3 development/Nightly profiles retain equivalent build options.
- 94 BLE/font/chapter host checks and all 43 build/packaging script tests passed (overlapping suites, not an additive total).
- Firmware builds and ELF/image checks: `default`, `gh_release`, `gh_release_rc`, `slim`, `sticky-gh_release`, `x4pro-gh_release`, `x4c-gh_release`, and `papermono-gh_release` all passed. Every ELF links NimBLE; C3 resolves the controller to Flash without S3 IPC, while S3 retains PSRAM/IPC and USB targets retain TinyUSB/MSC. All eight application checksums/hashes are valid. Artifact sizes and SHA256 references are in the validation document.
- `git diff --check` passed.

No device was flashed in this change. Existing X4 feedback and remaining endurance/other-board acceptance work are documented separately; compilation does not establish hardware acceptance. The runtime memory gates and rendering preferences remain unchanged.

Follows #289.
