### PR TITLE
fix(games): separate aiming from acting on touch in gomoku and minesweeper

### DIFF
--- a/src/activities/apps/gomoku/GomokuGameActivity.cpp
+++ b/src/activities/apps/gomoku/GomokuGameActivity.cpp
@@ -147,30 +147,83 @@ void GomokuGameActivity::intersectionXY(uint8_t r, uint8_t c, int* x, int* y) co
   *y = boardOriginY() + static_cast<int>(r) * boardPitch();
 }
 
+// The board's own rectangle: the grid plus half a pitch of slop, which is
+// exactly the intersection hit tolerance. Touch inside it aims the cursor.
+Rect GomokuGameActivity::boardTouchRect() const {
+  const int pitch = boardPitch();
+  const int n = board.boardSize;
+  const int ox = boardOriginX();
+  const int oy = boardOriginY();
+  const int len = (n - 1) * pitch;
+  const int pad = pitch / 2;
+  return Rect{ox - pad, oy - pad, len + 2 * pad, len + 2 * pad};
+}
+
+// Bottom action bar geometry, scaled from the panel size rather than pinned to
+// absolute pixels: this firmware ships several targets with different panels, so
+// the bar is measured UP FROM THE SCREEN BOTTOM and sized as a fraction of the
+// panel height, with a floor so it stays a comfortable touch target.
+int GomokuGameActivity::actionBarH() const {
+  return std::max(ACTION_BAR_MIN_H, renderer.getScreenHeight() * ACTION_BAR_H_FRAC / 100);
+}
+
+int GomokuGameActivity::actionBarY() const {
+  const int h = renderer.getScreenHeight();
+  return h - actionBarH() - std::max(4, h * ACTION_BAR_BOTTOM_FRAC / 100);
+}
+
+Rect GomokuGameActivity::actionBarRect() const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const int side = std::max(8, metrics.contentSidePadding);
+  return Rect{side, actionBarY(), renderer.getScreenWidth() - 2 * side, actionBarH()};
+}
+
 // ---------- Input ----------
 
 void GomokuGameActivity::handleInputPlaying() {
   int touchX = 0;
   int touchY = 0;
-  int row = 0;
-  int column = 0;
-  if (mappedInput.wasScreenTouchDown(touchX, touchY) &&
-      gameIntersectionFromPoint(boardOriginX(), boardOriginY(), boardPitch(), board.boardSize, board.boardSize, touchX,
-                                touchY, row, column)) {
+  // Touch never places a stone: touching the board only aims the cursor. The
+  // 15x15 grid has 30 px cells, so a finger landing "on" an intersection can
+  // still be aiming at its neighbour; placing on touch turns a mis-aim into an
+  // irreversible move. The bottom action bar commits the stone at the
+  // highlighted cursor, so aiming and committing are separate gestures.
+  const Rect boardRect = boardTouchRect();
+  const Rect placeButton = actionBarRect();
+  const auto inRect = [](const Rect& r, const int x, const int y) {
+    return r.width > 0 && r.height > 0 && x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height;
+  };
+  const auto aimAt = [&](const int x, const int y) {
+    int row = 0;
+    int column = 0;
+    if (!gameIntersectionFromPoint(boardOriginX(), boardOriginY(), boardPitch(), board.boardSize, board.boardSize, x, y,
+                                   row, column)) {
+      return false;
+    }
+    if (cursorR == static_cast<uint8_t>(row) && cursorC == static_cast<uint8_t>(column)) return false;
     cursorR = static_cast<uint8_t>(row);
     cursorC = static_cast<uint8_t>(column);
     requestUpdate();
-    return;
-  }
-  if (mappedInput.wasScreenTapped(touchX, touchY) &&
-      gameIntersectionFromPoint(boardOriginX(), boardOriginY(), boardPitch(), board.boardSize, board.boardSize, touchX,
-                                touchY, row, column)) {
-    cursorR = static_cast<uint8_t>(row);
-    cursorC = static_cast<uint8_t>(column);
+    return true;
+  };
+
+  // The action bar is checked first: it sits below the board, but checking it up
+  // front keeps the two regions from ever fighting over an edge pixel.
+  if (mappedInput.wasScreenTapped(touchX, touchY) && inRect(placeButton, touchX, touchY)) {
     doPlace();
     requestUpdate();
     return;
   }
+
+  if (mappedInput.wasScreenTouchDown(touchX, touchY) && inRect(boardRect, touchX, touchY)) {
+    aimAt(touchX, touchY);
+  }
+
+  if (mappedInput.wasScreenTapped(touchX, touchY) && inRect(boardRect, touchX, touchY)) {
+    aimAt(touchX, touchY);
+    return;  // aim only — the stone is committed by the action bar or Confirm
+  }
+
   if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
     moveCursor(-1, 0);
     requestUpdate();
@@ -398,6 +451,11 @@ void GomokuGameActivity::renderPlaying() {
   drawBoard();
   drawInfoPanel();
   drawModeLine();
+  // Touch targets: the place button is the only way to commit a stone by touch,
+  // since tapping the board just aims the cursor.
+  if (mappedInput.hasTouch()) {
+    GUI.drawActionButton(renderer, actionBarRect(), tr(STR_GOMOKU_PLACE), true);
+  }
   drawFooter();
 }
 
@@ -527,10 +585,12 @@ void GomokuGameActivity::drawInfoPanel() {
   // Two stat cells, narrower and shorter than v3, centered horizontally.
   // Inside each: a board-sized stone icon next to the count — the colour
   // itself identifies the side, so no "Black"/"White" text label.
-  constexpr int statH = 60;
+  // Anchored just above the action bar (measured from the screen bottom), so
+  // the row stays on-panel on every target instead of running off the bottom.
+  constexpr int statH = 44;
   constexpr int cellW = 160;
   constexpr int cellGap = 24;
-  const int statY = INFO_PANEL_Y;
+  const int statY = std::max(BOARD_AREA_Y, actionBarY() - statH - 6);
   const int totalW = 2 * cellW + cellGap;
   const int statXStart = (sw - totalW) / 2;
   const int statStoneR = stoneRadius();  // matches the board (12 for 15×15, 20 for 9×9)
@@ -579,7 +639,10 @@ void GomokuGameActivity::drawModeLine() {
   if (!aiThinkingArmed) {
     return;
   }
-  renderer.drawCenteredText(kStatusFont, MODE_LINE_Y, tr(STR_GOMOKU_AI_THINKING));
+  // Drawn directly above the action bar: the old anchor (702) was off the
+  // panel entirely, so the "Thinking…" notice never actually appeared.
+  renderer.drawCenteredText(kStatusFont, std::max(0, actionBarY() - renderer.getTextHeight(kStatusFont) - 4),
+                            tr(STR_GOMOKU_AI_THINKING));
 }
 
 // ---------- Footer (button hints) ----------

--- a/src/activities/apps/gomoku/GomokuGameActivity.h
+++ b/src/activities/apps/gomoku/GomokuGameActivity.h
@@ -23,14 +23,18 @@ class GomokuGameActivity final : public Activity {
   enum class State : uint8_t { Playing, GameMenu, GameOver };
 
   // Layout anchors — y values for top-of-section. Title bar / board area /
-  // mode line align with SudokuGameActivity; info-panel content sits a bit
-  // lower than Sudoku's palette for visual balance with the mode line.
+  // mode line align with SudokuGameActivity.
   static constexpr int CONTENT_X = 24;
   static constexpr int TITLE_BAR_H = 36;
-  static constexpr int BOARD_AREA_Y = 60;        // matches Sudoku GRID_Y
-  static constexpr int INFO_PANEL_Y = 540;       // 30 px below Sudoku PALETTE_Y
-  static constexpr int MODE_LINE_Y = 702;        // matches Sudoku MODE_LINE_Y
-  static constexpr uint8_t MENU_ITEM_COUNT = 5;  // Resume / Undo / Resign / New Game / Exit
+  static constexpr int BOARD_AREA_Y = 60;  // matches Sudoku GRID_Y
+  // Bottom action bar, measured UP FROM THE SCREEN BOTTOM as a fraction of the
+  // panel height. This firmware ships many targets with different panel sizes,
+  // so a bar pinned to absolute pixel offsets would land off-screen or overlap
+  // the board somewhere. Everything here scales with getScreenHeight().
+  static constexpr int ACTION_BAR_H_FRAC = 10;      // bar height = screenH / 10
+  static constexpr int ACTION_BAR_MIN_H = 40;       // never smaller than a fingertip
+  static constexpr int ACTION_BAR_BOTTOM_FRAC = 4;  // bottom gap = screenH / 4 / 10
+  static constexpr uint8_t MENU_ITEM_COUNT = 5;     // Resume / Undo / Resign / New Game / Exit
 
   State state = State::Playing;
   GomokuMode mode = GomokuMode::TwoPlayer;
@@ -64,6 +68,13 @@ class GomokuGameActivity final : public Activity {
   int boardOriginY() const;
   int stoneRadius() const;
   void intersectionXY(uint8_t r, uint8_t c, int* x, int* y) const;
+  // Screen-space touch zones. Touch aims the cursor only; the bottom action bar
+  // commits the stone. One geometry source for both drawing and hit-testing.
+  Rect boardTouchRect() const;
+  // Bottom action bar, measured up from the screen bottom (see the constants).
+  int actionBarH() const;
+  int actionBarY() const;
+  Rect actionBarRect() const;
 
   // Drawing
   void renderPlaying();

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.cpp
@@ -22,7 +22,6 @@ constexpr int kHeroFont = NOTOSERIF_16_FONT_ID;        // end-screen big title
 constexpr int kStatValueFont = NOTOSANS_16_FONT_ID;    // end-screen stat columns
 constexpr int kNumberFontBig = NOTOSERIF_16_FONT_ID;   // cell digit (Easy/Medium)
 constexpr int kNumberFontSmall = NOTOSANS_12_FONT_ID;  // cell digit (Hard)
-constexpr unsigned long TOUCH_FLAG_HOLD_MS = 700;
 
 }  // namespace
 
@@ -260,13 +259,41 @@ void MinesweeperGameActivity::enterGameMenu() {
                 [this](const int index) { runMenuItem(static_cast<uint8_t>(index)); });
 }
 
-void MinesweeperGameActivity::handleInputPlaying() {
+// Bottom action bar geometry, scaled from the panel size and measured UP FROM
+// THE SCREEN BOTTOM: this firmware ships several targets with different panels,
+// so absolute pixel offsets would land off-screen or over the board somewhere.
+int MinesweeperGameActivity::actionBarH() const {
+  return std::max(ACTION_BAR_MIN_H, renderer.getScreenHeight() * ACTION_BAR_H_FRAC / 100);
+}
+
+int MinesweeperGameActivity::actionBarY() const {
+  const int h = renderer.getScreenHeight();
+  return h - actionBarH() - std::max(4, h * ACTION_BAR_BOTTOM_FRAC / 100);
+}
+
+// Two equal buttons split across the content width, with the required >= 6 px
+// visible gap between them.
+Rect MinesweeperGameActivity::digButtonRect() const {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  const Rect modeButton =
-      gameTouchActionRect(renderer.getScreenWidth(), renderer.getScreenHeight(), metrics.contentSidePadding,
-                          metrics.menuSpacing, metrics.menuRowHeight, 0, 1);
+  const int side = std::max(8, metrics.contentSidePadding);
+  const int total = renderer.getScreenWidth() - 2 * side;
+  const int w = (total - ACTION_BAR_GAP) / 2;
+  return Rect{side, actionBarY(), w, actionBarH()};
+}
+
+Rect MinesweeperGameActivity::flagButtonRect() const {
+  const Rect dig = digButtonRect();
+  return Rect{dig.x + dig.width + ACTION_BAR_GAP, dig.y, dig.width, dig.height};
+}
+
+void MinesweeperGameActivity::handleInputPlaying() {
   int touchX = 0;
   int touchY = 0;
+  const Rect digButton = digButtonRect();
+  const Rect flagButton = flagButtonRect();
+  const auto inRect = [](const Rect& r, const int x, const int y) {
+    return r.width > 0 && r.height > 0 && x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height;
+  };
   if (mappedInput.wasScreenTouchDown(touchX, touchY)) {
     int row = 0;
     int column = 0;
@@ -281,10 +308,15 @@ void MinesweeperGameActivity::handleInputPlaying() {
     return;
   }
   if (mappedInput.wasScreenTapped(touchX, touchY)) {
-    if (touchX >= modeButton.x && touchX < modeButton.x + modeButton.width && touchY >= modeButton.y &&
-        touchY < modeButton.y + modeButton.height) {
-      flagMode = !flagMode;
-      scheduleSave();
+    // The action bar is checked before the board: tapping Dig or Flag acts on
+    // the highlighted cell, while tapping the board only aims the cursor.
+    if (inRect(digButton, touchX, touchY)) {
+      doDig();
+      requestUpdate();
+      return;
+    }
+    if (inRect(flagButton, touchX, touchY)) {
+      doFlag();
       requestUpdate();
       return;
     }
@@ -294,13 +326,10 @@ void MinesweeperGameActivity::handleInputPlaying() {
     if (gameGridCellFromPoint(
             Rect{(renderer.getScreenWidth() - BOARD_W) / 2, BOARD_Y, board.cols * size, board.rows * size}, board.rows,
             board.cols, touchX, touchY, row, column)) {
+      // Aim only. Digging/flagging happen through the buttons above, so a
+      // mis-aimed tap can no longer reveal or flag the wrong cell.
       cursorR = static_cast<uint8_t>(row);
       cursorC = static_cast<uint8_t>(column);
-      if (mappedInput.getHeldTime() >= TOUCH_FLAG_HOLD_MS) {
-        doFlag();
-      } else {
-        doDig();
-      }
       requestUpdate();
       return;
     }
@@ -413,13 +442,11 @@ void MinesweeperGameActivity::render(RenderLock&&) {
 void MinesweeperGameActivity::renderPlaying() {
   drawTitleBar();
   drawBoard();
+  // Two explicit targets instead of one mode-toggle button: the player sees
+  // both actions at once, and neither depends on remembering the current mode.
   if (mappedInput.hasTouch()) {
-    const auto& metrics = UITheme::getInstance().getMetrics();
-    GUI.drawActionButton(
-        renderer,
-        gameTouchActionRect(renderer.getScreenWidth(), renderer.getScreenHeight(), metrics.contentSidePadding,
-                            metrics.menuSpacing, metrics.menuRowHeight, 0, 1),
-        flagMode ? tr(STR_MINESWEEPER_MODE_FLAG) : tr(STR_MINESWEEPER_MODE_DIG), flagMode);
+    GUI.drawActionButton(renderer, digButtonRect(), tr(STR_MINESWEEPER_MODE_DIG), !flagMode);
+    GUI.drawActionButton(renderer, flagButtonRect(), tr(STR_MINESWEEPER_MODE_FLAG), flagMode);
   }
   drawFooter();
 }

--- a/src/activities/apps/minesweeper/MinesweeperGameActivity.h
+++ b/src/activities/apps/minesweeper/MinesweeperGameActivity.h
@@ -48,9 +48,17 @@ class MinesweeperGameActivity final : public Activity {
   static constexpr int TITLE_BAR_H = 36;
   static constexpr int BOARD_Y = 60;   // matches Sudoku GRID_Y
   static constexpr int BOARD_W = 432;  // matches Sudoku GRID_SIZE_PX
-  // End-game screen anchors. The Playing screen only uses the board area and
-  // the footer button hints — everything between board bottom (y=492) and the
-  // footer is intentionally left blank.
+  // Bottom action bar with separate Dig and Flag buttons. Touch on the board
+  // only aims the cursor, so digging and flagging each need their own visible
+  // target; a single mode-toggle button made the current mode invisible at the
+  // moment of use. Sized from the panel height (this firmware ships several
+  // targets) and measured UP FROM THE SCREEN BOTTOM.
+  static constexpr int ACTION_BAR_H_FRAC = 10;      // bar height = screenH / 10
+  static constexpr int ACTION_BAR_MIN_H = 40;       // stay a fingertip target
+  static constexpr int ACTION_BAR_BOTTOM_FRAC = 4;  // bottom gap = screenH / 4 / 10
+  static constexpr int ACTION_BAR_GAP = 8;          // >= the 6 px control spacing rule
+  // End-game screen anchors. The Playing screen uses the board area plus the
+  // action bar; everything between them stays blank.
   static constexpr int ENDGAME_HERO_Y = 524;   // "Cleared!" / "Boom!" headline top
   static constexpr int ENDGAME_STATS_Y = 588;  // top border of the 3-column stat row
 
@@ -82,6 +90,13 @@ class MinesweeperGameActivity final : public Activity {
   void doConfirmAction();  // dispatches dig/flag based on flagMode
   void onGameEnd(bool won);
   void useHint();
+
+  // Bottom action bar geometry, measured up from the screen bottom and scaled
+  // to the panel so it stays on-screen on every target.
+  int actionBarH() const;
+  int actionBarY() const;
+  Rect digButtonRect() const;
+  Rect flagButtonRect() const;
   void resetGameKeepLayout();  // "Restart" — clear reveals, keep mine layout
   void scheduleSave();
   void flushSave();


### PR DESCRIPTION
## Problem

Tapping the board performed the action immediately. On Gomoku's 15×15 grid an intersection target is only 30 px wide, so a fingertip aimed at one intersection could place a stone on its neighbour — an irreversible move. Minesweeper had the same shape of problem plus a hidden gesture: dig on tap, flag on a 700 ms long-press.

## Change

Touch now only **aims** the cursor. The action moves to explicit buttons on a bottom action bar.

**Gomoku**
- Touch moves the cursor to the nearest intersection; it no longer places.
- New **Place** button on the bottom bar commits the stone at the cursor.

**Minesweeper**
- Touch moves the cursor only; the long-press-to-flag gesture is removed.
- Separate **Dig** and **Flag** buttons replace the single mode-toggle button.

## Bugs found and fixed along the way

Both were pre-existing and made the bottom of the screen unusable:

| Screen | Problem | Effect |
|---|---|---|
| Gomoku | Stat row anchored at `INFO_PANEL_Y = 540` with 60 px height (= 600) | Ran 48 px off a 552 px panel; never fully visible |
| Gomoku | `MODE_LINE_Y = 702` | Entirely off-panel, so "AI thinking…" never appeared |
| Minesweeper | Mode button at y = 487…532 vs. board bottom at 492 | Button was drawn over the board's last row |

## Layout approach

The bar is measured **up from the screen bottom** and sized as a fraction of the panel height with a pixel floor:

```cpp
int actionBarH() const { return std::max(ACTION_BAR_MIN_H, renderer.getScreenHeight() * ACTION_BAR_H_FRAC / 100); }
```

Absolute pixel offsets would land off-screen or over the board on some of the targets this firmware ships, so nothing here is pinned to a fixed y. The two Minesweeper buttons keep the required ≥ 6 px visible gap, and both bars are gated on `mappedInput.hasTouch()`.

## Testing

- Built `env:eego_a4` — 0 errors, RAM 23.1%, Flash 89.7%.
- Flashed to the EEGO A4 and exercised both games on the device: aiming, the Place button, the Dig/Flag buttons, and the now-visible stat row.

The physical-button paths (Confirm / Back / arrows) are unchanged.