### PR TITLE
fix(ble): keep C3 and PSRAM hosts connected across chapter builds

### DIFF
--- a/docs/engineering/c3-bluetooth.md
+++ b/docs/engineering/c3-bluetooth.md
@@ -15,7 +15,7 @@ or completion of the quantitative endurance matrix below.
 | `HalPowerManager` | Keep normal CPU frequency throughout the C3 host lifetime, including scan/reconnect. Restore ordinary idle policy after stop. The manual 10 MHz idle clock bypasses IDF power locks. |
 | `BleInput` | Apply reader **80/32 KiB** and settings **70/24 KiB** internal free/largest gates. Reader recovery releases rebuildable font caches, retaining the selected font. Identical failure/context logs are suppressed; attempts still run. |
 | `main.cpp` | Maintain an existing reader/menu connection, and automatically start only when reading is ready. Wi-Fi, exclusive storage and leaving the reader stop the host. Keep the existing two-second failed-start retry. |
-| `EpubReaderActivity` | Share the partial-cache restart predicate between readiness and background construction. Evaluate restart/build/suspend under one render lock. Stop BLE **before** all four construction entrypoints allocate. |
+| `EpubReaderActivity` | Share the partial-cache restart predicate between readiness and background construction. Evaluate restart/build/suspend under one render lock. Retain existing C3/PSRAM BLE links during construction and first indexing; reclaim C3 font caches before all four chapter construction entrypoints allocate. Other internal-RAM BLE hosts still stop before building. |
 | `Section` | Own and release parser/build resources. Persist a partial cache on suspension; invalidate page counts and report I/O error if the commit fails. |
 | SDK `BleKeyboardHost` | Own the fixed device list, bonding, eight-second connection timeout and four-second reconnect cadence. C3 callbacks copy discoveries without retaining NimBLE's duplicate result list. Worker allocation failure cleans up and returns false. |
 
@@ -25,6 +25,10 @@ the parser. Merely pausing parsing would retain its heap. Approaching the partia
 watermark resumes the same construction path. Full-index requests and unresolved
 saved-position remapping retain their existing completion requirements. Other
 platforms and Bluetooth-off reading keep their original build window.
+
+Chapter construction and first indexing retain the existing memory thresholds,
+CSS fallback and framebuffer loan. Low memory does not trigger a BLE-disconnect
+fallback. Readiness still defers starting a new host until construction is ready.
 
 Large C3 BLE font coverage tables use 32-entry pages plus sparse first-codepoint
 keys when the resident representation exceeds 4 KiB. A 4,000-interval full table
@@ -80,6 +84,21 @@ Host checks exercise production lifecycle methods, startup failure/retry, input
 isolation, CPU protection, profile/link isolation, paged/resident lookup agreement,
 non-BMP and page boundaries, corrupt files, allocation failures, short-read retry
 and Flash fallback. They do not model the actual controller or prove radio timing.
+
+### Chapter-build connection retention (September 12)
+
+The user reported normal X4 operation with the C3 keep-connection experiment.
+The flashed diagnostic image had SHA256
+`e5b989bb776a1f7aced3b283bb40ad4c7a46b3f9a0d8556f74331573c1dfaac7`;
+write verification and an independent Flash comparison passed. The submitted
+version retains the two connection guards and removes experimental stage logs
+and the local NimBLE debug override. It is a different image and has not inherited
+the diagnostic image's hardware verification.
+
+Lifecycle and index-entry tests cover C3, PSRAM BLE, other internal-RAM BLE and
+unavailable BLE, including stop counts, failure paths and framebuffer return.
+User feedback does not complete the endurance matrix below or distinguish
+full-style success from CSS fallback. X3 hardware validation remains pending.
 
 ### All-hardware enablement (September 7)
 

--- a/scripts/tests/test_ble_chapter_lifecycle.py
+++ b/scripts/tests/test_ble_chapter_lifecycle.py
@@ -22,14 +22,15 @@ def method(source, signature):
     return source[start:end]
 
 
