### PR TITLE
fix: correct Metalio button navigation

### DIFF
--- a/docs/engineering/metalio-eink4.md
+++ b/docs/engineering/metalio-eink4.md
@@ -32,8 +32,8 @@ for other boards are rejected by the existing flash/OTA board-tag check.
 | Shared I²C | SDA41 SCL42, 400 kHz, Arduino Wire transaction locking |
 | TCA9555 | `0x20`, INT2 input pull-up; MAIN=P0.6, SCREEN=P0.5, touch reset=P1.1, shutdown pulse=P1.3 |
 | Touch | CST816S `0x15`, active-low IRQ1, reset through the expander |
-| Buttons | BOOT0=Back, POWER3=Power; P0.7=Up/previous, P1.0=Down/next, active-low |
-| Virtual keys | Raw Home=(80,900), Prev=(400,900), Next=(240,900) |
+| Buttons | BOOT0=Confirm, POWER3=Power; P0.7=Down/next, P1.0=Up/previous, active-low |
+| Virtual keys | Raw Home=(80,900) unchanged; Prev=(400,900) → Left, Next=(240,900) → Right |
 | Battery | BQ27220 `0x55`: percentage and gauge-native charging status |
 | Charger | Optional CX25601N `0x6B`: read status only; never interpreted as BQ25896 |
 | RTC | PCF8563 `0x51`, existing system-UTC restore/writeback behavior |
@@ -105,8 +105,12 @@ coordinates are discarded. Screen points map to `(rawY, 479-rawX)`, then pass
 through the normal orientation transform. Crossing from screen to bezel keys
 cancels that contact until release. Home short press returns Home; a 700 ms
 hold uses the existing reader-menu action and consumes the subsequent short
-release. Prev/Next and side buttons use the existing logical mapping, including
-user side-button swaps. Activity transitions retain input suppression.
+release. Bezel Prev/Next now report Left/Right through the existing front-button
+mapping; physical side buttons report Down/Up respectively and retain user
+side-button swaps. Activity transitions retain input suppression. This key-map
+correction follows hardware feedback. The user confirmed the corrected key mapping
+on the physical device; this does not extend the earlier display-retention or
+power-cycle acceptance.
 
 The initial held Power gesture and its release are consumed on every boot.
 Subsequent Power gestures and automatic sleep use existing settings. Shutdown
@@ -254,3 +258,20 @@ inside the configurable SSD1677 driver, with no duplicate platform driver.
 A host compatibility test implements only the original interface and verifies
 all three new hooks dispatch to it. The facade also forwards reading context
 when an inverted grayscale-base request falls back to ordinary display.
+
+### Key mapping validation (2026-09-12)
+
+- Real `InputManager.cpp` host coverage verifies BOOT confirmation, separate
+  expander directions, bezel Left/Right, failed-read release, and unchanged Home
+  tap/hold events. Existing 24 SDK input checks also passed.
+- Both Metalio build environments passed before rebasing onto the latest main.
+  The tested application SHA-256 was
+  `0a76680541efebd688a935ab926fad33173c1c2b4ac5fda19d3db23ac931a7a6`.
+- The initial app0 write verified successfully but the device still selected
+  app1. Reading the actual partition table and OTA metadata identified app1 at
+  `0x650000`; rewriting that slot took 51.1 seconds and passed hash verification.
+  Boot logs confirmed the expected build, SDMMC, RTC and saved settings.
+- The user confirmed the corrected key mapping. Future serial updates must
+  inspect the selected OTA slot; write verification alone does not establish
+  that the new image booted. App-menu logs also reported a drawing-boundary
+  warning; it is separate from this mapping change and was not addressed here.

--- a/scripts/tests/test_metalio_eink4.py
+++ b/scripts/tests/test_metalio_eink4.py
@@ -17,7 +17,21 @@ class MetalioTest(unittest.TestCase):
 #include <cstdint>
 #include <vector>
 #include <utility>
-constexpr int INPUT_PULLUP=2, OUTPUT=1, LOW=0;
+#include <climits>
+#include <cmath>
+#include <algorithm>
+#define IRAM_ATTR
+constexpr int INPUT_PULLUP=2, INPUT_PULLDOWN=4, ADC_11db=3, OUTPUT=1, LOW=0, HIGH=1, INPUT=0, FALLING=3;
+inline int Serial=0;
+inline int gpio0=HIGH;
+inline int digitalRead(int pin) { return pin==0 ? gpio0 : HIGH; }
+inline void analogSetAttenuation(int) {}
+inline int analogRead(int) { return 4095; }
+inline int analogReadMilliVolts(int) { return 3300; }
+inline void (*touchIrq)(void*)=nullptr;
+inline void* touchArg=nullptr;
+inline void attachInterruptArg(int,void (*fn)(void*),void* arg,int) { touchIrq=fn; touchArg=arg; }
+inline void detachInterrupt(int) {}
 inline uint32_t clockMs=0;
 inline std::vector<unsigned> waits;
 inline std::vector<std::pair<int,int>> modes;
