### PR TITLE
fix(home): tap the exact recent-book cover on multi-cover themes

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -448,6 +448,12 @@ void HomeActivity::loop() {
         touchedBook = centerBook;
       }
       lastCarouselBookIndex = touchedBook;
+    } else {
+      // Multi-cover themes (Lyra3Covers and the like) render several recent
+      // books side by side: map the finger to the cover it is on instead of
+      // always settling on the first book.
+      touchedBook = GUI.recentBookIndexAt(tx, renderer.getScreenWidth());
+      touchedBook = std::clamp(touchedBook, 0, static_cast<int>(recentBooks.size()) - 1);
     }
     if (selectorIndex != touchedBook) {
       selectorIndex = touchedBook;
@@ -456,9 +462,15 @@ void HomeActivity::loop() {
     return;
   }
 
-  if (!recentBooks.empty() &&
-      mappedInput.wasTapInRect(0, metrics.homeTopPadding, renderer.getScreenWidth(), metrics.homeCoverTileHeight)) {
-    if (!isCarousel) selectorIndex = 0;
+  int tapX = 0;
+  int tapY = 0;
+  if (!recentBooks.empty() && mappedInput.wasScreenTapped(tapX, tapY) && tapX >= 0 &&
+      tapX < renderer.getScreenWidth() && tapY >= metrics.homeTopPadding &&
+      tapY < metrics.homeTopPadding + metrics.homeCoverTileHeight) {
+    if (!isCarousel) {
+      selectorIndex = GUI.recentBookIndexAt(tapX, renderer.getScreenWidth());
+      selectorIndex = std::clamp(selectorIndex, 0, static_cast<int>(recentBooks.size()) - 1);
+    }
     activateSelection();
     return;
   }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -608,6 +608,12 @@ bool BaseTheme::tabIndexFromPoint(const GfxRenderer& renderer, const Rect rect, 
 
 // Draw the "Recent Book" cover card on the home screen
 // TODO: Refactor method to make it cleaner, split into smaller methods
+int BaseTheme::recentBookIndexAt(int, int) const {
+  // Single-cover themes show only the first recent book; a tap anywhere in
+  // the cover strip therefore selects book 0.
+  return 0;
+}
+
 void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                     const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
                                     bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -320,6 +320,12 @@ class BaseTheme {
   virtual void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                    const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
                                    bool& bufferRestored, std::function<bool()> storeCoverBuffer) const;
+  // Map a horizontal tap position inside the recent-books cover strip on the
+  // home screen to the index of the cover that was touched. Single-cover
+  // themes render only one tile and return 0; multi-cover themes (Lyra3Covers
+  // and the like) override this so a touch directly selects the book whose
+  // cover the finger is on, matching what the page-turn keys already do.
+  virtual int recentBookIndexAt(int x, int screenWidth) const;
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon, int rowSpacing = -1) const;

--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -3,6 +3,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -17,6 +18,17 @@ namespace {
 constexpr int hPaddingInSelection = 8;
 constexpr int cornerRadius = 6;
 }  // namespace
+
+int Lyra3CoversTheme::recentBookIndexAt(int x, int screenWidth) const {
+  // Three recent-book covers are laid out side by side: tile i spans
+  // [contentSidePadding + tileWidth * i, contentSidePadding + tileWidth * (i + 1)).
+  const int tileWidth = (screenWidth - 2 * Lyra3CoversMetrics::values.contentSidePadding) / 3;
+  if (tileWidth <= 0) {
+    return 0;
+  }
+  const int index = (x - Lyra3CoversMetrics::values.contentSidePadding) / tileWidth;
+  return std::clamp(index, 0, Lyra3CoversMetrics::values.homeRecentBooksCount - 1);
+}
 
 void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored,

--- a/src/components/themes/lyra/Lyra3CoversTheme.h
+++ b/src/components/themes/lyra/Lyra3CoversTheme.h
@@ -20,4 +20,5 @@ class Lyra3CoversTheme : public LyraTheme {
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
                            std::function<bool()> storeCoverBuffer) const override;
+  int recentBookIndexAt(int x, int screenWidth) const override;
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the home screen on multi-cover themes (Lyra3Covers and the like) so tapping the second or third recent-book cover opens that book, matching what the page-turn keys already do.
* **What changes are included?**
  - Add a `BaseTheme::recentBookIndexAt(x, screenWidth)` virtual hook. The default returns `0`, so single-cover themes (one tile in the strip) keep today's behaviour: a tap anywhere in the cover strip selects book 0.
  - Override it in `Lyra3CoversTheme` using the same tile geometry the theme uses to draw the covers (`tileWidth = (screenWidth - 2 * contentSidePadding) / 3`, result clamped to `[0, homeRecentBooksCount - 1]`).
  - In `HomeActivity::loop()`, use the hook for both the touch-down highlight path and the tap-to-open path, replacing the previous hard-coded `selectorIndex = 0` for non-carousel themes.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

## Additional Context

* Root cause: the touch path in `HomeActivity::loop()` mapped every tap inside the recent-books cover strip to `selectorIndex = 0` for non-carousel themes, so a touch on the second or third cover always opened the first book, even though the page-turn keys could select any of them.
* The fix adds a theme hook so the touch mapping is derived from the same geometry the theme uses to draw the covers; single-cover themes are unaffected (the hook returns 0).
* No memory / flash impact: 5 files, +40 / −3 lines; no new dependencies (only adds an `<algorithm>` include in `Lyra3CoversTheme.cpp`).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