-def execute(source, c3=1, ble=1):
+def execute(source, c3=1, ble=1, psram=0):
     with tempfile.TemporaryDirectory() as directory:
         cpp = Path(directory) / 'check.cpp'
         exe = Path(directory) / 'check'
         cpp.write_text(source)
         result = subprocess.run(shlex.split(os.environ.get('CXX', 'c++')) + [
             '-std=c++17', f'-DCONFIG_IDF_TARGET_ESP32C3={c3}',
-            f'-DFREEINK_CAP_BLE_HID_HOST={ble}', str(cpp), '-o', str(exe)],
+            f'-DFREEINK_CAP_BLE_HID_HOST={ble}', f'-DCROSSPOINT_BLE_HOST_PSRAM={psram}',
+            str(cpp), '-o', str(exe)],
             capture_output=True, text=True)
         if result.returncode:
             raise AssertionError(result.stderr)
@@ -46,20 +47,24 @@ class ChapterLifecycleTest(unittest.TestCase):
 #define LOG_DBG(...) ((void)0)
 #define LOG_INF(...) ((void)0)
 struct { bool bluetoothEnabled = true; } SETTINGS;
+constexpr bool hasBle = FREEINK_CAP_BLE_HID_HOST;
+constexpr bool keepBleDuringBuild = hasBle && (CONFIG_IDF_TARGET_ESP32C3 || CROSSPOINT_BLE_HOST_PSRAM);
+constexpr int buildStops = hasBle && !keepBleDuringBuild ? 1 : 0;
 bool running = false;
 namespace bleinput {
  enum class StartContext { Reader };
- enum class StartResult { Started, LowMemory, Failed };
+ enum class StartResult { Started, LowMemory, Failed, Unavailable };
  int starts=0, stops=0;
  StartResult result=StartResult::Started;
- bool isRunning() { return running; }
- void stop() { if(running) ++stops; running=false; }
+ bool isRunning() { return hasBle && running; }
+ void stop() { ++stops; running=false; }
  void logDiagnostics(const char*) {}
  template<class T> StartResult ensureStarted(T&, StartContext) {
+   if (!hasBle) return StartResult::Unavailable;
    ++starts; running=result==StartResult::Started; return result;
  }
 }