@@ -37,6 +51,7 @@ struct MockWire {
   std::vector<Transaction> transactions;
   std::vector<uint8_t> data;
   std::array<uint8_t,2> input{0xff,0xff};
+  std::array<uint8_t,5> touch{};
   uint8_t status=3, address=0;
   unsigned cursor=0;
   bool fail=false;
@@ -50,9 +65,37 @@ struct MockWire {
   }
   uint8_t requestFrom(uint8_t,uint8_t count,uint8_t) { cursor=0; return count; }
   int available() { return 0; }
-  uint8_t read() { return address==0x20 ? input.at(cursor++) : status; }
+  uint8_t read() { return address==0x20 ? input.at(cursor++) : address==0x15 ? touch.at(cursor++) : status; }
 };
 inline MockWire Wire;
+''')
+            (tmp / "driver").mkdir()
+            (tmp / "driver/gpio.h").write_text(r'''
+#pragma once
+using gpio_num_t=int;
+inline void gpio_hold_dis(int) {}
+inline void gpio_hold_en(int) {}
+''')
+            (tmp / "freertos").mkdir()
+            (tmp / "freertos/FreeRTOS.h").write_text(r'''
+#pragma once
+using QueueHandle_t=void*; using TaskHandle_t=void*;
+constexpr int pdTRUE=1, pdPASS=1;
+#define pdMS_TO_TICKS(x) (x)
+''')
+            (tmp / "freertos/queue.h").write_text(r'''
+#pragma once
+inline void* xQueueCreate(int,int) { return nullptr; }
+inline int xQueueReceive(void*,void*,int) { return 0; }
+inline int xQueueSend(void*,const void*,int) { return 0; }
+inline void xQueueReset(void*) {}
+''')
+            (tmp / "freertos/task.h").write_text(r'''
+#pragma once
+inline int xTaskCreate(void (*)(void*),const char*,unsigned,void*,unsigned,void**) { return 0; }
+inline int xTaskCreatePinnedToCore(void (*)(void*),const char*,unsigned,void*,int,void**,int) { return 0; }
+inline void vTaskDelay(unsigned) {}
+inline void vTaskDelete(void*) {}
 ''')
             # Compile the actual renderer transform, not a second implementation of it.
             renderer = (ROOT / "lib/GfxRenderer/GfxRenderer.cpp").read_text()
@@ -62,6 +105,7 @@ inline MockWire Wire;
 #include <cassert>
 #include <Cst816sInput.h>
 #include <MetalioEink4Board.h>
+#include <InputManager.h>
 struct GfxRenderer {
  enum Orientation { Portrait, LandscapeClockwise, PortraitInverted, LandscapeCounterClockwise };
  Orientation orientation=Portrait;
@@ -137,7 +181,11 @@ int main() {
  assert((waits==std::vector<unsigned>{10,120}));
  assert(!powerButtonPressed(true)); assert(!powerButtonPressed(true));
  assert(!powerButtonPressed(false)); assert(powerButtonPressed(true));
- Wire.input={0x7f,0xfe}; assert(buttons()==((1<<4)|(1<<5)));
+ Wire.input={0x7f,0xff}; assert(buttons()==(1<<5)); // P0.7 is Down.
+ clockMs+=21; Wire.input={0xff,0xff}; assert(buttons()==0);
+ clockMs+=21; Wire.input={0xff,0xfe}; assert(buttons()==(1<<4)); // P1.0 is Up.
+ clockMs+=21; assert(buttons()==(1<<4)); // Held state survives successful reads.
+ clockMs+=21; Wire.input={0x7f,0xfe}; assert(buttons()==((1<<4)|(1<<5)));
  clockMs+=21; Wire.fail=true; assert(buttons()==0);
  clockMs+=2001; Wire.fail=false; Wire.input={0xff,0xff}; assert(buttons()==0);
  bool connected=false; assert(externalPowerConnected(connected) && connected);
@@ -155,12 +203,45 @@ int main() {
    assert(bool(value & POWER_PULSE)==(i%2==0));
  }
  Wire.fail=true; assert(!shutdown());
+ Wire.fail=false; Wire.input={0xff,0xff};
+ InputManager input;
+ input.begin();
+ auto sample=[&]() { clockMs+=25; input.update(); clockMs+=25; input.update(); };
+ sample();
+ gpio0=LOW; sample();
+ assert(input.isPressed(InputManager::BTN_CONFIRM));
+ assert(!input.isPressed(InputManager::BTN_BACK));
+ gpio0=HIGH; sample(); assert(!input.isPressed(InputManager::BTN_CONFIRM));
+ auto touch=[&](unsigned x,unsigned y,unsigned count) {
+   Wire.touch={static_cast<uint8_t>(count),static_cast<uint8_t>(x>>8),static_cast<uint8_t>(x),
+               static_cast<uint8_t>(y>>8),static_cast<uint8_t>(y)};
+   assert(touchIrq); touchIrq(touchArg); sample();
+ };
+ for (auto [x,key] : {std::pair{400u,InputManager::BTN_LEFT},std::pair{240u,InputManager::BTN_RIGHT}}) {
+   touch(x,900,1); assert(input.isPressed(key));
+   assert(!input.isPressed(InputManager::BTN_UP) && !input.isPressed(InputManager::BTN_DOWN));
+   touch(x,900,0); assert(!input.isPressed(key));
+ }
+ touch(400,900,1); Wire.fail=true; sample();
+ assert(!input.isPressed(InputManager::BTN_LEFT));
+ Wire.fail=false; clockMs+=2001; touch(0,0,0);
+ // Existing Home tap/hold events remain independent of navigation button bits.
+ touch(80,900,1);
+ Wire.touch[0]=0; touchIrq(touchArg); clockMs+=25; input.update();
+ assert(input.wasHomeKeyTapped() && !input.wasHomeKeyLongPressed());
+ sample(); assert(!input.wasHomeKeyTapped());
+ touch(80,900,1); clockMs+=700; input.update();
+ assert(input.wasHomeKeyLongPressed());
+ Wire.touch[0]=0; touchIrq(touchArg); clockMs+=25; input.update();
+ assert(!input.wasHomeKeyTapped() && !input.wasHomeKeyLongPressed());
+
 }
 '''.replace("TRANSFORM", transform)
             (tmp / "test.cpp").write_text(source)
             subprocess.run(["c++", "-std=c++17", "-Wall", "-Wextra", "-Werror",
                             "-I" + str(tmp), "-I" + str(SDK / "BoardConfig/include"),
-                            "-I" + str(SDK / "InputManager/include"), str(tmp / "test.cpp"),
+                            "-I" + str(SDK / "InputManager/include"), "-DFREEINK_DEVICE_METALIO_EINK4=1",
+                            str(SDK / "InputManager/src/InputManager.cpp"), str(tmp / "test.cpp"),
                             "-o", str(tmp / "test")], check=True)
             subprocess.run([str(tmp / "test")], check=True)
 


