### PR TITLE
fix: validate reviewed SDK source snapshots

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -107,5 +107,11 @@ explicitly authorized:
 - CrossMux: index/conflict-marker checks, `git diff --check`, `pio run`,
   `pio run -e gh_release`, and extra build environments.
 
+SDK integration builds export the reviewed Git index into a real directory.
+This includes staged, uncommitted resolutions while excluding Git metadata and
+untracked/ignored debug artifacts; directory symlinks break PlatformIO's
+framework dependency path matching. Conflict-marker checks scan text files,
+so binary font bytes cannot produce false conflicts.
+
 Report local checks, dependency Draft PRs, CrossMux Draft PR, CI, deployment,
 and physical-device acceptance separately.

--- a/.claude/skills/sync-upstream/scripts/sync_upstream.py
+++ b/.claude/skills/sync-upstream/scripts/sync_upstream.py
@@ -681,7 +681,7 @@ def inspect_crossmux(
 
 def check_conflict_markers(root: Path) -> None:
     completed = git(
-        root, "grep", "-n", "-E", f"{'<' * 7}|{'>' * 7}", "--", ".", check=False
+        root, "grep", "-I", "-n", "-E", f"{'<' * 7}|{'>' * 7}", "--", ".", check=False
     )
     if completed.returncode == 0:
         raise RuntimeError("Conflict markers found in tracked files.")
@@ -731,7 +731,9 @@ def validate_sdk_candidate(
         run(["git", "clone", str(crossmux_root), str(checkout)], cwd=crossmux_root)
         if (checkout / "freeink-sdk").exists():
             shutil.rmtree(checkout / "freeink-sdk")
-        os.symlink(candidate, checkout / "freeink-sdk", target_is_directory=True)
+        # Materialize the reviewed index: symlinks break PlatformIO's path matching,
+        # and copying the worktree would also include unreviewed debug/build files.
+        git(candidate, "checkout-index", "--all", f"--prefix={checkout / 'freeink-sdk'}/")
         run_crossmux_builds(checkout, False, extra_envs)
 
 

--- a/.claude/skills/sync-upstream/tests/test_sync_upstream.py
+++ b/.claude/skills/sync-upstream/tests/test_sync_upstream.py
@@ -285,6 +285,36 @@ class UpstreamSnapshotPinTest(unittest.TestCase):
 
 
 class BuildValidationTest(unittest.TestCase):
+    def test_sdk_build_materializes_only_the_reviewed_index(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            crossmux = root / "crossmux"
+            candidate = root / "sdk"
+            init_repo(crossmux)
+            commit_file(crossmux, "README.md", "fixture\n", "initial")
+            init_repo(candidate)
+            commit_file(candidate, "source.cpp", "old source\n", "initial")
+            (candidate / "source.cpp").write_text("reviewed source\n")
+            (candidate / ".gitignore").write_text("*.o\n")
+            command(candidate, "git", "add", "source.cpp", ".gitignore")
+            (candidate / "debug.cpp").write_text("unreviewed\n")
+            (candidate / "build.o").write_bytes(b"ignored build artifact")
+
+            def build(checkout, skipped, extras):
+                sdk = checkout / "freeink-sdk"
+                self.assertFalse(sdk.is_symlink())
+                self.assertEqual((sdk / "source.cpp").read_text(), "reviewed source\n")
+                for excluded in (".git", "debug.cpp", "build.o"):
+                    self.assertFalse((sdk / excluded).exists())
+                self.assertFalse(skipped)
+                self.assertEqual(extras, ["x4c"])
+
+            with patch.object(sync_upstream, "SDK_HOST_TESTS", ()), patch.object(
+                sync_upstream, "run_crossmux_builds", side_effect=build
+            ) as builds:
+                sync_upstream.validate_sdk_candidate(candidate, crossmux, False, ["x4c"])
+            builds.assert_called_once()
+
     def test_crossmux_uses_current_release_environment(self):
         with patch.object(sync_upstream, "run") as run:
             sync_upstream.run_crossmux_builds(Path("/tmp/crossmux"), False, ["extra"])
@@ -300,6 +330,18 @@ class BuildValidationTest(unittest.TestCase):
 
 
 class ReviewGateTest(unittest.TestCase):
+    def test_conflict_scan_ignores_binary_fonts_but_rejects_text_markers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repo"
+            init_repo(root)
+            (root / "font.ttf").write_bytes(b"\0" + b">" * 7)
+            command(root, "git", "add", "font.ttf")
+            sync_upstream.check_conflict_markers(root)
+            (root / "source.cpp").write_text("<" * 7 + " HEAD\n")
+            command(root, "git", "add", "source.cpp")
+            with self.assertRaisesRegex(RuntimeError, "Conflict markers"):
+                sync_upstream.check_conflict_markers(root)
+
     def test_pr_body_pairs_each_review_item_with_its_decision(self):
         state = {
             "component": "sdk",


### PR DESCRIPTION
SDK candidate validation could fail before building: binary font bytes triggered the conflict scanner, and a symlinked SDK made PlatformIO's framework dependency paths disagree.

Export the reviewed Git index to a real SDK directory and scan text files for conflict markers. This validates staged, uncommitted resolutions without importing untracked debug files or ignored build artifacts. Document the validation contract.

Validation: 22 sync workflow tests passed, including a real-repository check for staged-source export and exclusion of Git/debug/build files, plus binary-font/text-conflict coverage. `git diff --check` passed.
