### PR TITLE
fix(sd): move SD data in blocks instead of one byte per SPI transaction

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,14 @@ build_flags =
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1
+# SdFat leaves USE_SPI_ARRAY_TRANSFER at 0 on every platform except RP2040 and
+# the Uno R4, which makes its SPI receive path move one byte per
+# m_spi->transfer() call -- and each of those is a full transaction on
+# Arduino-ESP32 (lock, register setup, polled transfer, teardown). Raw sector
+# reads on eego_a4's dedicated 20MHz SPI bus measure 1.94us/byte (503KB/s) at 0
+# versus 0.65us/byte (1502KB/s) with one array transfer per buffer. Every image
+# decode, EPUB extraction and pixel-cache read goes through this path.
+  -DUSE_SPI_ARRAY_TRANSFER=1
 # Increase PNG scanline buffer to support up to 2048px wide images
 # Default is (320*4+1)*2=2562, we need more for larger images
   -DPNG_MAX_BUFFERED_PIXELS=16416


### PR DESCRIPTION
## What

`build_flags` now sets `-DUSE_SPI_ARRAY_TRANSFER=1` for every ESP32 target.

SdFat defaults that macro to `0` on every platform except RP2040 and the Uno R4
(`SdFatConfig.h`). At `0`, its SPI receive path is a per-byte loop:

```cpp
inline uint8_t SdSpiArduinoDriver::receive(uint8_t* buf, size_t count) {
  for (size_t i = 0; i < count; i++) {
    buf[i] = m_spi->transfer(0XFF);
  }
}
```

so every byte read from the card costs a full `transfer()` call — and on
Arduino-ESP32 each of those is a complete transaction (bus lock, register
programming, polled transfer, teardown).

## Measurement

Raw sector reads (bypassing FAT, one `CMD18` per call) on an eego_a4 whose SD
card sits on its own 20MHz SPI bus:

| sectors/call | default | `USE_SPI_ARRAY_TRANSFER=1` |
|---|---|---|
| 1 | 385 KB/s (2.54 µs/byte) | 778 KB/s (1.25 µs/byte) |
| 8 | 503 KB/s (1.94 µs/byte) | 1500 KB/s (0.65 µs/byte) |

0.65 µs/byte is 1.54 MB/s, about 62% of the 2.5 MB/s raw rate for 20MHz SPI —
the normal figure for multi-block reads with command overhead. The 503 KB/s
plateau is also why neither the read size (2 KB → 32 KB) nor 512-byte buffer
alignment changed anything: the command path was already correct, only the data
path was degraded.

## Why it matters

This is the path behind every SD read on the device: EPUB image extraction,
inline image decoding, pixel caches, chapter/book caches, reading stats and font
loading. A single 704x1000 inline PNG (~710 KB) that spent 2.8 s of its 4.5 s
decode inside `read()` now spends about 0.9 s; a page whose image was not cached
yet went from ~11 s to ~5 s. The remaining ~2.5 s is the panel refresh plus the
grayscale AA pass, which is a hard floor.

`[base]` is shared by every ESP32 hardware env, so all targets get the faster
path. The desktop `[env:simulator]` does not inherit `[base]` and is unaffected,
and the macro only changes the SPI driver path, so native-SDMMC boards are
unaffected too.

## Verification

- On-device sector probe (numbers above), run at boot with and without the flag;
  the flag-only run reproduces the fast figures.
- `pio run -e eego_a4` builds clean, and the image-heavy EPUB page render timings
  in the serial log improve as described.
