### PR TITLE
fix(epub): pick image decoders by content, not just the href extension

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -35,10 +35,18 @@ namespace {
 //   60 / 61 - touch-link rectangles, inline direction inheritance, block spacing, and linked sup/sub
 //   62 / 63 - touch-link capability in the render spec
 //   64 / 65 - bounded no-PSRAM soft-flush windows
+//   66 / 67 - content-sniffed image decoders and the img2_ image cache prefix
+//
+// The 66/67 bump is not optional alongside the img2_ prefix in imageBasePath
+// below: recognising an image by its content instead of its href extension means
+// entries that used to be skipped now consume an imageCounter value, so a rebuilt
+// chapter numbers its images differently. Reusing a pre-upgrade path would serve
+// the wrong picture, because ImageBlock::ensureExtracted() accepts whatever file
+// already sits at the path (and its .pxc pixel cache) without checking the source.
 #ifdef ENABLE_CHINESE_VERSION
-constexpr uint8_t SECTION_FILE_VERSION = 65;
+constexpr uint8_t SECTION_FILE_VERSION = 67;
 #else
-constexpr uint8_t SECTION_FILE_VERSION = 64;
+constexpr uint8_t SECTION_FILE_VERSION = 66;
 #endif
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
@@ -399,7 +407,14 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   // Derive the content base directory and image cache path prefix for the parser
   const size_t lastSlash = localPath.find_last_of('/');
   ctx->contentBase = (lastSlash != std::string::npos) ? localPath.substr(0, lastSlash + 1) : "";
-  ctx->imageBasePath = epub->getCachePath() + "/img_" + std::to_string(spineIndex) + "_";
+  // The "img2_" prefix versions the extracted-image namespace. Content-based
+  // decoder selection hands an imageCounter value to entries the old extension
+  // gate skipped, which renumbers every later image in the chapter; without a new
+  // prefix a rebuilt chapter would land on a pre-upgrade file (and reuse its .pxc)
+  // that ImageBlock::ensureExtracted() accepts on existence alone. Bump it in
+  // lockstep with SECTION_FILE_VERSION above. Pre-upgrade "img_*" files are simply
+  // never referenced again.
+  ctx->imageBasePath = epub->getCachePath() + "/img2_" + std::to_string(spineIndex) + "_";
 
   if (spec.embeddedStyle) {
     ctx->cssParser = epub->getCssParser();

--- a/lib/Epub/Epub/converters/ImageDimsProbe.cpp
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.cpp
@@ -15,8 +15,10 @@ bool ImageDimsProbe::feed(const uint8_t b) {
   switch (state) {
     case State::Sniff:
       if (b == 0xFF) {
+        format = Format::Jpeg;
         state = State::JpegSoi;
       } else if (b == PNG_SIG[0]) {
+        format = Format::Png;
         state = State::PngHeader;
       } else {
         state = State::Failed;

--- a/lib/Epub/Epub/converters/ImageDimsProbe.cpp
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.cpp
@@ -14,11 +14,16 @@ constexpr uint8_t PNG_SIG[8] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
 bool ImageDimsProbe::feed(const uint8_t b) {
   switch (state) {
     case State::Sniff:
+      // The format is deliberately NOT set here. A bare 0xFF or 0x89 only picks
+      // the parser; it does not identify a JPEG or a PNG, and callers use
+      // detectedFormat() to accept an entry the extension gate would have
+      // rejected. Assigning it on the first byte made FF 00 and 89 58 look like
+      // supported images, which sent them through extraction and a decoder retry
+      // instead of being skipped. Each branch below stamps the format once its
+      // own signature has actually been validated.
       if (b == 0xFF) {
-        format = Format::Jpeg;
         state = State::JpegSoi;
       } else if (b == PNG_SIG[0]) {
-        format = Format::Png;
         state = State::PngHeader;
       } else {
         state = State::Failed;
@@ -34,6 +39,8 @@ bool ImageDimsProbe::feed(const uint8_t b) {
           state = State::Failed;
           return false;
         }
+        // All eight bytes have now matched: this is a PNG.
+        if (pos == 7) format = Format::Png;
       } else if (pos >= 12 && pos < 16) {
         if (b != "IHDR"[pos - 12]) {
           state = State::Failed;
@@ -57,6 +64,9 @@ bool ImageDimsProbe::feed(const uint8_t b) {
         state = State::Failed;
         return false;
       }
+      // SOI (FF D8) is the shortest complete JPEG signature; stamp it here, never
+      // on the leading 0xFF alone.
+      format = Format::Jpeg;
       state = State::JpegFf;
       return true;
 

--- a/lib/Epub/Epub/converters/ImageDimsProbe.h
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.h
@@ -15,11 +15,31 @@
 // PNG: reads the IHDR fields at their fixed offsets (bytes 16..23).
 class ImageDimsProbe : public Print {
  public:
+  // Format identified from the stream's leading bytes. The extension in an
+  // EPUB's href is only a hint — manifests legitimately point at images named
+  // without one — so callers that must choose a decoder should trust this.
+  enum class Format : uint8_t { Unknown, Jpeg, Png };
+
   size_t write(uint8_t b) override;
   size_t write(const uint8_t* data, size_t len) override;
 
   // True only when a valid header was found; fills `out`.
   bool getDimensions(ImageDimensions& out) const;
+
+  // Format seen so far (Unknown until the leading bytes arrived).
+  Format detectedFormat() const { return format; }
+  // Canonical extension for a format, or nullptr when it is not decodable.
+  static const char* extensionForFormat(const Format value) {
+    switch (value) {
+      case Format::Jpeg:
+        return ".jpg";
+      case Format::Png:
+        return ".png";
+      case Format::Unknown:
+        break;
+    }
+    return nullptr;
+  }
 
  private:
   bool feed(uint8_t b);  // returns false once parsing is finished (found or failed)
@@ -38,8 +58,9 @@ class ImageDimsProbe : public Print {
     Failed,
   };
   State state = State::Sniff;
-  uint32_t pos = 0;       // absolute stream offset (PNG fixed-offset parsing)
-  uint32_t skipLeft = 0;  // remaining segment bytes to skip
+  Format format = Format::Unknown;  // resolved by the sniff step
+  uint32_t pos = 0;                 // absolute stream offset (PNG fixed-offset parsing)
+  uint32_t skipLeft = 0;            // remaining segment bytes to skip
   uint16_t segLen = 0;
   bool sofPending = false;  // current segment is a SOF frame header
   uint8_t sofBuf[5] = {0};

--- a/lib/Epub/Epub/converters/ImageDimsProbe.h
+++ b/lib/Epub/Epub/converters/ImageDimsProbe.h
@@ -26,7 +26,9 @@ class ImageDimsProbe : public Print {
   // True only when a valid header was found; fills `out`.
   bool getDimensions(ImageDimensions& out) const;
 
-  // Format seen so far (Unknown until the leading bytes arrived).
+  // Format validated so far. Unknown until a signature has been checked in full
+  // (a bare 0xFF or 0x89 identifies nothing), and still Unknown after a failed
+  // parse.
   Format detectedFormat() const { return format; }
   // Canonical extension for a format, or nullptr when it is not decodable.
   static const char* extensionForFormat(const Format value) {
@@ -45,7 +47,7 @@ class ImageDimsProbe : public Print {
   bool feed(uint8_t b);  // returns false once parsing is finished (found or failed)
 
   enum class State : uint8_t {
-    Sniff,       // first byte decides the format
+    Sniff,       // first byte selects the parser; the format follows on validation
     PngHeader,   // PNG signature + IHDR at fixed offsets
     JpegSoi,     // second SOI byte (0xD8)
     JpegFf,      // expect a 0xFF marker prefix
@@ -58,7 +60,7 @@ class ImageDimsProbe : public Print {
     Failed,
   };
   State state = State::Sniff;
-  Format format = Format::Unknown;  // resolved by the sniff step
+  Format format = Format::Unknown;  // stamped once a signature has been validated
   uint32_t pos = 0;                 // absolute stream offset (PNG fixed-offset parsing)
   uint32_t skipLeft = 0;            // remaining segment bytes to skip
   uint16_t segLen = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -994,26 +994,38 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
           // Resolve the image path relative to the HTML file
           std::string resolvedPath = FsHelpers::normalisePath(FsHelpers::decodeUriEscapes(self->contentBase + src));
 
-          if (ImageDecoderFactory::isFormatSupported(resolvedPath)) {
-            // Create a unique filename for the cached image
+          // Read the entry's first bytes before deciding anything. They carry both
+          // the dimensions AND the real format, and an EPUB may name an image
+          // without an extension or with a misleading one — while the decoder
+          // lookup is extension-based. Deciding on the href alone dropped those
+          // images silently: no log, no placeholder, the picture just vanished.
+          // The header therefore decides; the path extension is only the fallback.
+          ImageDimensions dims = {0, 0};
+          ImageDimsProbe headerProbe;
+          self->epub->readItemContentsToStream(resolvedPath, headerProbe, 1024, /*allowEarlyStop=*/true);
+          bool gotDimensions = headerProbe.getDimensions(dims);
+          const char* sniffedExtension = ImageDimsProbe::extensionForFormat(headerProbe.detectedFormat());
+          const bool recognised = sniffedExtension != nullptr || ImageDecoderFactory::isFormatSupported(resolvedPath);
+
+          if (!recognised) {
+            LOG_ERR("EHP", "Unsupported image entry (neither JPEG/PNG content nor a known extension): %s",
+                    resolvedPath.c_str());
+          } else {
+            // Create a unique filename for the cached image. Prefer the sniffed
+            // format so the cached file always carries an extension the decoder
+            // can act on, whatever the href said.
             std::string ext;
-            size_t extPos = resolvedPath.rfind('.');
-            if (extPos != std::string::npos) {
-              ext = resolvedPath.substr(extPos);
+            if (sniffedExtension != nullptr) {
+              ext = sniffedExtension;
+            } else {
+              const size_t extPos = resolvedPath.rfind('.');
+              if (extPos != std::string::npos) {
+                ext = resolvedPath.substr(extPos);
+              }
             }
             std::string cachedImagePath = self->imageBasePath + std::to_string(self->imageCounter++) + ext;
 
             {
-              // Probe the dimensions from the entry's first bytes (early-aborted
-              // inflate, a few KB) instead of extracting the whole image now —
-              // extraction is deferred to the first render of the page (see
-              // ImageBlock's lazy extractor). This is what keeps first-open of an
-              // image-heavy chapter from stalling for seconds per image.
-              ImageDimensions dims = {0, 0};
-              ImageDimsProbe headerProbe;
-              self->epub->readItemContentsToStream(resolvedPath, headerProbe, 1024, /*allowEarlyStop=*/true);
-              bool gotDimensions = headerProbe.getDimensions(dims);
-
               if (!gotDimensions) {
                 // No header within the stream (rare) — fall back to extracting the
                 // whole image and probing the file. That can take seconds, so

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -398,6 +398,22 @@ TEST_F(SectionMemoryTest, OomAbandonsBuildAndBasicRetryPreservesBodyAndOffsets) 
   EXPECT_FALSE(restored.loadSectionFile(spec));
 }
 
+// Recognising an image by its content instead of its href extension hands an
+// imageCounter value to entries the old extension gate skipped, so a rebuilt
+// chapter numbers its images differently. The extracted-image namespace is
+// versioned for that reason: a pre-upgrade "img_*" file (and the .pxc beside it)
+// must never be picked up again, because ImageBlock::ensureExtracted() accepts
+// whatever file already sits at the path without checking where it came from.
+// Bump this prefix in lockstep with SECTION_FILE_VERSION.
+TEST_F(SectionMemoryTest, ImageCacheNamespaceIsVersionedSoPreUpgradeFilesAreNotReused) {
+  writeHtml("<html><body><p>plain text</p></body></html>");
+  Section section(epub, 0, renderer);
+  ASSERT_TRUE(section.startBuild(spec));
+  ASSERT_TRUE(section.build_ != nullptr);
+  EXPECT_NE(section.build_->imageBasePath.find("/img2_"), std::string::npos)
+      << "image cache base path was " << section.build_->imageBasePath;
+}
+
 TEST_F(SectionMemoryTest, ReclaimsCachesBeforeStartAndContinuation) {
   std::string html = "<html><body>";
   for (int i = 0; i < 500; ++i) html += "<p>word</p>";

--- a/test/memory_safety/MemorySafetyTest.cpp
+++ b/test/memory_safety/MemorySafetyTest.cpp
@@ -130,6 +130,31 @@ TEST(ZipImageProbe, FindsJpegFrameWithinSixteenKilobytePrefix) {
   EXPECT_EQ(dimensions.height, 240);
 }
 
+// A leading 0xFF or 0x89 only selects a parser; it does not identify a format.
+// Callers use detectedFormat() to accept an entry the href extension would have
+// rejected, so a truncated signature must stay Unknown instead of claiming
+// JPEG/PNG and sending the entry through extraction plus a decoder retry.
+TEST(ZipImageProbe, SignsAFormatOnlyOnceItsSignatureIsValidated) {
+  const auto formatOf = [](const std::vector<uint8_t>& bytes) {
+    ImageDimsProbe probe;
+    for (const uint8_t b : bytes) probe.write(b);
+    return probe.detectedFormat();
+  };
+
+  EXPECT_EQ(formatOf({0xFF}), ImageDimsProbe::Format::Unknown);
+  EXPECT_EQ(formatOf({0xFF, 0x00}), ImageDimsProbe::Format::Unknown);
+  EXPECT_EQ(formatOf({0x89}), ImageDimsProbe::Format::Unknown);
+  EXPECT_EQ(formatOf({0x89, 0x58}), ImageDimsProbe::Format::Unknown);
+  // Seven of the eight PNG signature bytes is not a PNG yet.
+  EXPECT_EQ(formatOf({0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A}), ImageDimsProbe::Format::Unknown);
+  // A JPEG that starts with SOI but never reaches a frame header is still a JPEG.
+  EXPECT_EQ(formatOf({0xFF, 0xD8, 0xFF, 0xD9}), ImageDimsProbe::Format::Jpeg);
+
+  // The shortest complete JPEG signature, and the full PNG one.
+  EXPECT_EQ(formatOf({0xFF, 0xD8}), ImageDimsProbe::Format::Jpeg);
+  EXPECT_EQ(formatOf({0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}), ImageDimsProbe::Format::Png);
+}
+
 TEST(ZipImageProbe, RejectsTruncatedDeflateStream) {
   constexpr uint8_t TRUNCATED_DEFLATE[] = {0xeb, 0x0c, 0xf0};
   InflateReader inflate;


### PR DESCRIPTION
## Problem

An EPUB image entry was accepted or dropped purely on its **path extension**:

```cpp
// ChapterHtmlSlimParser.cpp
if (ImageDecoderFactory::isFormatSupported(resolvedPath)) {   // extension-only
  ext = resolvedPath.substr(resolvedPath.rfind('.'));
```

`isFormatSupported` ends up in `FsHelpers::hasJpgExtension`, so it matches `.jpg` / `.jpeg` / `.png` on the **href** — never the content. An EPUB may legitimately point at an image whose href carries:

- no extension at all (the media type lives in the manifest: `image/jpeg`),
- a query or fragment (`pic.jpg?v=2`, `pic.png#page`),
- an unusual suffix (`.jfif`, `.jpe`).

In every one of those cases the whole `<img>` block was skipped **without a single log line** — the picture vanished with no trace and no placeholder, and nothing in the log explained why.

## Change

The dimension probe already reads the entry's opening bytes and already identifies the format from them (PNG signature / JPEG `FF D8`). That identification now decides:

- `ImageDimsProbe` exposes the sniffed format (`Format::Jpeg/Png`) and the canonical extension for it.
- `ChapterHtmlSlimParser` hoists the probe **above** the decision, accepts an entry when either the content or the path identifies JPEG/PNG, and names the cached copy after the **sniffed** format — so the downstream `getDecoder(cachedImagePath)` lookup always finds an extension it understands.
- An entry recognisable neither by content nor by extension now logs `Unsupported image entry (neither JPEG/PNG content nor a known extension)` instead of disappearing silently.

The probe is the same read that was already performed for the dimensions, so there is no extra I/O and no extra buffering.

## Compatibility

No behaviour change for well-formed EPUBs: those entries passed the old gate, and the extension remains the fallback whenever the header is inconclusive (probe failed or content unrecognised). Image size limits, the dimension probe's early-stop, and the lazy-extract path are untouched.

## Testing

Built `env:eego_a4` (0 errors). On the device, EPUB pages that previously showed no image now render JPEG illustrations.