-struct Cache { int releases=0; void releaseSdFontCaches() { assert(!running); ++releases; } };
+struct Cache { int releases=0; void releaseSdFontCaches() { assert(!running || keepBleDuringBuild); ++releases; } };
 struct { Cache cache; Cache* getFontCacheManager() { return &cache; } } renderer;
 struct RenderLock {
  static inline bool held=false;
@@ -79,9 +84,9 @@ struct Section {
  bool isPartial() const { return partial; }
  bool isBuildComplete() const { return complete; }
  BuildError buildError() const { return error; }
- bool startBuild(int) { assert(!running && RenderLock::depth==1); ++begins; building=true; return true; }
+ bool startBuild(int) { assert((!running || keepBleDuringBuild) && RenderLock::depth==1); ++begins; building=true; return true; }
  bool buildSomeMore(int pages) {
-   assert(!running && RenderLock::depth==1);
+   assert((!running || keepBleDuringBuild) && RenderLock::depth==1);
    if(fail) { building=false; error=BuildError::Io; return false; }
    pageCount+=pages;
    if(pageCount>=end) { complete=true; building=false; partial=false; }
@@ -126,9 +131,12 @@ int main() {
  assert(!reader.deferBluetoothStart());
  reader.section=nullptr; assert(reader.deferBluetoothStart());
  updateBluetoothLifecycle(); assert(bleinput::starts==0); // Initial open / chapter selection.
- running=true; updateBluetoothLifecycle(); assert(running); // Menu / cancellation holds link.
- reader.section=&section; updateBluetoothLifecycle(); assert(running);
- reader.prepareChapterBuild(); assert(!running);
+ running=hasBle; updateBluetoothLifecycle(); assert(running==hasBle); // Menu / cancellation holds link.
+ reader.section=&section; updateBluetoothLifecycle(); assert(running==hasBle);
+ const int stopsBeforePrepare=bleinput::stops;
+ reader.prepareChapterBuild(); assert(running==keepBleDuringBuild);
+ assert(bleinput::stops==stopsBeforePrepare+buildStops);
+ assert(renderer.cache.releases==(CONFIG_IDF_TARGET_ESP32C3 && hasBle ? 1 : 0));
  section.building=true; updateBluetoothLifecycle(); assert(bleinput::starts==0);
  section.building=false; section.pageCount=0;
  assert(reader.deferBluetoothStart()); // Failed build cannot reconnect into unreadable state.
@@ -148,6 +156,7 @@ int main() {
  bleinput::result=bleinput::StartResult::Started; now=4000;
  updateBluetoothLifecycle(); assert(running);
 #endif
+ const int stopsBeforeBackground=bleinput::stops;
  RenderLock::held=true;
  assert(reader.updateChapterBuild());
  assert(section.begins==0); // Busy rendering must never trigger construction.
@@ -157,9 +166,11 @@ int main() {
  RenderLock::onAcquire=[] { reader.section=nullptr; };
  assert(reader.updateChapterBuild());
  RenderLock::onAcquire=nullptr; reader.section=&section;
+ assert(bleinput::stops==stopsBeforeBackground);
  section.currentPage=15; assert(reader.deferBluetoothStart());
- reader.updateChapterBuild(); assert(!running && section.begins==1); // Stop precedes background allocations.
+ reader.updateChapterBuild(); assert(running==keepBleDuringBuild && section.begins==1);
  for(int i=0;i<100 && section.building;++i) reader.updateChapterBuild();
+ assert(running==keepBleDuringBuild && bleinput::stops==stopsBeforeBackground+buildStops);
 #if CONFIG_IDF_TARGET_ESP32C3 && FREEINK_CAP_BLE_HID_HOST
  assert(section.partial && section.suspends==1 && section.pageCount<section.end);
 #else
@@ -170,8 +181,10 @@ int main() {
 #if FREEINK_CAP_BLE_HID_HOST
  assert(running);
 #endif
+ const int stopsBeforeFailure=bleinput::stops;
  section.partial=true; section.currentPage=section.pageCount-1; section.fail=true;
- reader.updateChapterBuild(); assert(!running && !section.building && reader.failures==1);
+ reader.updateChapterBuild(); assert(running==keepBleDuringBuild && !section.building && reader.failures==1);
+ assert(bleinput::stops==stopsBeforeFailure+buildStops);
  section.fail=false; section.partial=false; section.complete=false; section.building=true;
  section.currentPage=0; section.pageCount=2; section.end=8;
  reader.cachedVisibleTextOffset=42;
@@ -183,8 +196,75 @@ int main() {
 #endif
 }
 '''
-        for c3, ble in ((1, 1), (0, 1), (1, 0)):
-            execute(harness + production + checks, c3, ble)
+        for c3, ble, psram in ((1, 1, 0), (0, 1, 0), (0, 1, 1), (1, 0, 0)):
+            with self.subTest(c3=c3, ble=ble, psram=psram):
+                execute(harness + production + checks, c3, ble, psram)
+
+    def test_book_index_preserves_connection_and_framebuffer_loan(self):
+        # Execute the real loadBook prefix through indexing, before reader-position setup.
+        source = method(EPUB, 'bool EpubReaderActivity::loadBook()')
+        source = source[:source.index('  if (!loaded) {')] + '  return loaded;\n}'
+        harness = r'''
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#define LOG_ERR(...) ((void)0)
+constexpr bool hasBle = FREEINK_CAP_BLE_HID_HOST;
+constexpr bool keepBle = hasBle && (CONFIG_IDF_TARGET_ESP32C3 || CROSSPOINT_BLE_HOST_PSRAM);
+bool running=false, cacheExists=false, borrowed=false, loadSuccess=true;
+int stops=0, loads=0, popups=0, refreshDisables=0;
+namespace bleinput {
+ void stop() { ++stops; running=false; }
+ void logDiagnostics(const char*) {}
+}
+struct { bool exists(const char*) { return cacheExists; } } Storage;
+struct GfxRenderer {
+ struct FrameBufferLoan {
+  explicit FrameBufferLoan(GfxRenderer&) { assert(!borrowed); borrowed=true; }
+  ~FrameBufferLoan() { assert(borrowed); borrowed=false; }
+ };
+} renderer;
+constexpr int STR_INDEXING=1;
+int tr(int value) { return value; }
+struct { void drawPopup(GfxRenderer&,int) { assert(!borrowed); ++popups; } } GUI;
+struct { int embeddedStyle=1; } SETTINGS;
+struct Epub {
+ Epub(const std::string&,const char*) {}
+ std::string getCachePath() { return "/test"; }
+ bool load(bool,bool) {
+  ++loads;
+  assert(borrowed==!cacheExists);
+  assert(running==(cacheExists ? hasBle : keepBle));
+  return loadSuccess;
+ }
+};
+template<class T,class... Args> auto makeUniqueNoThrow(Args&&... args) {
+ return std::make_unique<T>(std::forward<Args>(args)...);
+}
+struct EpubReaderActivity {
+ std::string bookPath="test.epub";
+ bool loadBook();
+ void disableFastInitialRefresh() { ++refreshDisables; }
+};
+'''
+        checks = r'''
+int main() {
+ EpubReaderActivity reader;
+ for(bool cached : {false,true}) for(bool success : {false,true}) {
+  cacheExists=cached; loadSuccess=success; running=hasBle;
+  stops=loads=popups=refreshDisables=0;
+  assert(reader.loadBook()==success);
+  assert(!borrowed && loads==1);
+  assert(stops==(!cached && hasBle && !keepBle ? 1 : 0));
+  assert(popups==(!cached ? 1 : 0) && refreshDisables==popups);
+ }
+}
+'''
+        for c3, ble, psram in ((1, 1, 0), (0, 1, 0), (0, 1, 1), (1, 0, 0)):
+            with self.subTest(c3=c3, ble=ble, psram=psram):
+                execute(harness + source + checks, c3, ble, psram)
 
     def test_every_build_entry_prepares_before_allocating(self):
         for match in re.finditer(r'section->(?:startBuild|createSectionFile)\(', EPUB):

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -197,7 +197,15 @@ bool EpubReaderActivity::deferBluetoothStart() const {
 }
 
 void EpubReaderActivity::prepareChapterBuild() {
+#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM
+  // A non-PSRAM BLE host (C3 X3/X4) shares internal RAM with the chapter
+  // parser, so it must drop the link here; the host restarts and the remote
+  // reconnects after the build. On PSRAM-hosted BLE (X4 Pro, X4C, Sticky,
+  // EEGO A4, Murphy M4) the parser and the host use separate memory pools:
+  // keep the existing BT connection alive so the page-turn remote does not
+  // disconnect and reconnect on every chapter switch.
   bleinput::stop();
+#endif
 #if CONFIG_IDF_TARGET_ESP32C3 && FREEINK_CAP_BLE_HID_HOST
   // Reclaim arenas before parser allocations interleave with them; retain the
   // selected font and coverage index for both layout and subsequent reading.
@@ -290,7 +298,12 @@ bool EpubReaderActivity::loadBook() {
 
   const bool uncached = !Storage.exists((loadedEpub->getCachePath() + "/book.bin").c_str());
   if (uncached) {
+#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM
+    // Same rationale as prepareChapterBuild(): only a non-PSRAM BLE host drops
+    // the link while the book index is being built. PSRAM-hosted hosts (X4 Pro
+    // et al.) keep the existing connection alive across indexing.
     bleinput::stop();
+#endif
     disableFastInitialRefresh();
     GUI.drawPopup(renderer, tr(STR_INDEXING));
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -197,13 +197,8 @@ bool EpubReaderActivity::deferBluetoothStart() const {
 }
 
 void EpubReaderActivity::prepareChapterBuild() {
-#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM
-  // A non-PSRAM BLE host (C3 X3/X4) shares internal RAM with the chapter
-  // parser, so it must drop the link here; the host restarts and the remote
-  // reconnects after the build. On PSRAM-hosted BLE (X4 Pro, X4C, Sticky,
-  // EEGO A4, Murphy M4) the parser and the host use separate memory pools:
-  // keep the existing BT connection alive so the page-turn remote does not
-  // disconnect and reconnect on every chapter switch.
+  // C3 and PSRAM hosts retain existing links; parser memory guards still apply.
+#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM && !CONFIG_IDF_TARGET_ESP32C3
   bleinput::stop();
 #endif
 #if CONFIG_IDF_TARGET_ESP32C3 && FREEINK_CAP_BLE_HID_HOST
@@ -235,7 +230,7 @@ bool EpubReaderActivity::updateChapterBuild() {
   suspendForBluetooth = SETTINGS.bluetoothEnabled;
 #endif
   // A paused parser still owns its heap. Build beyond the restart margin, then
-  // persist a partial cache and release the parser before BLE may reconnect.
+  // persist a partial cache and release the parser to bound its lifetime.
   const int buildWindow = BUILD_WINDOW_AHEAD + (suspendForBluetooth ? PARTIAL_REBUILD_START_MARGIN : 0);
   const bool pendingReposition = cachedVisibleTextOffset.has_value() || cachedChapterTotalPageCount != 0;
   if (((!suspendForBluetooth && section->isPartial()) || (suspendForBluetooth && pendingReposition) ||
@@ -298,10 +293,7 @@ bool EpubReaderActivity::loadBook() {
 
   const bool uncached = !Storage.exists((loadedEpub->getCachePath() + "/book.bin").c_str());
   if (uncached) {
-#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM
-    // Same rationale as prepareChapterBuild(): only a non-PSRAM BLE host drops
-    // the link while the book index is being built. PSRAM-hosted hosts (X4 Pro
-    // et al.) keep the existing connection alive across indexing.
+#if FREEINK_CAP_BLE_HID_HOST && !CROSSPOINT_BLE_HOST_PSRAM && !CONFIG_IDF_TARGET_ESP32C3
     bleinput::stop();
 #endif
     disableFastInitialRefresh();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,8 +94,8 @@ void updateBluetoothLifecycle() {
     bleinput::stop();
     return;
   }
-  // Preparation blocks new starts, not a link held by a reader's menu. Actual
-  // build entrypoints stop BLE before allocating their working memory.
+  // Preparation blocks new starts; C3 and PSRAM readers keep existing links
+  // through chapter construction and book indexing.
   if (bleinput::isRunning() || activityManager.deferBluetoothStart() || RenderLock::peek() ||
       millis() < nextStartAttemptAt)
     return;


### PR DESCRIPTION
## Behavior

Chapter construction and uncached book indexing now retain existing BLE connections on ESP32-C3 (shared X3/X4 firmware) and PSRAM-hosted BLE targets. Other internal-RAM BLE targets retain their stop-before-build policy.

C3 font-cache reclamation, the 20-page partial-build window, render locking, framebuffer borrowing, memory thresholds and CSS fallback remain unchanged. Existing startup readiness/retry and Bluetooth-off, reader-exit, sleep and Wi-Fi lifecycle rules are preserved. No new public API, setting or persistent allocation is added.

## Tests

Fix the lifecycle test's unavailable-BLE double and obsolete stop assertions. Exercise C3, PSRAM BLE, other internal-RAM BLE and unavailable BLE with explicit stop counts; add cached/uncached index-entry checks, including failure and framebuffer return.

Local validation of the cleaned source:
- Lifecycle tests pass; independently forcing BLE to stop at either build entrypoint fails the C3 and PSRAM checks.
- All 547 CTest entries and 46 script tests pass; FreeInk Book/UI host tests pass.
- Repository clang-format 21 check and default cppcheck pass.
- Standard `default` and `x4pro` firmware builds pass without the experimental local logging override.

## Hardware evidence and limits

The user reported normal X4 operation with the flashed diagnostic experiment (`e5b989bb776a1f7aced3b283bb40ad4c7a46b3f9a0d8556f74331573c1dfaac7`), whose Flash contents were independently verified. This PR retains its connection conditions, removes experimental diagnostics, and corrects the resource-policy documentation/comments.

The cleaned firmware has not been flashed or hardware-validated. X3 hardware acceptance and the full endurance matrix remain pending; user feedback does not establish zero radio disconnects across that matrix or distinguish full-style success from CSS fallback.

Implementation and validation were assisted by Codex.
