### PR TITLE
fix(eego-a4): persist the frontlight colour temperature

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -546,6 +546,13 @@ build_flags =
   ${s3_ble_psram.build_flags}
   -DFREEINK_DEVICE_EEGO_A4=1
   -DBOARD_HAS_PSRAM
+  ; The A4's frontlight is an LM3630A, whose two current sinks give it a real
+  ; colour-temperature channel (see BoardConfig::hasColorTemperatureFrontlight).
+  ; The SDK's FREEINK_CAP_WARMLIGHT default only lists the PWM warm-light boards,
+  ; so on this target the warmth entry was left out of the settings list — and
+  ; the settings list is what gets serialized, which is why brightness persisted
+  ; while colour temperature never did. Declare the capability for this target.
+  -DFREEINK_CAP_WARMLIGHT=1
 ; WeRead's network steps (TLS handshake + JSON decode) run on the Arduino
 ; loop task; the 8KB default stack overflows there (observed crashes entering
 ; WeRead on the A4). Give the loop task 16KB like the render task.


### PR DESCRIPTION
## Problem

The user report: *the frontlight saves brightness but not colour temperature*.

The A4's frontlight is an **LM3630A**, whose two current sinks give it a real colour-temperature channel — and `BoardConfig::hasColorTemperatureFrontlight()` already reports exactly that for this board.

The SDK's `FREEINK_CAP_WARMLIGHT` default, however, only lists the PWM warm-light boards:

```cpp
// BoardConfig.h
#define FREEINK_CAP_WARMLIGHT (FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_MURPHY_M4)
```

With that macro at 0 for `eego_a4`, the warmth entry was compiled out of `getBaseSettingsList()`:

```cpp
#if FREEINK_CAP_WARMLIGHT
  SettingInfo::Value(StrId::STR_WARMTH, &CrossPointSettings::frontlightWarmth, {0, 100, 5}, "frontlightWarmth"),
```

and settings are read and written by **walking that list**, keyed by name. A setting that is not in the list is never serialized. Brightness lives on a different path (guarded only by `hasI2cFrontlight`) and was saved normally; colour temperature was silently dropped on every save.

## Change

Declare the capability for this target:

```ini
[eego_a4_hardware]
build_flags =
  ...
  -DFREEINK_CAP_WARMLIGHT=1
```

`BoardConfig.h` guards the default with `#ifndef`, so a build flag for this target wins. That restores the entry (and therefore the persistence), and as a side effect makes the warmth setting visible in the Settings app — it had been compiled out there too.

`FREEINK_CAP_FRONTLIGHT` already includes `EEGO_A4`, so `FrontlightManager`'s `EegoA4` branch stays in charge of `hasColorTemperature()` at runtime and the PWM-pin fallback is never consulted on this board.

## Testing

Built `env:eego_a4` (0 errors). Changing the warmth in the frontlight panel and rebooting keeps the value.

> An alternative would be to add `FREEINK_DEVICE_EEGO_A4` to the SDK's default instead. Kept here as a per-target build declaration so the change stays in this repository; happy to move it into the SDK if you prefer it as the board's own capability.