### PR TITLE
fix(ui): improve font readability and default sleep screen to light

### DIFF
--- a/docs/engineering/ui-and-input.md
+++ b/docs/engineering/ui-and-input.md
@@ -192,6 +192,9 @@ and 232-byte glyph scratch buffer, too large for the activity task stack.
 Only one font-map entry is added on entry and removed on exit; no additional
 framebuffer or SD font is needed.
 
+The default sleep screen is Light. Existing saved sleep-screen selections are
+preserved; the default applies when no selection has been saved.
+
 ## Retained Framebuffer Updates
 
 The firmware has one framebuffer, and its contents remain available after

--- a/docs/engineering/ui-and-input.md
+++ b/docs/engineering/ui-and-input.md
@@ -179,6 +179,19 @@ action**.
   logical selection and viewport remain intact, and FreeInkUI's active touch
   feedback plus semantic values such as checks and switches remain visible.
 
+The calculator registers a dedicated built-in Noto Sans 18pt regular/bold family
+for its expression and result, then unregisters it on exit. Legacy reader font
+IDs (including `NOTOSANS_18_FONT_ID`) resolve to the 12pt offline fallback and
+must not be used to select a larger display font. The two display rows reserve
+their actual line heights plus at least 12 px spacing; overflowing text is
+right-aligned and clipped to the display area. Error messages use the UI font
+and its language fallback. Key labels retain their existing font.
+The font tables stay in Flash. Drawing reuses the renderer's decompression
+cache: the calculator's digits/operators require at most a 14,675-byte group
+and 232-byte glyph scratch buffer, too large for the activity task stack.
+Only one font-map entry is added on entry and removed on exit; no additional
+framebuffer or SD font is needed.
+
 ## Retained Framebuffer Updates
 
 The firmware has one framebuffer, and its contents remain available after

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -264,7 +264,7 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   };
 
   // Sleep screen settings
-  uint8_t sleepScreen = DARK;
+  uint8_t sleepScreen = LIGHT;
   // Night mode: inverted output polarity, applied to every activity per
   // render by ActivityManager. The sleep screen opts out itself.
   uint8_t screenInverted = 0;

--- a/src/activities/apps/calculator/CalculatorActivity.cpp
+++ b/src/activities/apps/calculator/CalculatorActivity.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 
+#include "CalculatorFont.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -52,7 +53,8 @@ CalculatorLayout layoutFor(const GfxRenderer& renderer) {
 
   const int displayTop = header.y + header.height + metrics.verticalSpacing / 2;
   const int availableHeight = std::max(0, bottom - displayTop);
-  const int displayHeight = std::max(112, availableHeight / 4);
+  const int minimumDisplayHeight = 2 * renderer.getLineHeight(calculator::DISPLAY_FONT_ID) + 3 * sectionSpacing;
+  const int displayHeight = std::max(minimumDisplayHeight, availableHeight / 4);
   const Rect displayArea{left, displayTop, width, displayHeight};
 
   const int gridTop = displayArea.y + displayArea.height + sectionSpacing;
