### PR TITLE
chore: integrate reviewed SDK upstream snapshot

### DIFF
--- a/docs/engineering/index.md
+++ b/docs/engineering/index.md
@@ -26,6 +26,7 @@ that matches your task — don't load everything at once.
 | [eego-a4.md](eego-a4.md) | Building, first-flashing, recovering, or hardware-validating the experimental ESP32-S3 eego A4 target. |
 | [murphy-m4.md](murphy-m4.md) | Building, first-flashing, recovering, or hardware-validating the experimental ESP32-S3 Murphy M4 target. |
 | [waveshare-epaper-397.md](waveshare-epaper-397.md) | Building, flashing, or hardware-validating the experimental Waveshare ESP32-S3 ePaper 3.97 target. |
+| [sdk-upstream-sync.md](sdk-upstream-sync.md) | Reviewing the September 2026 SDK integration, upstream touch-menu behavior, source snapshots, and hardware acceptance limits. |
 | [upstream-merge-policy.md](upstream-merge-policy.md) | Resolving a sync conflict on `CLAUDE.md` / `.skills/SKILL.md` — how to keep the map thin and route upstream changes into these docs. |
 
 ## Related docs outside this directory

--- a/docs/engineering/sdk-upstream-sync.md
+++ b/docs/engineering/sdk-upstream-sync.md
@@ -1,0 +1,77 @@
+# FreeInk SDK synchronization — September 2026
+
+This integration preserves CrossMux's device support and UI extensions while
+bringing the SDK fork through upstream `14028b179cc5a85a7a4cf0ccb33980dce8737735`.
+The `freeink-sdk` gitlink is the authoritative fork revision; the SDK review is
+[freeink-sdk#24](https://github.com/0x1abin/freeink-sdk/pull/24). The simulator
+remains pinned to `dacbbbcdc133a052f9122347429fdcb8cddf80af`, which already
+contains its reviewed upstream snapshot. Reader behavior comparisons use
+`da7feed5c7e777b2bb9be6e0848c9e42a5faea29`.
+
+## Review decisions
+
+- Preserve the fork's dark-background redrive. Add the UC8279 four-tone image
+  bank with upstream's 60% timing and 25% coverage threshold. Its five 49-byte
+  tables and initialization flag use 246 static bytes; bounded phase fields
+  keep the temporary array at 140 bytes, without a new heap buffer.
+- Keep device-specific input edges and transition isolation. Standalone Home
+  events count as activity; a Home event during a held screen contact must not
+  retire that contact's suppression.
+- Keep the fork's SPI configuration. Large stream reads service a subscribed
+  task watchdog and yield every 100 ms in the shared SD streaming routine.
+- Preserve list styling, add section headings, and use measured row counts for
+  clipped-list scrolling and scrollbar placement. Draw the scrollbar after a
+  full-width selected background.
+- Keep selected tab text and add optional arrows. Measure with the same style
+  used for drawing; reuse each tab's measured geometry within the drawing pass.
+  Content-width layout still needs a separate width preflight. No metrics cache
+  or new allocation is introduced.
+- Resolve solid foreground ink once. Native text must not invert white twice;
+  the legacy renderer adapter retains its explicit-inverted semantics.
+
+The temporary lightless-page control-center extension was removed completely.
+There is no Sticky-specific replacement handler. Menu dispatch follows the
+existing upstream capability rule:
+
+| Input | No frontlight, including Sticky | Frontlight present, including X4 Pro |
+| --- | --- | --- |
+| Ordinary-page top-edge down-swipe | Delivered to the current page | Control center |
+| Reading-page top-edge down-swipe | Reading menu | Control center |
+| Reading-page center tap | Reading menu when enabled by settings | Same |
+
+Status-bar taps retain the existing top-level page whitelist. The Inx recent
+page does not acquire a new tap region. The control-center regression executes
+production dispatch, including pending transitions, exclusive storage,
+allocation failure, and suppression; it adds no production policy abstraction.
+
+## Validation and limits
+
+The SDK's four host suites retain both upstream and fork coverage. Regression
+checks cover Home/contact overlap, clipped-list tails, selected-font arrows,
+white foreground pixels, and generated UC8279 LUT bytes at five timing settings.
+Tab measurement checks also cover content-width and equal-width layouts.
+
+Final publication passed builds for `default`, `gh_release`, `x4c`, `eego_a4`,
+`murphy_m4`, `waveshare_epaper_397`, and `sticky`. SDK integration also runs the
+normal CrossMux CI, including the X4/X4 Pro build and hardware/simulator matrix.
+A successful build is not a hardware acceptance result.
+
+The user confirmed the three Sticky menu gestures above and reported normal
+X4 validation after testing the candidate. Those hardware runs used CrossMux
+`c2fb3467c39a3e067fe4e41303fa4226e40e986a` and SDK candidate tree
+`0eb44b2461b3112c8bdc94035b1aa1cd1e4de86a`; the final review additionally reuses
+tab metrics and integrates the current CrossMux base. These later changes are
+covered by host/build checks, not a claim of another hardware run.
+
+UC8279 physical waveform quality, Home/screen overlap timing, SD long-transfer
+watchdog behavior, and other boards still need their own hardware acceptance.
+Sticky logs also recorded existing duplicate framebuffer-storage and power-lock
+warnings; the menu acceptance does not establish that these unrelated paths
+are warning-free.
+
+For repeatable validation, the sync tool exports the reviewed Git index into a
+real directory rather than linking or copying an entire working directory.
+Only staged sources enter the build; untracked debug files, ignored artifacts,
+and Git metadata do not. The conflict scanner checks text files, excluding
+binary font bytes. See the [sync skill](../../.claude/skills/sync-upstream/SKILL.md)
+for the candidate and publication workflow.

--- a/scripts/tests/test_control_center_gesture.py
+++ b/scripts/tests/test_control_center_gesture.py
@@ -1,0 +1,109 @@
+"""Keep menu dispatch aligned with Reader upstream da7feed5 on touch devices."""
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ControlCenterGestureTest(unittest.TestCase):
+    def test_dispatch_and_input_ownership(self):
+        source = (ROOT / "src/activities/ActivityManager.cpp").read_text()
+        start = source.index("void ActivityManager::loop() {")
+        end = source.index("  while (pendingAction.load() != PendingAction::None)", start)
+        dispatch = source[start:end] + "}\n"
+        harness = r'''
+#include <atomic>
+#include <cassert>
+#include <memory>
+#include <string>
+#define LOG_ERR(...) ((void)0)
+enum { eIncrement };
+void xTaskNotify(int, int, int) {}
+struct Activity {
+  std::string name = "InxRecent";
+  bool reader = false, exclusive = false;
+  int loops = 0;
+  bool requiresExclusiveStorageLoop() { return exclusive; }
+  bool isReaderActivity() { return reader; }
+  bool isHomeActivity() { return false; }
+  bool handleHomeGesture() { return false; }
+  void loop() { ++loops; }
+};
+struct Input {
+  bool topSwipe = true, light = false, tap = false, suppressed = false;
+  bool consumeSuppressedRelease() { return suppressed; }
+  bool wasHomeGesture() { return false; }
+  bool hasTouch() { return true; }
+  bool wasScreenTapped(int&, int& y) { y = 10; return tap; }
+  bool wasLightPanelGesture() { return light && topSwipe; }
+  bool wasMenuGesture() { return topSwipe; }
+};
+struct FrontlightPanelActivity { FrontlightPanelActivity(int, Input&) {} };
+bool failAllocation = false;
+template<class T, class... Args> std::unique_ptr<T> makeUniqueNoThrow(Args&&... args) {
+  return failAllocation ? nullptr : std::make_unique<T>(std::forward<Args>(args)...);
+}
+struct ActivityManager {
+  enum class PendingAction { None, Push };
+  std::atomic<PendingAction> pendingAction{PendingAction::None};
+  std::atomic<bool> requestedUpdate{false};
+  Activity* currentActivity;
+  Input mappedInput;
+  int renderer = 0, renderTaskHandle = 0, pushes = 0;
+  bool handleMainTabInput() { return false; }
+  void goHome() { assert(false); }
+  void pushActivity(std::unique_ptr<FrontlightPanelActivity>) {
+    ++pushes; pendingAction = PendingAction::Push;
+  }
+  void loop();
+};
+'''
+        cases = r'''
+int main() {
+  const auto check = [](Activity page, Input input, bool opens, bool runs) {
+    ActivityManager manager{.currentActivity = &page, .mappedInput = input};
+    manager.loop();
+    assert(manager.pushes == int(opens));
+    assert(page.loops == int(runs)); // Opening must not also scroll/turn a page.
+    if (opens) {
+      manager.loop(); // A pending push cannot enqueue a second panel.
+      assert(manager.pushes == 1 && page.loops == 0);
+    }
+  };
+  for (bool light : {false, true})
+    for (bool reader : {false, true})
+      check({.reader = reader}, {.light = light}, light, !light);
+
+  for (const char* name : {"InxRecent", "FileBrowser", "Settings", "Home", "FrontlightPanel"}) {
+    const bool opens = std::string(name) != "FrontlightPanel";
+    check({.name = name}, {.light = true}, opens, !opens);
+  }
+  for (const char* name : {"Home", "FileBrowser", "Settings", "NetworkModeSelection", "InxRecent", "EpubReader", "FrontlightPanel"}) {
+    const std::string page(name);
+    const bool opens = page == "Home" || page == "FileBrowser" ||
+                       page == "Settings" || page == "NetworkModeSelection";
+    check({.name = name}, {.topSwipe = false, .tap = true}, opens, !opens);
+  }
+  check({}, {.light = true, .suppressed = true}, false, false);
+  check({.exclusive = true}, {.light = true}, false, true);
+  check({}, {.topSwipe = false}, false, true);
+  failAllocation = true;
+  check({}, {.light = true}, false, false); // OOM does not leak the gesture.
+}
+
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            cpp = Path(directory) / "check.cpp"
+            exe = Path(directory) / "check"
+            cpp.write_text(harness + dispatch + cases)
+            subprocess.run(shlex.split(os.environ.get("CXX", "c++")) + [
+                "-std=c++20", str(cpp), "-o", str(exe)], check=True)
+            subprocess.run([str(exe)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,3 +99,5 @@ add_subdirectory(reader_build_failure)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 add_test(NAME PioarduinoCache
   COMMAND ${Python3_EXECUTABLE} ${REPO_ROOT}/scripts/tests/test_pioarduino_cache.py)
+add_test(NAME ControlCenterGesture
+  COMMAND ${Python3_EXECUTABLE} ${REPO_ROOT}/scripts/tests/test_control_center_gesture.py)


### PR DESCRIPTION
Integrate the reviewed FreeInk SDK upstream snapshot `14028b17` while preserving CrossMux device support, dark-background redrive, input isolation and UI styling. The SDK now supports the upstream grayscale bank, Home-key activity, periodic SD watchdog servicing, measured list scrolling and optional tab arrows. The final review removes repeated tab measurement without adding storage or APIs.

SDK review and merge: [freeink-sdk#24](https://github.com/0x1abin/freeink-sdk/pull/24). Reviewed-source validation tooling: [#293](https://github.com/0x1abin/crossmux/pull/293).

Menu behavior stays at Reader upstream `da7feed5`: frontlit devices use top-edge down-swipes for the control center; lightless reading pages retain the reading menu. The temporary ordinary-page extension was completely removed. This PR adds a regression that executes the existing dispatch and checks frontlight routing, status-bar taps, duplicate pushes, storage exclusivity and input ownership. There is no ActivityManager production change.

The engineering record captures the overlap decisions, bounded memory cost, source snapshot validation and hardware acceptance limits. The simulator pin remains unchanged.

Validation:
- Four SDK host suites pass, including 2,867 UI checks and Home/contact checks; five waveform timing settings match the reviewed LUT bytes.
- Final SDK source passes local default, gh_release, x4c, eego_a4, murphy_m4, waveshare_epaper_397 and sticky builds.
- Menu dispatch and existing Inx navigation: 19/19 checks pass; whitespace checks pass.
- User confirmed Sticky menu behavior and normal X4 operation on the earlier candidate. The final tab measurement cleanup/current base have host/build coverage; no additional physical run is claimed. UC8279 waveform quality and long-transfer timing still require device acceptance.

Full Reader upstream integration remains a separate review stage.
