### PR TITLE
fix: serialize standby CPU clock transitions

### DIFF
--- a/docs/engineering/architecture-and-patterns.md
+++ b/docs/engineering/architecture-and-patterns.md
@@ -50,6 +50,12 @@ if (Storage.openFileForRead("MODULE", "/path/to/file.bin", file)) {
 - `HalStorage` serializes everything via `storageMutex`. Downstream code uses `HalFile` (declared in `<HalStorage.h>`); every method call (read, write, seek, close) takes the mutex. `HalFile`'s destructor also takes the mutex before letting the underlying SdFat `FsFile` close.
 - **Never** call into `SdFat` / `SdSpiCard` / `FsBaseFile` / `SDCardManager` / raw `FsFile` directly — that bypasses the mutex.
 
+**CPU frequency changes must go through `HalPowerManager::setPowerSaving()`**:
+- `modeMutex` protects the target-mode decision, the entire `setCpuFrequencyMhz()` call, and the `isLowPower` update. Update state only after a successful transition; repeated requests for the current state do nothing.
+- Arduino's APB callbacks hold SPI locks between the BEFORE and AFTER callbacks. Concurrent frequency changes can deadlock: one task holds a SPI lock while waiting for the APB callback lock, and another holds the APB callback lock while waiting for that SPI lock. Serializing only the state assignment is insufficient.
+- `HalPowerManager::Lock` sets `NormalSpeed` under `modeMutex`, then releases the mutex **before** calling `setPowerSaving(false)`. Keep that ordering: the mutex is not recursive. Obtain the power lock before starting SPI work. The existing helper supports only one active power lock; it is not a nested-lock counter.
+- Preserve the Wi-Fi/C3 BLE host guards and board-specific frequency restrictions. Light sleep and CPU downclocking are separate decisions; fixing clock serialization must not disable either Bluetooth or standby light sleep.
+
 ---
 
 ## Common Patterns

--- a/docs/engineering/testing-and-debugging.md
+++ b/docs/engineering/testing-and-debugging.md
@@ -292,3 +292,56 @@ GitHub publish job can continue.
 **Flush**: `logSerial.flush();` (force output before crash)
 
 **Port Detection**: Windows: `mode` | Linux: `ls /dev/ttyUSB* /dev/ttyACM*` or `dmesg | grep tty`
+
+### Standby power-button wake on X3/X4
+
+Test on battery power: USB prevents standby light sleep. Disconnect USB, enter
+standby, and leave it untouched for at least 45 seconds (the idle threshold is
+35 seconds). The title disappearing only indicates immersive display mode.
+During light sleep, other buttons should have no effect; a short power-button
+press and release should restore the title and hints without also confirming,
+turning a page, or entering sleep again.
+
+If the clock updates but power-button wake stalls, distinguish GPIO wake from
+the work after wake. Capture the GPIO level, sleep return value, wake reason,
+cleanup result, and entry/exit of CPU frequency restoration with task names.
+In the X4 regression, GPIO3 woke successfully, but `ActivityManager` and
+`loopTask` both entered frequency restoration and neither completed. Timer
+updates waited for rendering, so they did not expose the same concurrency.
+See the [clock serialization invariant](architecture-and-patterns.md).
+
+When collecting the existing RTC log ring (`lib/Logging/Logging.cpp`), avoid
+serial monitors that toggle DTR/RTS: a reset followed by normal startup clears
+the retained log. For a temporary diagnostic build with a log export command,
+open pyserial without changing those lines:
+
+```python
+import serial
+
+class NoResetSerial(serial.Serial):
+    def _update_dtr_state(self):
+        pass
+
+    def _update_rts_state(self):
+        pass
+
+with NoResetSerial("/dev/cu.usbmodem101", 115200, timeout=0.2) as port:
+    # Send the temporary build's log export command here, then read its reply.
+    pass
+```
+
+Reconnect promptly after the wake attempt; frequent draw logs can overwrite
+the small RTC ring. If the app is deadlocked, read RTC memory through the ROM
+loader without booting the app afterward, using symbol addresses from that
+exact ELF. Remove temporary diagnostics before the final build.
+
+Run `python3 -m unittest discover -v -s scripts/tests` for the compiled-production
+power regression in `test_ble_c3_config.py`. It covers BLE/Wi-Fi guards,
+concurrent restoration, repeated requests, failed transitions, and retries.
+Host tests do not prove physical sleep or Bluetooth page turning. Record each
+device and firmware hash separately, including:
+
+- BLE off: ten consecutive power-button wakes and at least ten minutes of clock updates.
+- BLE connected: five cycles of reading/page turning, standby, power-button wake, and resumed Bluetooth page turning.
+- No extra action from the wake gesture; normal buttons, display, and SD reading after leaving standby.
+- Whether the final build without diagnostics was flashed and retested. Report X3 and X4 results independently.

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -83,30 +83,21 @@ void HalPowerManager::setPowerSaving(bool enabled) {
   if (BleHid.isRunning()) enabled = false;
 #endif
 
-  // Note: We don't use mutex here to avoid too much overhead,
-  // it's not very important if we read a slightly stale value for currentLockMode
-  const LockMode mode = currentLockMode;
-
-  if (mode == None && enabled && !isLowPower) {
-    LOG_DBG("PWR", "Going to low-power mode");
-    if (!setCpuFrequencyMhz(LOW_POWER_FREQ)) {
-      LOG_DBG("PWR", "Failed to set CPU frequency = %d MHz", LOW_POWER_FREQ);
-      return;
+  // Serialize the entire clock transition: Arduino's APB callbacks retain SPI
+  // locks between BEFORE/AFTER, so concurrent frequency changes can deadlock.
+  xSemaphoreTake(modeMutex, portMAX_DELAY);
+  const bool targetLowPower = enabled && currentLockMode == None;
+  if (isLowPower != targetLowPower) {
+    const int targetFrequency = targetLowPower ? LOW_POWER_FREQ : normalFreq;
+    if (setCpuFrequencyMhz(targetFrequency)) {
+      isLowPower = targetLowPower;
+      LOG_DBG("PWR", "CPU frequency now %u MHz", getCpuFrequencyMhz());
+    } else {
+      LOG_DBG("PWR", "Failed to set CPU frequency = %d MHz", targetFrequency);
     }
-    isLowPower = true;
-    LOG_DBG("PWR", "CPU frequency now %u MHz", getCpuFrequencyMhz());
-
-  } else if ((!enabled || mode != None) && isLowPower) {
-    LOG_DBG("PWR", "Restoring normal CPU frequency");
-    if (!setCpuFrequencyMhz(normalFreq)) {
-      LOG_DBG("PWR", "Failed to set CPU frequency = %d MHz", normalFreq);
-      return;
-    }
-    isLowPower = false;
-    LOG_DBG("PWR", "CPU frequency now %u MHz", getCpuFrequencyMhz());
   }
 
-  // Otherwise, no change needed
+  xSemaphoreGive(modeMutex);
 #endif
 }
 

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -22,7 +22,7 @@ class HalPowerManager {
 
   enum LockMode { None, NormalSpeed };
   LockMode currentLockMode = None;
-  SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
+  SemaphoreHandle_t modeMutex = nullptr;  // Protect lock mode, clock transitions, and isLowPower
 
  public:
   enum class LightSleepWakeReason : uint8_t { Timer, PowerButton, Failed };

--- a/scripts/tests/test_ble_c3_config.py
+++ b/scripts/tests/test_ble_c3_config.py
@@ -22,19 +22,48 @@ class BleC3ConfigTest(unittest.TestCase):
             "void HalPowerManager::startDeepSleep", 1)[0]
         harness = r'''
 #include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 #define LOG_DBG(...) ((void)0)
 #define LOG_INF(...) ((void)0)
 constexpr int WIFI_MODE_NULL = 0;
+constexpr int portMAX_DELAY = -1;
 struct { int mode = 0; int getMode() { return mode; } } WiFi;
 struct { bool running = false; bool isRunning() { return running; } } BleHid;
 unsigned frequency = 160;
 unsigned getCpuFrequencyMhz() { return frequency; }
-bool setCpuFrequencyMhz(unsigned value) { frequency = value; return true; }
+std::mutex stateMutex, powerModeMutex;
+std::condition_variable changed;
+bool holdClock = false, insideClock = false, contended = false, overlap = false, failClock = false;
+int clockCalls = 0;
+void xSemaphoreTake(std::mutex* mutex, int) {
+    if (!mutex->try_lock()) {
+        { std::lock_guard<std::mutex> guard(stateMutex); contended = true; }
+        changed.notify_all();
+        mutex->lock();
+    }
+}
+void xSemaphoreGive(std::mutex* mutex) { mutex->unlock(); }
+bool setCpuFrequencyMhz(unsigned value) {
+    std::unique_lock<std::mutex> guard(stateMutex);
+    ++clockCalls;
+    overlap |= insideClock;
+    insideClock = true;
+    changed.notify_all();
+    changed.wait(guard, [] { return !holdClock; });
+    insideClock = false;
+    if (failClock) return false;
+    frequency = value;
+    return true;
+}
 struct HalPowerManager {
     enum LockMode { None, NormalSpeed };
     int normalFreq = 160;
     bool isLowPower = false;
     LockMode currentLockMode = None;
+    std::mutex* modeMutex = &powerModeMutex;
     static constexpr int LOW_POWER_FREQ = 10;
     void setPowerSaving(bool enabled);
 };
@@ -44,6 +73,8 @@ int main() {
     HalPowerManager power;
     power.setPowerSaving(true);
     assert(frequency == 10);
+    power.setPowerSaving(true);
+    assert(clockCalls == 1); // Repeated idle requests must not change the clock again.
     BleHid.running = true;
     power.setPowerSaving(true);
 #if CONFIG_IDF_TARGET_ESP32C3 && FREEINK_CAP_BLE_HID_HOST
@@ -68,6 +99,45 @@ int main() {
     assert(frequency == 10);
     power.setPowerSaving(false);
     assert(frequency == 160);
+
+    // GPIO wake queues rendering while the idle main loop also requests normal
+    // speed under the render lock. Hold the first transition to force overlap.
+    power.isLowPower = true;
+    frequency = 10;
+    power.currentLockMode = HalPowerManager::NormalSpeed;
+    holdClock = true;
+    clockCalls = 0;
+    contended = false;
+    std::thread render([&] { power.setPowerSaving(false); });
+    { std::unique_lock<std::mutex> guard(stateMutex);
+      assert(changed.wait_for(guard, std::chrono::seconds(2), [] { return insideClock; })); }
+    std::thread mainLoop([&] { power.setPowerSaving(true); });
+    { std::unique_lock<std::mutex> guard(stateMutex);
+      assert(changed.wait_for(guard, std::chrono::seconds(2), [] { return contended || overlap; }));
+      holdClock = false; }
+    changed.notify_all();
+    render.join(); mainLoop.join();
+    assert(!overlap && clockCalls == 1 && frequency == 160 && !power.isLowPower);
+
+    // Both failed-transition paths must release the mutex and preserve state.
+    power.currentLockMode = HalPowerManager::None;
+    failClock = true;
+    power.setPowerSaving(true);
+    assert(!power.isLowPower && frequency == 160);
+    assert(powerModeMutex.try_lock()); powerModeMutex.unlock();
+    failClock = false;
+    power.setPowerSaving(true);
+    assert(power.isLowPower && frequency == 10);
+    failClock = true;
+    power.setPowerSaving(false);
+    assert(power.isLowPower && frequency == 10);
+    assert(powerModeMutex.try_lock()); powerModeMutex.unlock();
+    failClock = false;
+    power.setPowerSaving(false);
+    assert(!power.isLowPower && frequency == 160);
+    const int restoredCalls = clockCalls;
+    power.setPowerSaving(false);
+    assert(clockCalls == restoredCalls);
 }
 '''
         with tempfile.TemporaryDirectory() as directory:
@@ -76,10 +146,10 @@ int main() {
             exe = Path(directory) / "power"
             for c3, ble in ((1, 1), (1, 0), (0, 1)):
                 subprocess.run(shlex.split(os.environ.get("CXX", "c++")) + [
-                    "-std=c++17", f"-DCONFIG_IDF_TARGET_ESP32C3={c3}",
+                    "-std=c++17", "-pthread", f"-DCONFIG_IDF_TARGET_ESP32C3={c3}",
                     f"-DFREEINK_CAP_BLE_HID_HOST={ble}", str(cpp), "-o", str(exe),
                 ], check=True, capture_output=True)
-                subprocess.run([str(exe)], check=True)
+                subprocess.run([str(exe)], check=True, timeout=10)
 
     def test_all_hardware_builds_enable_ble_with_target_specific_configuration(self):
         config = configparser.ConfigParser(interpolation=None)


### PR DESCRIPTION
## Summary

Fix the X3/X4 standby symptom where the clock continues updating but a power-button wake stalls. On the reproduced X4 failure, GPIO3 wake and sleep cleanup succeeded; `ActivityManager` and `loopTask` then entered CPU frequency restoration concurrently and neither completed.

Arduino serializes each APB callback traversal separately, while SPI retains its mutex from BEFORE to AFTER. Interleaved transitions can therefore leave one task holding SPI and waiting for the APB callback lock, with the other holding the APB callback lock and waiting for SPI.

Use the existing `modeMutex` around the target-state decision, complete frequency transition, and successful state update. Merge the up/down branches into one frequency call and one unlock; failures retain state for retry. Preserve BLE/Wi-Fi guards, board exceptions, light sleep, and input behavior. No new locks, heap allocations, or public interfaces. Document the lock ordering and hardware debugging procedure.

## Validation

- 43 script tests passed, including the existing harness compiling production `setPowerSaving()` for C3 BLE on/off and non-C3 BLE configurations. Covers forced concurrent restoration, repeated requests, failed transitions, and retries.
- The original implementation is rejected by the same concurrent-transition assertion.
- clang-format 22.1.2 and `git diff --check` passed. Main CI also passed: X4/X4 Pro build, formatting, cppcheck, 546 host tests, and 43 script tests. Extended simulator/S3 hardware CI is still running.
- Isolated C3 firmware build passed with BLE enabled; FreeInk SDK remains `5faf69e8fdd4f3f959faa99c8814a38c117d7678`. Temporary diagnostics are absent.
- X4 mutex candidate: user confirmed non-power buttons do not respond during sleep, the power button wakes and restores title/hints, and Bluetooth connects.
- Final refactored firmware: flashed to X4 app0 after verifying chip, unchanged partition table/OTA selection, and a full app backup. Write hash and independent `verify-flash` both passed; About-screen version confirmation and battery-powered retest await user feedback. Firmware SHA-256: `d5e7f6fa3262cecd69bccd3dfa519b892b71b1dde06cb8520c4fc5ffdbbac58a`.
- Still unverified: ten consecutive BLE-off wakes plus ten minutes of clock updates, five complete Bluetooth reading/standby/wake/resumed-page-turn cycles, and X3 hardware acceptance. Bluetooth connection alone is not joint acceptance.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not a new interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This repairs an existing CrossMux regression; stock/fork feature comparisons do not remove the need to fix its wake deadlock.
- [x] HAL work was requested and reviewed with the CrossMux maintainer in the device-debugging session.

## Additional Context

The device bisect reports `cea786ea` working and `d4f62dc6` (PR #289) failing. The unsynchronized frequency method predates #289; the specific change exposing the timing has not been isolated. This PR fixes the demonstrated concurrency fault without attributing it to an unproven individual BLE change.

Device backups, diagnostic code, local build configuration, and firmware caches are excluded from the commit. No SDK changes.

### AI Usage

YES — Codex assisted with debugging, implementation, tests, and documentation; hardware observations above were reported by the maintainer.