@@ -151,13 +153,17 @@ void drawBackspaceIcon(const GfxRenderer& renderer, const Rect key, const bool b
 
 void CalculatorActivity::onEnter() {
   Activity::onEnter();
+  renderer.insertFont(calculator::DISPLAY_FONT_ID, calculator::displayFontFamily);
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
   state_.reset();
   selected_ = kInitialSelection;
   requestUpdate();
 }
 
-void CalculatorActivity::onExit() { Activity::onExit(); }
+void CalculatorActivity::onExit() {
+  renderer.removeFont(calculator::DISPLAY_FONT_ID);
+  Activity::onExit();
+}
 
 void CalculatorActivity::loop() {
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
@@ -223,17 +229,23 @@ void CalculatorActivity::render(RenderLock&&) {
   const CalculatorLayout layout = layoutFor(renderer);
   GUI.drawHeader(renderer, layout.header, tr(STR_CALCULATOR_TITLE));
 
-  const char* expression = state_.expressionText();
-  const int expressionWidth = renderer.getTextWidth(UI_12_FONT_ID, expression);
-  const int expressionY = layout.display.y + sectionSpacing;
-  renderer.drawText(UI_12_FONT_ID, layout.display.x + layout.display.width - expressionWidth, expressionY, expression);
+  {
+    const GfxRenderer::ClipScope clip(renderer, layout.display.x, layout.display.y, layout.display.width,
+                                      layout.display.height);
+    const char* expression = state_.expressionText();
+    const int expressionWidth = renderer.getTextWidth(calculator::DISPLAY_FONT_ID, expression);
+    const int expressionY = layout.display.y + sectionSpacing;
+    renderer.drawText(calculator::DISPLAY_FONT_ID, layout.display.x + layout.display.width - expressionWidth,
+                      expressionY, expression);
 
-  const char* result = state_.hasError() ? tr(STR_CALCULATOR_ERROR) : state_.resultText();
-  const int resultWidth = renderer.getTextWidth(NOTOSANS_18_FONT_ID, result, EpdFontFamily::BOLD);
-  const int resultLineHeight = renderer.getLineHeight(NOTOSANS_18_FONT_ID);
-  const int resultY = layout.display.y + layout.display.height - resultLineHeight - sectionSpacing;
-  renderer.drawText(NOTOSANS_18_FONT_ID, layout.display.x + layout.display.width - resultWidth, resultY, result, true,
-                    EpdFontFamily::BOLD);
+    const int resultFontId = state_.hasError() ? UI_12_FONT_ID : calculator::DISPLAY_FONT_ID;
+    const char* result = state_.hasError() ? tr(STR_CALCULATOR_ERROR) : state_.resultText();
+    const int resultWidth = renderer.getTextWidth(resultFontId, result, EpdFontFamily::BOLD);
+    const int resultLineHeight = renderer.getLineHeight(resultFontId);
+    const int resultY = layout.display.y + layout.display.height - resultLineHeight - sectionSpacing;
+    renderer.drawText(resultFontId, layout.display.x + layout.display.width - resultWidth, resultY, result, true,
+                      EpdFontFamily::BOLD);
+  }
 
   const EpdFontFamily::Style keyStyle =
       metrics.optionPopupOptionFontBold ? EpdFontFamily::BOLD : EpdFontFamily::REGULAR;

--- a/src/activities/apps/calculator/CalculatorFont.h
+++ b/src/activities/apps/calculator/CalculatorFont.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <EpdFontFamily.h>
+#include <builtinFonts/notosans_18_bold.h>
+#include <builtinFonts/notosans_18_regular.h>
+
+namespace calculator {
+
+// Separate from legacy reader IDs, which are bound to the 12pt offline fallback.
+inline constexpr int DISPLAY_FONT_ID = 0x43414C12;
+inline const EpdFont displayRegularFont(&notosans_18_regular);
+inline const EpdFont displayBoldFont(&notosans_18_bold);
+inline const EpdFontFamily displayFontFamily(&displayRegularFont, &displayBoldFont);
+
+}  // namespace calculator

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -1352,12 +1352,18 @@ void FontDownloadActivity::render(RenderLock&&) {
     const char* finalLine = accelerationCompleted_ ? tr(STR_FONT_CACHE_READY)
                             : !selectionUpdated_   ? tr(STR_READER_FONT_SELECTION_PATH)
                                                    : nullptr;
-    const int detailY = centerY;
-    renderer.drawCenteredText(UI_12_FONT_ID, detailY - lineHeight - metrics.verticalSpacing, tr(STR_FONT_INSTALLED),
-                              true, EpdFontFamily::BOLD);
+    const Rect safeArea = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+    const Rect content = SubpageLayout::contentRect(safeArea, metrics);
+    const int headingHeight = renderer.getLineHeight(UI_12_FONT_ID);
+    const int sectionGap = SubpageLayout::sectionGap(metrics);
+    const int lineGap = SubpageLayout::relatedGap(metrics);
+    const int blockHeight = headingHeight + sectionGap + lineHeight + (finalLine ? lineGap + lineHeight : 0);
+    const int headingY = SubpageLayout::centeredTop(content, blockHeight);
+    const int detailY = headingY + headingHeight + sectionGap;
+    renderer.drawCenteredText(UI_12_FONT_ID, headingY, tr(STR_FONT_INSTALLED), true, EpdFontFamily::BOLD);
     renderer.drawCenteredText(UI_10_FONT_ID, detailY, detail);
     if (finalLine) {
-      renderer.drawCenteredText(UI_10_FONT_ID, detailY + lineHeight + metrics.verticalSpacing, finalLine);
+      renderer.drawCenteredText(UI_10_FONT_ID, detailY + lineHeight + lineGap, finalLine);
     }
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/test/calculator/CMakeLists.txt
+++ b/test/calculator/CMakeLists.txt
@@ -13,3 +13,17 @@ target_link_libraries(CalculatorStateTest PRIVATE
 )
 
 gtest_discover_tests(CalculatorStateTest)
+
+add_executable(CalculatorFontTest
+  CalculatorFontTest.cpp
+  ${REPO_ROOT}/lib/EpdFont/EpdFont.cpp
+  ${REPO_ROOT}/lib/EpdFont/EpdFontFamily.cpp
+  ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+)
+target_include_directories(CalculatorFontTest PRIVATE
+  ${REPO_ROOT}/src/activities/apps/calculator
+  ${REPO_ROOT}/lib/EpdFont
+  ${REPO_ROOT}/lib/Utf8
+)
+target_compile_options(CalculatorFontTest PRIVATE -UNDEBUG)
+add_test(NAME CalculatorFontTest COMMAND CalculatorFontTest)

--- a/test/calculator/CalculatorFontTest.cpp
+++ b/test/calculator/CalculatorFontTest.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include <cstdio>
+#include <initializer_list>
+
+#include "CalculatorFont.h"
+#include "builtinFonts/notosans_cjk_12.h"
+
+int main() {
+  const EpdFont previousFont(&notosans_cjk_12);
+  const auto& family = calculator::displayFontFamily;
+  assert(family.getData(EpdFontFamily::REGULAR) == &notosans_18_regular);
+  assert(family.getData(EpdFontFamily::BOLD) == &notosans_18_bold);
+  assert(family.getData(EpdFontFamily::REGULAR)->advanceY == 51);
+  std::printf("Digit height: %u -> %u px\n", previousFont.getGlyph('0')->height, family.getGlyph('0')->height);
+  for (const auto style : {EpdFontFamily::REGULAR, EpdFontFamily::BOLD}) {
+    for (char digit = '0'; digit <= '9'; ++digit) {
+      assert(family.hasCodepoint(digit, style));
+      assert(family.getGlyph(digit, style)->height > previousFont.getGlyph(digit)->height);
+    }
+    for (const uint32_t symbol : std::initializer_list<uint32_t>{'+', '-', '.', '%', '=', 'e', ' ', 0xD7, 0xF7}) {
+      assert(family.hasCodepoint(symbol, style));
+    }
+    for (const char* text : {"0", "123456789012", "-123.456", "123456789012 + 987654321098 =", "1.23456789e+12"}) {
+      int width = 0, height = 0;
+      family.getTextDimensions(text, &width, &height, style);
+      assert(width > 0 && height > 0 && height <= 51);
+      std::printf("%s: %d x %d px (%s)\n", text, width, height, style == EpdFontFamily::BOLD ? "bold" : "regular");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

修复字体安装完成页文字挤压，以及计算器使用“18 pt”字体 ID 却实际显示 12 pt 备用字体的问题；将未配置设备的休眠画面默认值改为浅色。

按修改类型拆为三个提交：
- `87c638bb`：字体浏览器按标题自身行高和主题间距布局，整组提示在内容区居中。
- `0ed058da`：计算器独立注册真实 Noto Sans 18 pt 常规/粗体资源，退出时注销；保留右对齐、至少 12 px 行间距、超宽左侧裁剪，以及 UI 字体错误提示。
- `8e2b8a49`：休眠画面默认浅色，保留已有用户设置。

## Scope Check

- 已阅读 SCOPE.md 和 ROADMAP.md；本 PR 修复现有功能，不新增应用、主题或网络连接器。
- 未修改 SDK、HAL、引导程序、OTA 或恢复代码。
- 复用已有字体与渲染接口，不新增依赖、SD 字体下载或帧缓冲。

## Validation

- [x] 全仓库 clang-format 检查、`git diff --check`。
- [x] CMake/CTest：8 项 CalculatorState 测试和 CalculatorFontTest，共 9 项通过。
- [x] 字形验证：数字高度由 20 px 增至 29 px；覆盖常规/粗体数字、运算符、12 位数字、负数、小数、完整算式和科学计数法。
- [x] 最终源码 `pio run -e sticky` 构建通过（包含浅色默认值）。
- [x] 字体浏览器与计算器修复已烧录 Sticky，写入 hash 校验通过；启动日志识别 Sticky 并正常进入休眠。
- [x] `pio check` / cppcheck：No defects found。
- [ ] 本地 `./bin/ci-check` 剩余硬件构建矩阵及 GitHub CI 仍在运行，尚未声明全矩阵通过。
- [ ] 最新计算器字号和字体完成页仍需用户确认屏幕效果；浅色默认值尚未重新烧录。

复验：安装字体检查完成页行距；计算器输入 12 位数字、长算式和除零，检查两行及边界；无保存配置时休眠应为浅色，已有配置应保持原选择。

## Additional Context

真实 18 pt 字体使 Sticky 构建的 Flash 用量从 5,844,491 B 增至 5,969,171 B，静态 RAM 从 75,740 B 增至 75,788 B（同一修改前后构建读数）。字体表位于 Flash，数字/运算符复用现有解压缓存，最大字体组 14,675 B、字形暂存 232 B。此处静态 RAM 数值不代表运行时峰值。

已烧录的字体修复固件 SHA256：`51d0919e7e76f7857c013285c084360f01a8af78bb9f28d846ff97cba40c6c65`，不包含随后新增的浅色默认值修改。构建和烧录成功不等同于完整真机视觉验收。

### AI Usage

YES — Codex assisted with implementation, tests, commit splitting, and PR preparation.