### PR DESCRIPTION
## Summary

Integrate Metalio E-Ink 4's physically validated key mapping: swap the side Up/Down keys, make BOOT Confirm, and map bezel Previous/Next to Left/Right while preserving Home touch behavior.

Pins merged SDK commit `e8e0276d06094e87b89d269ab680008e122916eb` from the configured 0x1abin/freeink-sdk remote. Its source tree is identical to the tested `2bf6cdd` (tree `055b785894a84fe2343bf115e498cec5f7a70471`). The host test now compiles the real InputManager implementation and checks the corrected identities, release/failure behavior, and unchanged Home tap/hold. The device guide records mapping and flash evidence.

## Dependency / merge order

SDK https://github.com/0x1abin/freeink-sdk/pull/28 is merged; the gitlink is updated in `2a3c922e`. No source changes in this dependency-only update, so hardware results remain applicable to the key mapping. Draft remains while CI is unresolved.

## Validation

- Metalio host tests passed; SDK input suite: 24 checks passed; touch activity checks passed.
- Both Metalio environments passed on submitted revision c8396517: ordinary 133.77 s, Nightly 123.72 s. CI unit tests, clang-format and cppcheck passed on the previous head. Hardware CI compiled targets but failed packaging because `sticky_nightly/bootloader.bin` was missing, despite its generation appearing earlier in the build log. New CI runs were triggered by the merged-gitlink update; their results are pending.
- Actual hardware: corrected app1 write verified; boot confirmed expected test build, SDMMC, RTC and settings. Maintainer confirmed key mapping normal.
- Tested application SHA-256: `0a76680541efebd688a935ab926fad33173c1c2b4ac5fda19d3db23ac931a7a6`. This is the pre-rebase image, not a claim of flashing the submitted revision.
- Physical long-retention and power-cycle acceptance remain outside this change. Separate app-menu drawing-boundary warning recorded, not addressed here.

## Scope Check / Additional Context

Existing device correction only; no new feature, shared driver API change, or runtime allocation. Other-board mappings unchanged. No automatic merge or release.

### AI Usage

YES — implemented with Codex and verified on hardware by the maintainer.

